### PR TITLE
fix typing for taipy.run

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,23 @@
+[flake8]
+# required by black, https://github.com/psf/black/blob/master/.flake8
+max-line-length = 120
+max-complexity = 18
+ignore = E203, E266, E501, E722, W503, F403, F401
+select = B,C,E,F,W,T4,B9
+docstring-convention = google
+per-file-ignores =
+    __init__.py:F401
+exclude =
+    .git,
+    __pycache__,
+    setup.py,
+    build,
+    dist,
+    releases,
+    .venv,
+    .tox,
+    .mypy_cache,
+    .pytest_cache,
+    .vscode,
+    .github,
+    tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.910'  # Use the sha / tag you want to point at
+    rev: 'v0.991'  # Use the sha / tag you want to point at
     hooks:
     -   id: mypy
         additional_dependencies: [
@@ -35,7 +35,7 @@ repos:
     - id: black
       args: [--line-length=120]
       language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 taipy-gui = {git="https://git@github.com/Avaiga/taipy-gui.git@develop"}
 taipy-rest = {git="https://git@github.com/Avaiga/taipy-rest.git@develop"}
-typing-extensions = {version=">4.1.0", markers="python_version < '3.10'"}
 tox = "*"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ tox = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.8"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,10 @@ name = "pypi"
 [packages]
 taipy-gui = {git="https://git@github.com/Avaiga/taipy-gui.git@develop"}
 taipy-rest = {git="https://git@github.com/Avaiga/taipy-rest.git@develop"}
-tox = "*"
 
 [dev-packages]
 pytest = "*"
+tox = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -4,14 +4,16 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-taipy-gui = {git = "https://git@github.com/Avaiga/taipy-gui.git@develop"}
-taipy-rest = {git = "https://git@github.com/Avaiga/taipy-rest.git@develop"}
+taipy-gui = {git="https://git@github.com/Avaiga/taipy-gui.git@develop"}
+taipy-rest = {git="https://git@github.com/Avaiga/taipy-rest.git@develop"}
+typing-extensions = {version=">4.1.0", markers="python_version < '3.10'"}
+tox = "*"
 
 [dev-packages]
 pytest = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"
 
 [pipenv]
 allow_prereleases = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,4 @@
 [tool.black]
 line-length = 120
+
+[tool.pyright]

--- a/src/taipy/_run.py
+++ b/src/taipy/_run.py
@@ -24,14 +24,15 @@ else:
     from typing import TypeGuard
 
 
-def _run(*apps: t.Union[Gui, Rest, Core], **kwargs) -> t.Optional[t.Union[Gui, Rest, Core, Flask]]:
+def _run(*apps: t.Union[Gui, Rest, Core], **kwargs) -> t.Optional[Flask]:
     """Run one or multiple Taipy services.
 
     A Taipy service is an instance of a class that runs code as a Web application.
 
     Parameters:
         *args (Union[`Gui^`, `Rest^`, `Core^`]): Services to run, as separate arguments.
-            If several services are provided, all the services run simultaneously. If this is empty or set to None, this method does nothing.
+            If several services are provided, all the services run simultaneously.
+            If this is empty or set to None, this method does nothing.
         **kwargs: Other parameters to provide to the services.
     """
 
@@ -63,11 +64,11 @@ def _run(*apps: t.Union[Gui, Rest, Core], **kwargs) -> t.Optional[t.Union[Gui, R
         return app.run(**kwargs)
 
 
-TObj = t.TypeVar("TObj", bound=t.Union[Gui, Core, Rest])
+_TObj = t.TypeVar("_TObj", bound=t.Union[Gui, Core, Rest])
 
 
-def __typing_get(tup_obj: t.Tuple[t.Union[Gui, Core, Rest], ...], type_: t.Type[TObj]) -> t.Optional[TObj]:
-    def filter_isinstance(tl: t.Union[Gui, Core, Rest]) -> TypeGuard[TObj]:
+def __typing_get(tup_obj: t.Tuple[t.Union[Gui, Core, Rest], ...], type_: t.Type[_TObj]) -> t.Optional[_TObj]:
+    def filter_isinstance(tl: t.Union[Gui, Core, Rest]) -> TypeGuard[_TObj]:
         return isinstance(tl, type_)
 
     return next(filter(filter_isinstance, tup_obj), None)

--- a/src/taipy/_run.py
+++ b/src/taipy/_run.py
@@ -30,8 +30,8 @@ def _run(*apps: t.Union[Gui, Rest, Core], **kwargs) -> t.Optional[Flask]:
     A Taipy service is an instance of a class that runs code as a Web application.
 
     Parameters:
-        *args (Union[`Gui^`, `Rest^`, `Core^`]): Services to run, as separate arguments.
-            If several services are provided, all the services run simultaneously.
+        *args (Union[`Gui^`, `Rest^`, `Core^`]): Services to run, as separate arguments.<br/>
+            If several services are provided, all the services run simultaneously.<br/>
             If this is empty or set to None, this method does nothing.
         **kwargs: Other parameters to provide to the services.
     """

--- a/src/taipy/_run.py
+++ b/src/taipy/_run.py
@@ -9,22 +9,32 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import sys
 import typing as t
+
+from flask import Flask
 
 from taipy.gui import Gui
 from taipy.rest import Rest
 from taipy.core import Core
 
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeGuard
+else:
+    from typing import TypeGuard
 
-def _run(*apps: t.List[t.Union[Gui, Rest, Core]], **kwargs) -> t.Optional[t.Union[Gui, Rest, Core]]:
+
+def _run(*apps: t.Union[Gui, Rest, Core], **kwargs) -> t.Optional[t.Union[Gui, Rest, Core, Flask]]:
     """Run one or multiple Taipy services.
 
     A Taipy service is an instance of a class that runs code as a Web application.
 
     Parameters:
-        *args (List[Union[`Gui^`, `Rest^`, `Core^`]]): Services to run. If several services are provided, all the services run simultaneously. If this is empty or set to None, this method does nothing.
+        *args (Union[`Gui^`, `Rest^`, `Core^`]): Services to run, as separate arguments.
+            If several services are provided, all the services run simultaneously. If this is empty or set to None, this method does nothing.
         **kwargs: Other parameters to provide to the services.
     """
+
     gui = __typing_get(apps, Gui)
     rest = __typing_get(apps, Rest)
     core = __typing_get(apps, Core)
@@ -49,8 +59,15 @@ def _run(*apps: t.List[t.Union[Gui, Rest, Core]], **kwargs) -> t.Optional[t.Unio
         return gui.run(**kwargs)
     else:
         app = rest or gui
+        assert app is not None  # for pyright typing
         return app.run(**kwargs)
 
 
-def __typing_get(l, type_):
-    return next(filter(lambda o: isinstance(o, type_), l), None)
+TObj = t.TypeVar("TObj", bound=t.Union[Gui, Core, Rest])
+
+
+def __typing_get(tup_obj: t.Tuple[t.Union[Gui, Core, Rest], ...], type_: t.Type[TObj]) -> t.Optional[TObj]:
+    def filter_isinstance(tl: t.Union[Gui, Core, Rest]) -> TypeGuard[TObj]:
+        return isinstance(tl, type_)
+
+    return next(filter(filter_isinstance, tup_obj), None)

--- a/src/taipy/version.json
+++ b/src/taipy/version.json
@@ -1,1 +1,1 @@
-{"major": 3, "minor": 0, "patch": 0, "ext": "dev0"}
+{"major": 2, "minor": 2, "patch": 0, "ext": "dev0"}

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ deps = pipenv
 [testenv:tests]
 commands =
     pipenv install --dev --skip-lock
+    pipenv run pip freeze
     pytest tests


### PR DESCRIPTION
The typing hints for the new `taipy.run()` were wrong.  It's not expecting a list.  Since the argument is `*apps`, you then specify the type of each element of `apps`.  So this updates the docs and the typing, and properly types the function `__typing_get()`

In addition, the pre-commit stuff didn't work.  Had to copy over some files from `taipy-gui` and also update the `pre-commit` file to get correct versions.