### PR TITLE
use the new optional feature of lov_value from gui

### DIFF
--- a/src/taipy/gui_core/_GuiCoreLib.py
+++ b/src/taipy/gui_core/_GuiCoreLib.py
@@ -133,7 +133,7 @@ class _GuiCore(ElementLibrary):
                 "show_data": ElementProperty(PropertyType.boolean, True),
                 "chart_configs": ElementProperty(PropertyType.dict),
                 "class_name": ElementProperty(PropertyType.dynamic_string),
-                "scenario": ElementProperty(PropertyType.lov_value),
+                "scenario": ElementProperty(PropertyType.lov_value, "optional"),
                 "width": ElementProperty(PropertyType.string),
             },
             inner_properties={


### PR DESCRIPTION
depends on https://github.com/Avaiga/taipy-gui/pull/970 to work
But won't break anything
<|{data_node}|data_node|>  used to show a warning about scenario not being bound