### PR TITLE
Feature - Add --version and -v option to print Taipy version

### DIFF
--- a/src/taipy/_cli/_help_cli.py
+++ b/src/taipy/_cli/_help_cli.py
@@ -31,7 +31,6 @@ class _HelpCLI:
 
         if getattr(args, "which", None) == "help":
             if args.command:
-                _CLI._sub_taipyparsers.keys()
                 if args.command in _CLI._sub_taipyparsers.keys():
                     _CLI._sub_taipyparsers.get(args.command).print_help()
                 else:

--- a/src/taipy/_entrypoint.py
+++ b/src/taipy/_entrypoint.py
@@ -25,14 +25,15 @@ def _entrypoint():
     sys.path.append(os.path.normpath(os.getcwd()))
 
     _CLI._parser.add_argument("-v", "--version", action="store_true", help="Print the current Taipy version and exit.")
-    args = _CLI._parse()
-    if args.version:
-        print(f"Taipy {_get_version()}")
-        sys.exit(0)
 
     _VersionCLI.create_parser()
     _ScaffoldCLI.create_parser()
     _HelpCLI.create_parser()
+
+    args = _CLI._parse()
+    if args.version:
+        print(f"Taipy {_get_version()}")
+        sys.exit(0)
 
     _HelpCLI.parse_arguments()
     _VersionCLI.parse_arguments()

--- a/src/taipy/_entrypoint.py
+++ b/src/taipy/_entrypoint.py
@@ -17,11 +17,18 @@ from taipy.core._version._cli._version_cli import _VersionCLI
 
 from ._cli._help_cli import _HelpCLI
 from ._cli._scaffold_cli import _ScaffoldCLI
+from .version import _get_version
 
 
 def _entrypoint():
     # Add the current working directory to path to execute version command on FS repo
     sys.path.append(os.path.normpath(os.getcwd()))
+
+    _CLI._parser.add_argument("-v", "--version", action="store_true", help="Print the current Taipy version and exit.")
+    args = _CLI._parse()
+    if args.version:
+        print(f"Taipy {_get_version()}")
+        sys.exit(0)
 
     _VersionCLI.create_parser()
     _ScaffoldCLI.create_parser()


### PR DESCRIPTION
This PR adds `taipy --version` or `taipy -v` command to show Taipy version.