### PR TITLE
Remove setup_requires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,14 +71,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install build wheel
           # install taipy-gui from based on setup.py version
+          pip install "${{ steps.taipy_gui_version.outputs.VERSION }}"
 
       - name: Build and test the package
         run: |
           python setup.py build_py && python -m build
-          pwd
-          ls -l .
           rm -rf taipy
-          ls -l dist/
           pip install dist/*.tar.gz
           python -c "import taipy as tp; tp.Scenario"
           python -c "import taipy as tp; tp.gui"

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ requirements = [
     "taipy-templates>=3.0,<3.1",
 ]
 
-setup_requirements = [(requirement for requirement in requirements if requirement.startswith("taipy-gui"))]
-
 test_requirements = ["pytest>=3.8"]
 
 extras_require = {
@@ -95,7 +93,6 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     description="A 360° open-source platform from Python pilots to production-ready web apps.",
-    setup_requires=setup_requirements,
     install_requires=requirements,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Yesterday, we have a problem with the release process due to a problem when executing the setup_requires process in setup.py. The problem is due to a dependency PACKAGE NAME incompatibility that we have no control over (zope.interface != zope-interface).

If we remove the setup_requrires process on the develop branch similarly like what we are about to do on the release branch, you can no longer install taipy directly from develop branch. 

We can, however, in the next version of taipy-gui, moved to a previous version of `twisted` package which does not have the typo issue with zope.interface package. If we don't change the twisted version, the setup_requires process will not work on taipy package and we might as well remove it on the develop branch.