### PR TITLE
Support direct taipy installation on dev branches

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   standard-packages:
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         python-versions: [ '3.8', '3.9', '3.10', '3.11' ]
@@ -36,6 +36,15 @@ jobs:
           python -c "import taipy as tp; tp.Scenario"
           python -c "import taipy as tp; tp.gui"
           python -c "import taipy as tp; tp.rest"
+          
+          echo """
+          import taipy
+          from pathlib import Path
+          taipy_gui_core_path = Path(taipy.__file__).absolute().parent / 'gui_core' / 'lib' / 'taipy-gui-core.js'
+          if not taipy_gui_core_path.exists():
+              raise FileNotFoundError(f'taipy-gui-core.js not found in {taipy_gui_core_path}')
+          """ > /tmp/verify_gui_core.py
+          python /tmp/verify_gui_core.py
 
       - name: Notify user if failed
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,3 +101,12 @@ jobs:
           python -c "import taipy as tp; tp.Scenario"
           python -c "import taipy as tp; tp.gui"
           python -c "import taipy as tp; tp.rest"
+
+          echo """
+          import taipy
+          from pathlib import Path
+          taipy_gui_core_path = Path(taipy.__file__).absolute().parent / 'gui_core' / 'lib' / 'taipy-gui-core.js'
+          if not taipy_gui_core_path.exists():
+              raise FileNotFoundError(f'taipy-gui-core.js not found in {taipy_gui_core_path}')
+          """ > /tmp/verify_gui_core.py
+          python /tmp/verify_gui_core.py

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -118,6 +118,15 @@ jobs:
           python -c "import taipy as tp; tp.gui"
           python -c "import taipy as tp; tp.rest"
 
+          echo """
+          import taipy
+          from pathlib import Path
+          taipy_gui_core_path = Path(taipy.__file__).absolute().parent / 'gui_core' / 'lib' / 'taipy-gui-core.js'
+          if not taipy_gui_core_path.exists():
+              raise FileNotFoundError(f'taipy-gui-core.js not found in {taipy_gui_core_path}')
+          """ > /tmp/verify_gui_core.py
+          python /tmp/verify_gui_core.py
+
       - name: Extract commit hash
         shell: bash
         run: echo "HASH=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
           # install taipy-gui from based on setup.py version
-          pip install "{{ steps.taipy_gui_version.outputs.VERSION }}"
 
       - name: Build and test the package
         run: |
@@ -81,6 +80,15 @@ jobs:
           python -c "import taipy as tp; tp.Scenario"
           python -c "import taipy as tp; tp.gui"
           python -c "import taipy as tp; tp.rest"
+
+          echo """
+          import taipy
+          from pathlib import Path
+          taipy_gui_core_path = Path(taipy.__file__).absolute().parent / 'gui_core' / 'lib' / 'taipy-gui-core.js'
+          if not taipy_gui_core_path.exists():
+              raise FileNotFoundError(f'taipy-gui-core.js not found in {taipy_gui_core_path}')
+          """ > /tmp/verify_gui_core.py
+          python /tmp/verify_gui_core.py
 
       - name: Extract commit hash
         shell: bash

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,13 @@
 
 """The setup script."""
 
+
 import json
 import os
 import sysconfig
-from pathlib import Path
 
+from pathlib import Path
+from importlib.util import find_spec
 from setuptools import find_namespace_packages, find_packages, setup
 from setuptools.command.build_py import build_py
 
@@ -55,8 +57,13 @@ extras_require = {
 def _build_webapp():
     already_exists = Path("./src/taipy/gui_core/lib/taipy-gui-core.js").exists()
     if not already_exists:
-        site_packages_path = sysconfig.get_path('purelib')
-        env_file_path = Path(__file__).absolute().parent / "gui" /".env"
+        site_packages_path = sysconfig.get_path("purelib")
+        if find_spec("taipy") and find_spec("taipy.gui"):
+            import taipy
+
+            site_packages_path = Path(taipy.__file__).parent.parent
+
+        env_file_path = Path(__file__).absolute().parent / "gui" / ".env"
         if not os.path.exists(env_file_path):
             with open(env_file_path, "w") as env_file:
                 env_file.write(f"TAIPY_GUI_DIR={site_packages_path}\n")

--- a/setup.py
+++ b/setup.py
@@ -57,12 +57,16 @@ extras_require = {
 def _build_webapp():
     already_exists = Path("./src/taipy/gui_core/lib/taipy-gui-core.js").exists()
     if not already_exists:
+        # default site-packages path is from the current python interpreter
         site_packages_path = sysconfig.get_path("purelib")
+        # taipy-gui should be available through setup_requires option
+        # taipy-gui at this step is installed in a backend site-packages separated from the one being used by pip
         if find_spec("taipy") and find_spec("taipy.gui"):
             import taipy
 
             site_packages_path = Path(taipy.__file__).parent.parent
 
+        # Specify the correct path to taipy-gui in gui/.env file
         env_file_path = Path(__file__).absolute().parent / "gui" / ".env"
         if not os.path.exists(env_file_path):
             with open(env_file_path, "w") as env_file:

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@
 import json
 import os
 import sysconfig
-
-from pathlib import Path
 from importlib.util import find_spec
+from pathlib import Path
+
 from setuptools import find_namespace_packages, find_packages, setup
 from setuptools.command.build_py import build_py
 
@@ -64,7 +64,7 @@ def _build_webapp():
         if find_spec("taipy") and find_spec("taipy.gui"):
             import taipy
 
-            site_packages_path = Path(taipy.__file__).parent.parent
+            site_packages_path = Path(taipy.__file__).absolute().parent.parent
 
         # Specify the correct path to taipy-gui in gui/.env file
         env_file_path = Path(__file__).absolute().parent / "gui" / ".env"

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 
 import json
 import os
+import sysconfig
 from pathlib import Path
 
 from setuptools import find_namespace_packages, find_packages, setup
@@ -35,6 +36,8 @@ requirements = [
     "taipy-templates@git+https://git@github.com/Avaiga/taipy-templates.git@develop",
 ]
 
+setup_requirements = [(requirement for requirement in requirements if requirement.startswith("taipy-gui"))]
+
 test_requirements = ["pytest>=3.8"]
 
 extras_require = {
@@ -52,6 +55,11 @@ extras_require = {
 def _build_webapp():
     already_exists = Path("./src/taipy/gui_core/lib/taipy-gui-core.js").exists()
     if not already_exists:
+        site_packages_path = sysconfig.get_path('purelib')
+        env_file_path = Path(__file__).absolute().parent / "gui" /".env"
+        if not os.path.exists(env_file_path):
+            with open(env_file_path, "w") as env_file:
+                env_file.write(f"TAIPY_GUI_DIR={site_packages_path}\n")
         os.system("cd gui && npm ci && npm run build")
 
 
@@ -76,6 +84,7 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     description="A 360° open-source platform from Python pilots to production-ready web apps.",
+    setup_requires=setup_requirements,
     install_requires=requirements,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Solve Avaiga/taipy-enterprise#208

To test it out, you can run this command and verify that `src/taipy/gui_core/lib` is available in python site-packages
```
pip install "taipy@git+https://git@github.com/Avaiga/taipy.git@feature/direct-taipy-installation
```