### PR TITLE
force refresh on scenario creation (#955)

### DIFF
--- a/src/taipy/gui_core/_context.py
+++ b/src/taipy/gui_core/_context.py
@@ -128,7 +128,9 @@ class _GuiCoreContext(CoreEventConsumerBase):
             if event.operation == EventOperation.SUBMISSION:
                 self.scenario_status_callback(event.attribute_name, True)
                 return
-            self.scenario_refresh(event.entity_id if event.operation != EventOperation.DELETION and is_readable(event.entity_id) else None)
+            self.scenario_refresh(
+                event.entity_id if event.operation != EventOperation.DELETION and is_readable(event.entity_id) else None
+            )
         elif event.entity_type == EventEntityType.SEQUENCE and event.entity_id:
             try:
                 sequence = (


### PR DESCRIPTION
Addresses [taipy-gui/#955](https://github.com/Avaiga/taipy-gui/issues/955).

force refresh on creation


```
import taipy as tp
from taipy import Config

x_cfg = Config.configure_pickle_data_node(id="x", default_data=5)
y_cfg = Config.configure_data_node(id="y")


def square(x):
    return x**2


task1_cfg = Config.configure_task(id="task1", function=square, input=x_cfg, output=y_cfg)

scenario_cfg = Config.configure_scenario(id="scenario", task_configs=[task1_cfg])


def scenario_on_creation(state, id, payload: dict):
    config = payload.get("config")
    date = payload.get("date")
    label = payload.get("label")
    properties = payload.get("properties")

    scenario = tp.create_scenario(config, creation_date=date, name=label)
    scenario.x.write(3)  # This line prevents the scenario from showing up in the scenario_selector list

    for key, value in properties.items():
        scenario.properties[key] = value

    return scenario


selected_scenario = None
md = """
# Create scenario

<|{selected_scenario}|scenario_selector|on_creation=scenario_on_creation|>
"""

if __name__ == "__main__":
    tp.Core().run()
    tp.Gui(md).run()

```