### PR TITLE
Feature - Add sync-project-issue-state workflow

### DIFF
--- a/.github/workflows/sync-project-issue-state.yml
+++ b/.github/workflows/sync-project-issue-state.yml
@@ -2,8 +2,8 @@ name: Project Issue State Sync
 
 on:
   schedule:
-    # Run every 5 minutes between 10am and 11am
-    - cron: 0-59/5 10-11 * * *
+    # Run once every day at mid day
+    - cron: 00 12 * * *
 
   workflow_dispatch:
     # Manual trigger

--- a/.github/workflows/sync-project-issue-state.yml
+++ b/.github/workflows/sync-project-issue-state.yml
@@ -1,0 +1,23 @@
+name: Project Issue State Sync
+
+on:
+  schedule:
+    # Run every 5 minutes between 10am and 11am
+    - cron: 0-59/5 10-11 * * *
+
+  workflow_dispatch:
+    # Manual trigger
+
+jobs:
+  issue-state-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync issue states
+        uses: dasmerlon/project-issue-state-sync@v2
+        with:
+          github_token: ${{ secrets.PROJECT_ISSUE_SYNC_TOKEN }}
+          owner: Avaiga
+          project_number: 6
+          closed_statuses: Closed
+          open_statuses: New Issue,Icebox,Contributor,Product Backlog,Sprint Backlog,In Progress,Review/QA,Done


### PR DESCRIPTION
This workflow sync the status of Github issues (open/close) with the github project board.

For this to work, we need to add `secrets.PROJECT_ISSUE_SYNC_TOKEN` to the organization setting.

Problems:
- The `on schedule` is delayed a lot. This is a problem that Github does acknowledge but there is no plan to fix in the near future.
- We need to add this workflow to all repositories that used in the board.
