### PR TITLE
Feature/new update submission status algorithm

### DIFF
--- a/src/taipy/core/_backup/_backup.py
+++ b/src/taipy/core/_backup/_backup.py
@@ -12,7 +12,7 @@
 
 import os
 
-from taipy.config import Config
+from ...config import Config
 
 __BACKUP_FILE_PATH_ENVIRONMENT_VARIABLE_NAME = "TAIPY_BACKUP_FILE_PATH"
 

--- a/src/taipy/core/_core.py
+++ b/src/taipy/core/_core.py
@@ -12,9 +12,8 @@
 from multiprocessing import Lock
 from typing import Optional
 
-from taipy.config import Config
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ..config import Config
+from ..logger._taipy_logger import _TaipyLogger
 from ._backup._backup import _init_backup_file_with_storage_folder
 from ._core_cli import _CoreCLI
 from ._orchestrator._dispatcher._job_dispatcher import _JobDispatcher

--- a/src/taipy/core/_core_cli.py
+++ b/src/taipy/core/_core_cli.py
@@ -11,8 +11,7 @@
 
 from typing import Dict
 
-from taipy._cli._base_cli import _CLI
-
+from .._cli._base_cli import _CLI
 from .config import CoreSection
 
 

--- a/src/taipy/core/_entity/_migrate/_migrate_fs.py
+++ b/src/taipy/core/_entity/_migrate/_migrate_fs.py
@@ -14,8 +14,7 @@ import os
 import shutil
 from typing import Dict
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ....logger._taipy_logger import _TaipyLogger
 from ._utils import _migrate
 
 __logger = _TaipyLogger._get_logger()

--- a/src/taipy/core/_entity/_migrate/_migrate_mongo.py
+++ b/src/taipy/core/_entity/_migrate/_migrate_mongo.py
@@ -17,8 +17,7 @@ from typing import Dict
 import bson
 import pymongo
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ....logger._taipy_logger import _TaipyLogger
 from ._utils import _migrate
 
 __logger = _TaipyLogger._get_logger()

--- a/src/taipy/core/_entity/_migrate/_migrate_sql.py
+++ b/src/taipy/core/_entity/_migrate/_migrate_sql.py
@@ -15,8 +15,7 @@ import shutil
 import sqlite3
 from typing import Dict, Tuple
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ....logger._taipy_logger import _TaipyLogger
 from ._utils import _migrate
 
 __logger = _TaipyLogger._get_logger()

--- a/src/taipy/core/_entity/_migrate/_utils.py
+++ b/src/taipy/core/_entity/_migrate/_utils.py
@@ -12,7 +12,7 @@
 import json
 from typing import Dict, List, Optional, Tuple
 
-from taipy.logger._taipy_logger import _TaipyLogger
+from ....logger._taipy_logger import _TaipyLogger
 
 __logger = _TaipyLogger._get_logger()
 

--- a/src/taipy/core/_entity/_migrate_cli.py
+++ b/src/taipy/core/_entity/_migrate_cli.py
@@ -12,9 +12,8 @@
 import sys
 from typing import List
 
-from taipy._cli._base_cli import _CLI
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ..._cli._base_cli import _CLI
+from ...logger._taipy_logger import _TaipyLogger
 from ._migrate import (
     _migrate_fs_entities,
     _migrate_mongo_entities,

--- a/src/taipy/core/_entity/_properties.py
+++ b/src/taipy/core/_entity/_properties.py
@@ -44,7 +44,7 @@ class _Properties(UserDict):
                 self._entity_owner._in_context_attributes_changed_collector.append(event)
 
     def __getitem__(self, key):
-        from taipy.config.common._template_handler import _TemplateHandler as _tpl
+        from ...config.common._template_handler import _TemplateHandler as _tpl
 
         return _tpl._replace_templates(super(_Properties, self).__getitem__(key))
 

--- a/src/taipy/core/_manager/_manager.py
+++ b/src/taipy/core/_manager/_manager.py
@@ -13,8 +13,7 @@ import pathlib
 from importlib import metadata
 from typing import Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...logger._taipy_logger import _TaipyLogger
 from .._entity._entity_ids import _EntityIds
 from .._repository._abstract_repository import _AbstractRepository
 from ..exceptions.exceptions import ModelNotFound

--- a/src/taipy/core/_manager/_manager_factory.py
+++ b/src/taipy/core/_manager/_manager_factory.py
@@ -13,8 +13,7 @@ from abc import abstractmethod
 from importlib import util
 from typing import Type
 
-from taipy.config import Config
-
+from ...config import Config
 from ._manager import _Manager
 
 

--- a/src/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -13,9 +13,8 @@ import threading
 from abc import abstractmethod
 from typing import Dict, Optional
 
-from taipy.config.config import Config
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ....config.config import Config
+from ....logger._taipy_logger import _TaipyLogger
 from ...data._data_manager_factory import _DataManagerFactory
 from ...job._job_manager_factory import _JobManagerFactory
 from ...job.job import Job

--- a/src/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -13,9 +13,8 @@ from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from typing import Optional
 
-from taipy.config._serializer._toml_serializer import _TomlSerializer
-from taipy.config.config import Config
-
+from ....config._serializer._toml_serializer import _TomlSerializer
+from ....config.config import Config
 from ...job.job import Job
 from .._abstract_orchestrator import _AbstractOrchestrator
 from ._job_dispatcher import _JobDispatcher

--- a/src/taipy/core/_orchestrator/_dispatcher/_task_function_wrapper.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_task_function_wrapper.py
@@ -11,9 +11,8 @@
 
 from typing import Any, List
 
-from taipy.config._serializer._toml_serializer import _TomlSerializer
-from taipy.config.config import Config
-
+from ....config._serializer._toml_serializer import _TomlSerializer
+from ....config.config import Config
 from ...data._data_manager_factory import _DataManagerFactory
 from ...data.data_node import DataNode
 from ...exceptions import DataNodeWritingError

--- a/src/taipy/core/_orchestrator/_orchestrator.py
+++ b/src/taipy/core/_orchestrator/_orchestrator.py
@@ -17,9 +17,8 @@ from queue import Queue
 from time import sleep
 from typing import Callable, Iterable, List, Optional, Set, Union
 
-from taipy.config.config import Config
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...config.config import Config
+from ...logger._taipy_logger import _TaipyLogger
 from .._entity.submittable import Submittable
 from ..data._data_manager_factory import _DataManagerFactory
 from ..job._job_manager_factory import _JobManagerFactory

--- a/src/taipy/core/_orchestrator/_orchestrator_factory.py
+++ b/src/taipy/core/_orchestrator/_orchestrator_factory.py
@@ -12,8 +12,7 @@
 from importlib import util
 from typing import Optional, Type
 
-from taipy.config.config import Config
-
+from ...config.config import Config
 from ..common._utils import _load_fct
 from ..exceptions.exceptions import ModeNotAvailable, OrchestratorNotBuilt
 from ._abstract_orchestrator import _AbstractOrchestrator

--- a/src/taipy/core/_repository/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_filesystem_repository.py
@@ -15,8 +15,7 @@ import pathlib
 import shutil
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Type, Union
 
-from taipy.config.config import Config
-
+from ...config.config import Config
 from ..common._utils import _retry_read_entity
 from ..common.typing import Converter, Entity, Json, ModelType
 from ..exceptions import FileCannotBeRead, InvalidExportPath, ModelNotFound

--- a/src/taipy/core/_repository/db/_sql_connection.py
+++ b/src/taipy/core/_repository/db/_sql_connection.py
@@ -16,8 +16,7 @@ from sqlite3 import Connection
 from sqlalchemy.dialects import sqlite
 from sqlalchemy.schema import CreateTable
 
-from taipy.config.config import Config
-
+from ....config.config import Config
 from ...exceptions import MissingRequiredProperty
 
 

--- a/src/taipy/core/_version/_cli/_version_cli.py
+++ b/src/taipy/core/_version/_cli/_version_cli.py
@@ -11,11 +11,10 @@
 
 import sys
 
-from taipy._cli._base_cli import _CLI
-from taipy.config import Config
-from taipy.config.exceptions.exceptions import InconsistentEnvVariableError
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...._cli._base_cli import _CLI
+from ....config import Config
+from ....config.exceptions.exceptions import InconsistentEnvVariableError
+from ....logger._taipy_logger import _TaipyLogger
 from ...data._data_manager_factory import _DataManagerFactory
 from ...exceptions.exceptions import VersionIsNotProductionVersion
 from ...job._job_manager_factory import _JobManagerFactory

--- a/src/taipy/core/_version/_utils.py
+++ b/src/taipy/core/_version/_utils.py
@@ -11,8 +11,7 @@
 
 from typing import Callable, List
 
-from taipy.config.config import Config
-
+from ...config.config import Config
 from .._entity._reload import _Reloader
 from ..config import MigrationConfig
 from ._version_manager_factory import _VersionManagerFactory

--- a/src/taipy/core/_version/_version.py
+++ b/src/taipy/core/_version/_version.py
@@ -12,9 +12,8 @@
 from datetime import datetime
 from typing import Any
 
-from taipy.config import Config
-from taipy.config._config import _Config
-
+from ...config import Config
+from ...config._config import _Config
 from .._entity._entity import _Entity
 
 

--- a/src/taipy/core/_version/_version_converter.py
+++ b/src/taipy/core/_version/_version_converter.py
@@ -11,8 +11,7 @@
 
 from datetime import datetime
 
-from taipy.config import Config
-
+from ...config import Config
 from .._repository._abstract_converter import _AbstractConverter
 from .._version._version import _Version
 from .._version._version_model import _VersionModel

--- a/src/taipy/core/_version/_version_fs_repository.py
+++ b/src/taipy/core/_version/_version_fs_repository.py
@@ -12,8 +12,7 @@
 import json
 from typing import List
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...logger._taipy_logger import _TaipyLogger
 from .._repository._filesystem_repository import _FileSystemRepository
 from ..exceptions.exceptions import VersionIsNotProductionVersion
 from ._version_converter import _VersionConverter

--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -12,12 +12,11 @@
 import uuid
 from typing import List, Optional, Union
 
-from taipy.config import Config
-from taipy.config._config_comparator._comparator_result import _ComparatorResult
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.exceptions.exceptions import InconsistentEnvVariableError
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...config import Config
+from ...config._config_comparator._comparator_result import _ComparatorResult
+from ...config.checker.issue_collector import IssueCollector
+from ...config.exceptions.exceptions import InconsistentEnvVariableError
+from ...logger._taipy_logger import _TaipyLogger
 from .._manager._manager import _Manager
 from ..exceptions.exceptions import ConflictedConfigurationError, ModelNotFound, NonExistingVersion
 from ._version import _Version

--- a/src/taipy/core/common/_utils.py
+++ b/src/taipy/core/common/_utils.py
@@ -16,7 +16,7 @@ from importlib import import_module
 from operator import attrgetter
 from typing import Callable, Optional, Tuple
 
-from taipy.config import Config
+from ...config import Config
 
 
 @functools.lru_cache

--- a/src/taipy/core/common/mongo_default_document.py
+++ b/src/taipy/core/common/mongo_default_document.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config.common._validate_id import _validate_id
+from ...config.common._validate_id import _validate_id
 
 
 class MongoDefaultDocument:

--- a/src/taipy/core/common/warn_if_inputs_not_ready.py
+++ b/src/taipy/core/common/warn_if_inputs_not_ready.py
@@ -11,8 +11,7 @@
 
 from typing import Iterable
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...logger._taipy_logger import _TaipyLogger
 from ..data import DataNode
 
 

--- a/src/taipy/core/config/__init__.py
+++ b/src/taipy/core/config/__init__.py
@@ -9,13 +9,12 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config import _inject_section
-from taipy.config.checker._checker import _Checker
-from taipy.config.common.frequency import Frequency  # type: ignore
-from taipy.config.common.scope import Scope  # type: ignore
-from taipy.config.config import Config  # type: ignore
-from taipy.config.global_app.global_app_config import GlobalAppConfig  # type: ignore
-
+from ...config import _inject_section
+from ...config.checker._checker import _Checker
+from ...config.common.frequency import Frequency  # type: ignore
+from ...config.common.scope import Scope  # type: ignore
+from ...config.config import Config  # type: ignore
+from ...config.global_app.global_app_config import GlobalAppConfig  # type: ignore
 from .checkers._config_id_checker import _ConfigIdChecker
 from .checkers._core_section_checker import _CoreSectionChecker
 from .checkers._data_node_config_checker import _DataNodeConfigChecker

--- a/src/taipy/core/config/checkers/_config_id_checker.py
+++ b/src/taipy/core/config/checkers/_config_id_checker.py
@@ -11,9 +11,9 @@
 
 from typing import Dict, List
 
-from taipy.config._config import _Config
-from taipy.config.checker._checkers._config_checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
+from ....config._config import _Config
+from ....config.checker._checkers._config_checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
 
 
 class _ConfigIdChecker(_ConfigChecker):

--- a/src/taipy/core/config/checkers/_core_section_checker.py
+++ b/src/taipy/core/config/checkers/_core_section_checker.py
@@ -11,10 +11,9 @@
 
 from typing import Set
 
-from taipy.config._config import _Config
-from taipy.config.checker._checkers._config_checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
-
+from ....config._config import _Config
+from ....config.checker._checkers._config_checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
 from ..core_section import CoreSection
 
 

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -12,11 +12,10 @@
 from datetime import timedelta
 from typing import Dict
 
-from taipy.config._config import _Config
-from taipy.config.checker._checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.common.scope import Scope
-
+from ....config._config import _Config
+from ....config.checker._checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
+from ....config.common.scope import Scope
 from ..data_node_config import DataNodeConfig
 
 

--- a/src/taipy/core/config/checkers/_job_config_checker.py
+++ b/src/taipy/core/config/checkers/_job_config_checker.py
@@ -11,10 +11,9 @@
 
 from typing import Dict
 
-from taipy.config._config import _Config
-from taipy.config.checker._checkers._config_checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
-
+from ....config._config import _Config
+from ....config.checker._checkers._config_checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
 from ..data_node_config import DataNodeConfig
 from ..job_config import JobConfig
 

--- a/src/taipy/core/config/checkers/_migration_config_checker.py
+++ b/src/taipy/core/config/checkers/_migration_config_checker.py
@@ -9,10 +9,9 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config._config import _Config
-from taipy.config.checker._checkers._config_checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
-
+from ....config._config import _Config
+from ....config.checker._checkers._config_checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
 from ..._version._version_manager_factory import _VersionManagerFactory
 from ..migration_config import MigrationConfig
 

--- a/src/taipy/core/config/checkers/_scenario_config_checker.py
+++ b/src/taipy/core/config/checkers/_scenario_config_checker.py
@@ -9,12 +9,11 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config import Config
-from taipy.config._config import _Config
-from taipy.config.checker._checkers._config_checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.common.frequency import Frequency
-
+from ....config import Config
+from ....config._config import _Config
+from ....config.checker._checkers._config_checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
+from ....config.common.frequency import Frequency
 from ..data_node_config import DataNodeConfig
 from ..scenario_config import ScenarioConfig
 from ..task_config import TaskConfig

--- a/src/taipy/core/config/checkers/_task_config_checker.py
+++ b/src/taipy/core/config/checkers/_task_config_checker.py
@@ -9,10 +9,9 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config._config import _Config
-from taipy.config.checker._checkers._config_checker import _ConfigChecker
-from taipy.config.checker.issue_collector import IssueCollector
-
+from ....config._config import _Config
+from ....config.checker._checkers._config_checker import _ConfigChecker
+from ....config.checker.issue_collector import IssueCollector
 from ..data_node_config import DataNodeConfig
 from ..task_config import TaskConfig
 

--- a/src/taipy/core/config/core_section.py
+++ b/src/taipy/core/config/core_section.py
@@ -13,11 +13,10 @@ import re
 from copy import copy
 from typing import Any, Dict, Optional, Union
 
-from taipy.config import Config, UniqueSection
-from taipy.config._config import _Config
-from taipy.config.common._config_blocker import _ConfigBlocker
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-
+from ...config import Config, UniqueSection
+from ...config._config import _Config
+from ...config.common._config_blocker import _ConfigBlocker
+from ...config.common._template_handler import _TemplateHandler as _tpl
 from .._init_version import _read_version
 from ..exceptions.exceptions import ConfigCoreVersionMismatched
 

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -14,13 +14,12 @@ from copy import copy
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from taipy.config._config import _Config
-from taipy.config.common._config_blocker import _ConfigBlocker
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.section import Section
-
+from ...config._config import _Config
+from ...config.common._config_blocker import _ConfigBlocker
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.common.scope import Scope
+from ...config.config import Config
+from ...config.section import Section
 from ..common._warnings import _warn_deprecated
 from ..common.mongo_default_document import MongoDefaultDocument
 

--- a/src/taipy/core/config/job_config.py
+++ b/src/taipy/core/config/job_config.py
@@ -11,11 +11,10 @@
 from copy import copy
 from typing import Any, Dict, Optional, Union
 
-from taipy.config import Config
-from taipy.config._config import _Config
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.unique_section import UniqueSection
-
+from ...config import Config
+from ...config._config import _Config
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.unique_section import UniqueSection
 from ..exceptions.exceptions import ModeNotAvailable
 
 

--- a/src/taipy/core/config/migration_config.py
+++ b/src/taipy/core/config/migration_config.py
@@ -13,11 +13,11 @@ import collections.abc
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
 
-from taipy.config._config import _Config
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.config import Config
-from taipy.config.section import Section
-from taipy.config.unique_section import UniqueSection
+from ...config._config import _Config
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.config import Config
+from ...config.section import Section
+from ...config.unique_section import UniqueSection
 
 
 class MigrationConfig(UniqueSection):

--- a/src/taipy/core/config/scenario_config.py
+++ b/src/taipy/core/config/scenario_config.py
@@ -13,13 +13,12 @@ from collections import defaultdict
 from copy import copy
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from taipy.config._config import _Config
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.common._validate_id import _validate_id
-from taipy.config.common.frequency import Frequency
-from taipy.config.config import Config
-from taipy.config.section import Section
-
+from ...config._config import _Config
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.common._validate_id import _validate_id
+from ...config.common.frequency import Frequency
+from ...config.config import Config
+from ...config.section import Section
 from .data_node_config import DataNodeConfig
 from .task_config import TaskConfig
 

--- a/src/taipy/core/config/task_config.py
+++ b/src/taipy/core/config/task_config.py
@@ -12,11 +12,10 @@
 from copy import copy
 from typing import Any, Dict, List, Optional, Union
 
-from taipy.config._config import _Config
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.config import Config
-from taipy.config.section import Section
-
+from ...config._config import _Config
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.config import Config
+from ...config.section import Section
 from ..common._warnings import _warn_deprecated
 from .data_node_config import DataNodeConfig
 

--- a/src/taipy/core/cycle/_cycle_manager.py
+++ b/src/taipy/core/cycle/_cycle_manager.py
@@ -13,8 +13,7 @@ import calendar
 from datetime import datetime, time, timedelta
 from typing import Callable, Dict, List, Optional
 
-from taipy.config.common.frequency import Frequency
-
+from ...config.common.frequency import Frequency
 from .._entity._entity_ids import _EntityIds
 from .._manager._manager import _Manager
 from .._repository._abstract_repository import _AbstractRepository

--- a/src/taipy/core/cycle/_cycle_model.py
+++ b/src/taipy/core/cycle/_cycle_model.py
@@ -14,8 +14,7 @@ from typing import Any, Dict
 
 from sqlalchemy import JSON, Column, Enum, String, Table
 
-from taipy.config.common.frequency import Frequency
-
+from ...config.common.frequency import Frequency
 from .._repository._base_taipy_model import _BaseModel
 from .._repository.db._sql_base_model import mapper_registry
 from .cycle_id import CycleId

--- a/src/taipy/core/cycle/cycle.py
+++ b/src/taipy/core/cycle/cycle.py
@@ -14,8 +14,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from taipy.config.common.frequency import Frequency
-
+from ...config.common.frequency import Frequency
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties

--- a/src/taipy/core/data/_abstract_file.py
+++ b/src/taipy/core/data/_abstract_file.py
@@ -19,7 +19,7 @@ class _AbstractFileDataNode(object):
     __EXTENSION_MAP = {"csv": "csv", "excel": "xlsx", "parquet": "parquet", "pickle": "p", "json": "json"}
 
     def _build_path(self, storage_type):
-        from taipy.config.config import Config
+        from ...config.config import Config
 
         folder = f"{storage_type}s"
         dir_path = pathlib.Path(Config.core.storage_folder) / folder

--- a/src/taipy/core/data/_abstract_sql.py
+++ b/src/taipy/core/data/_abstract_sql.py
@@ -21,8 +21,7 @@ import numpy as np
 import pandas as pd
 from sqlalchemy import create_engine, text
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..data.operator import JoinOperator, Operator
 from ..exceptions.exceptions import MissingRequiredProperty, UnknownDatabaseEngine

--- a/src/taipy/core/data/_data_manager.py
+++ b/src/taipy/core/data/_data_manager.py
@@ -12,10 +12,9 @@
 import os
 from typing import Dict, Iterable, List, Optional, Set, Union
 
-from taipy.config._config import _Config
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-
+from ...config._config import _Config
+from ...config.common.scope import Scope
+from ...config.config import Config
 from .._backup._backup import _append_to_backup_file, _remove_from_backup_file
 from .._manager._manager import _Manager
 from .._version._version_mixin import _VersionMixin

--- a/src/taipy/core/data/_data_model.py
+++ b/src/taipy/core/data/_data_model.py
@@ -14,8 +14,7 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import JSON, Boolean, Column, Enum, Float, String, Table, UniqueConstraint
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._repository._base_taipy_model import _BaseModel
 from .._repository.db._sql_base_model import mapper_registry
 from .data_node_id import Edit

--- a/src/taipy/core/data/csv.py
+++ b/src/taipy/core/data/csv.py
@@ -19,8 +19,7 @@ import modin.pandas as modin_pd
 import numpy as np
 import pandas as pd
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -17,10 +17,9 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import networkx as nx
 
-from taipy.config.common._validate_id import _validate_id
-from taipy.config.common.scope import Scope
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...config.common._validate_id import _validate_id
+from ...config.common.scope import Scope
+from ...logger._taipy_logger import _TaipyLogger
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties

--- a/src/taipy/core/data/excel.py
+++ b/src/taipy/core/data/excel.py
@@ -20,8 +20,7 @@ import numpy as np
 import pandas as pd
 from openpyxl import load_workbook
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory

--- a/src/taipy/core/data/generic.py
+++ b/src/taipy/core/data/generic.py
@@ -12,8 +12,7 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import MissingReadFunction, MissingRequiredProperty, MissingWriteFunction
 from .data_node import DataNode

--- a/src/taipy/core/data/in_memory.py
+++ b/src/taipy/core/data/in_memory.py
@@ -12,8 +12,7 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._version._version_manager_factory import _VersionManagerFactory
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit

--- a/src/taipy/core/data/json.py
+++ b/src/taipy/core/data/json.py
@@ -18,8 +18,7 @@ from os.path import isfile
 from pydoc import locate
 from typing import Any, Dict, List, Optional, Set
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory

--- a/src/taipy/core/data/mongo.py
+++ b/src/taipy/core/data/mongo.py
@@ -13,8 +13,7 @@ from datetime import datetime, timedelta
 from inspect import isclass
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..common._mongo_connector import _connect_mongodb
 from ..data.operator import JoinOperator, Operator

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -18,8 +18,7 @@ import modin.pandas as modin_pd
 import numpy as np
 import pandas as pd
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory

--- a/src/taipy/core/data/pickle.py
+++ b/src/taipy/core/data/pickle.py
@@ -16,8 +16,7 @@ from typing import Any, List, Optional, Set
 
 import modin.pandas as pd
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -14,8 +14,7 @@ from typing import Dict, List, Optional, Set
 
 from sqlalchemy import text
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import MissingAppendQueryBuilder, MissingRequiredProperty
 from ._abstract_sql import _AbstractSQLDataNode

--- a/src/taipy/core/data/sql_table.py
+++ b/src/taipy/core/data/sql_table.py
@@ -17,8 +17,7 @@ import numpy as np
 import pandas as pd
 from sqlalchemy import MetaData, Table
 
-from taipy.config.common.scope import Scope
-
+from ...config.common.scope import Scope
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import MissingRequiredProperty
 from ._abstract_sql import _AbstractSQLDataNode

--- a/src/taipy/core/job/job.py
+++ b/src/taipy/core/job/job.py
@@ -15,8 +15,7 @@ import traceback
 from datetime import datetime
 from typing import Any, Callable, List, Optional
 
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ...logger._taipy_logger import _TaipyLogger
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._reload import _self_reload, _self_setter

--- a/src/taipy/core/scenario/_scenario_manager.py
+++ b/src/taipy/core/scenario/_scenario_manager.py
@@ -13,8 +13,7 @@ import datetime
 from functools import partial
 from typing import Any, Callable, List, Optional, Union
 
-from taipy.config import Config
-
+from ...config import Config
 from .._entity._entity_ids import _EntityIds
 from .._manager._manager import _Manager
 from .._repository._abstract_repository import _AbstractRepository

--- a/src/taipy/core/scenario/scenario.py
+++ b/src/taipy/core/scenario/scenario.py
@@ -18,9 +18,8 @@ from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import networkx as nx
 
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.common._validate_id import _validate_id
-
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.common._validate_id import _validate_id
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties

--- a/src/taipy/core/sequence/sequence.py
+++ b/src/taipy/core/sequence/sequence.py
@@ -15,9 +15,8 @@ from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import networkx as nx
 
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.common._validate_id import _validate_id
-
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.common._validate_id import _validate_id
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties

--- a/src/taipy/core/submission/_submission_converter.py
+++ b/src/taipy/core/submission/_submission_converter.py
@@ -24,6 +24,7 @@ class _SubmissionConverter(_AbstractConverter):
         return _SubmissionModel(
             id=submission.id,
             entity_id=submission._entity_id,
+            entity_type=submission.entity_type,
             job_ids=[job.id if isinstance(job, Job) else JobId(str(job)) for job in list(submission._jobs)],
             creation_date=submission._creation_date.isoformat(),
             submission_status=submission._submission_status,
@@ -34,6 +35,7 @@ class _SubmissionConverter(_AbstractConverter):
     def _model_to_entity(cls, model: _SubmissionModel) -> Submission:
         submission = Submission(
             entity_id=model.entity_id,
+            entity_type=model.entity_type,
             id=SubmissionId(model.id),
             jobs=model.job_ids,
             creation_date=datetime.fromisoformat(model.creation_date),

--- a/src/taipy/core/submission/_submission_manager.py
+++ b/src/taipy/core/submission/_submission_manager.py
@@ -35,11 +35,8 @@ class _SubmissionManager(_Manager[Submission], _VersionMixin):
         return cls._repository._load_all(filters)
 
     @classmethod
-    def _create(
-        cls,
-        entity_id: str,
-    ) -> Submission:
-        submission = Submission(entity_id=entity_id)
+    def _create(cls, entity_id: str, entity_type: str) -> Submission:
+        submission = Submission(entity_id=entity_id, entity_type=entity_type)
         cls._set(submission)
 
         Notifier.publish(_make_event(submission, EventOperation.CREATION))

--- a/src/taipy/core/submission/_submission_model.py
+++ b/src/taipy/core/submission/_submission_model.py
@@ -28,6 +28,7 @@ class _SubmissionModel(_BaseModel):
         mapper_registry.metadata,
         Column("id", String, primary_key=True),
         Column("entity_id", String),
+        Column("entity_type", String),
         Column("job_ids", JSON),
         Column("creation_date", String),
         Column("submission_status", Enum(SubmissionStatus)),
@@ -35,6 +36,7 @@ class _SubmissionModel(_BaseModel):
     )
     id: str
     entity_id: str
+    entity_type: str
     job_ids: Union[List[JobId], List]
     creation_date: str
     submission_status: SubmissionStatus
@@ -45,6 +47,7 @@ class _SubmissionModel(_BaseModel):
         return _SubmissionModel(
             id=data["id"],
             entity_id=data["entity_id"],
+            entity_type=data["entity_type"],
             job_ids=_BaseModel._deserialize_attribute(data["job_ids"]),
             creation_date=data["creation_date"],
             submission_status=SubmissionStatus._from_repr(data["submission_status"]),
@@ -55,6 +58,7 @@ class _SubmissionModel(_BaseModel):
         return [
             self.id,
             self.entity_id,
+            self.entity_type,
             _BaseModel._serialize_attribute(self.job_ids),
             self.creation_date,
             repr(self.submission_status),

--- a/src/taipy/core/submission/submission.py
+++ b/src/taipy/core/submission/submission.py
@@ -44,6 +44,7 @@ class Submission(_Entity, _Labeled):
     def __init__(
         self,
         entity_id: str,
+        entity_type: str,
         id: Optional[str] = None,
         jobs: Optional[Union[List[Job], List[JobId]]] = None,
         creation_date: Optional[datetime] = None,
@@ -51,6 +52,7 @@ class Submission(_Entity, _Labeled):
         version: Optional[str] = None,
     ):
         self._entity_id = entity_id
+        self._entity_type = entity_type
         self.id = id or self.__new_id()
         self._jobs: Union[List[Job], List[JobId], List] = jobs or []
         self._creation_date = creation_date or datetime.now()
@@ -65,6 +67,10 @@ class Submission(_Entity, _Labeled):
     @property
     def entity_id(self) -> str:
         return self._entity_id
+
+    @property
+    def entity_type(self) -> str:
+        return self._entity_type
 
     @property
     def creation_date(self):

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -14,9 +14,8 @@ import shutil
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Set, Union, overload
 
-from taipy.config.common.scope import Scope
-from taipy.logger._taipy_logger import _TaipyLogger
-
+from ..config.common.scope import Scope
+from ..logger._taipy_logger import _TaipyLogger
 from ._entity._entity import _Entity
 from ._version._version_manager_factory import _VersionManagerFactory
 from .common._warnings import _warn_no_core_service

--- a/src/taipy/core/task/_task_manager.py
+++ b/src/taipy/core/task/_task_manager.py
@@ -11,9 +11,8 @@
 
 from typing import Callable, List, Optional, Type, Union
 
-from taipy.config import Config
-from taipy.config.common.scope import Scope
-
+from ...config import Config
+from ...config.common.scope import Scope
 from .._entity._entity_ids import _EntityIds
 from .._manager._manager import _Manager
 from .._orchestrator._abstract_orchestrator import _AbstractOrchestrator

--- a/src/taipy/core/task/task.py
+++ b/src/taipy/core/task/task.py
@@ -12,10 +12,9 @@
 import uuid
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set, Union
 
-from taipy.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.config.common._validate_id import _validate_id
-from taipy.config.common.scope import Scope
-
+from ...config.common._template_handler import _TemplateHandler as _tpl
+from ...config.common._validate_id import _validate_id
+from ...config.common.scope import Scope
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties

--- a/tests/core/_backup/test_backup.py
+++ b/tests/core/_backup/test_backup.py
@@ -13,7 +13,7 @@ import os
 from unittest.mock import patch
 
 import pytest
-
+from src.taipy.config.config import Config
 from src.taipy.core import Core
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.csv import CSVDataNode
@@ -21,7 +21,6 @@ from src.taipy.core.data.excel import ExcelDataNode
 from src.taipy.core.data.json import JSONDataNode
 from src.taipy.core.data.parquet import ParquetDataNode
 from src.taipy.core.data.pickle import PickleDataNode
-from taipy.config.config import Config
 
 
 def read_backup_file(path):

--- a/tests/core/_entity/test_dag.py
+++ b/tests/core/_entity/test_dag.py
@@ -10,9 +10,9 @@
 # specific language governing permissions and limitations under the License.
 from typing import List
 
+from src.taipy.config.common.scope import Scope
 from src.taipy.core import DataNode, Sequence, SequenceId, Task, TaskId
 from src.taipy.core._entity._dag import _DAG
-from taipy.config.common.scope import Scope
 
 
 def assert_x(x: int, *nodes):

--- a/tests/core/_entity/test_labelled.py
+++ b/tests/core/_entity/test_labelled.py
@@ -13,9 +13,11 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.config import Config
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
 from src.taipy.core import taipy
 from src.taipy.core._entity._labeled import _Labeled
-from taipy.config import Config, Frequency, Scope
 
 
 class MockOwner:

--- a/tests/core/_manager/test_manager.py
+++ b/tests/core/_manager/test_manager.py
@@ -14,12 +14,12 @@ import pathlib
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+from src.taipy.config.config import Config
 from src.taipy.core._manager._manager import _Manager
 from src.taipy.core._repository._abstract_converter import _AbstractConverter
 from src.taipy.core._repository._abstract_repository import _AbstractRepository
 from src.taipy.core._repository._filesystem_repository import _FileSystemRepository
 from src.taipy.core._version._version_manager import _VersionManager
-from taipy.config.config import Config
 
 
 @dataclass

--- a/tests/core/_orchestrator/_dispatcher/test_job_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/test_job_dispatcher.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 
 from pytest import raises
 
+from src.taipy.config.config import Config
 from src.taipy.core import DataNodeId, JobId, TaskId
 from src.taipy.core._orchestrator._dispatcher._development_job_dispatcher import _DevelopmentJobDispatcher
 from src.taipy.core._orchestrator._dispatcher._standalone_job_dispatcher import _StandaloneJobDispatcher
@@ -26,7 +27,6 @@ from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.job.job import Job
 from src.taipy.core.submission._submission_manager_factory import _SubmissionManagerFactory
 from src.taipy.core.task.task import Task
-from taipy.config.config import Config
 from tests.core.utils import assert_true_after_time
 
 

--- a/tests/core/_orchestrator/_dispatcher/test_job_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/test_job_dispatcher.py
@@ -112,7 +112,7 @@ def test_can_execute_synchronous():
 
     task_id = TaskId("task_id1")
     task = Task(config_id="name", properties={}, input=[], function=print, output=[], id=task_id)
-    submission = _SubmissionManagerFactory._build_manager()._create(task_id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task_id, task._ID_PREFIX)
     job_id = JobId("id1")
     job = Job(job_id, task, submission.id, task.id)
 
@@ -130,7 +130,7 @@ def test_exception_in_user_function():
     task_id = TaskId("task_id1")
     job_id = JobId("id1")
     task = Task(config_id="name", properties={}, input=[], function=_error, output=[], id=task_id)
-    submission = _SubmissionManagerFactory._build_manager()._create(task_id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task_id, task._ID_PREFIX)
     job = Job(job_id, task, submission.id, task.id)
 
     dispatcher = _OrchestratorFactory._dispatcher
@@ -151,7 +151,7 @@ def test_exception_in_writing_data():
     output._is_in_cache = False
     output.write.side_effect = ValueError()
     task = Task(config_id="name", properties={}, input=[], function=print, output=[output], id=task_id)
-    submission = _SubmissionManagerFactory._build_manager()._create(task_id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task_id, task._ID_PREFIX)
     job = Job(job_id, task, submission.id, task.id)
 
     dispatcher = _OrchestratorFactory._dispatcher

--- a/tests/core/_orchestrator/test_orchestrator.py
+++ b/tests/core/_orchestrator/test_orchestrator.py
@@ -18,7 +18,9 @@ from functools import partial
 from time import sleep
 
 import pytest
-
+from src.taipy.config import Config
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from src.taipy.core import taipy
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
@@ -31,9 +33,6 @@ from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.sequence.sequence import Sequence
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
-from taipy.config import Config
-from taipy.config.common.scope import Scope
-from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from tests.core.utils import assert_true_after_time
 
 # ################################  USER FUNCTIONS  ##################################
@@ -875,7 +874,7 @@ def test_task_orchestrator_create_standalone_dispatcher():
 
 
 def modified_config_task(n):
-    from taipy.config import Config
+    from src.taipy.config import Config
 
     assert_true_after_time(lambda: Config.core.storage_folder == ".my_data/")
     assert_true_after_time(lambda: Config.core.custom_property == "custom_property")
@@ -903,7 +902,7 @@ def test_can_exec_task_with_modified_config():
 
 
 def update_config_task(n):
-    from taipy.config import Config
+    from src.taipy.config import Config
 
     # The exception will be saved to logger, and there is no way to check for it
     # so it will be checked here

--- a/tests/core/_orchestrator/test_orchestrator_factory.py
+++ b/tests/core/_orchestrator/test_orchestrator_factory.py
@@ -13,12 +13,12 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.config import Config
 from src.taipy.core._orchestrator._dispatcher import _DevelopmentJobDispatcher, _JobDispatcher, _StandaloneJobDispatcher
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.exceptions.exceptions import OrchestratorNotBuilt
-from taipy.config import Config
 
 
 def test_build_orchestrator():

--- a/tests/core/common/test_retry.py
+++ b/tests/core/common/test_retry.py
@@ -11,8 +11,8 @@
 
 import pytest
 
+from src.taipy.config import Config
 from src.taipy.core.common._utils import _retry_read_entity
-from taipy.config import Config
 
 
 def test_retry_decorator(mocker):

--- a/tests/core/common/test_warn_if_inputs_not_ready.py
+++ b/tests/core/common/test_warn_if_inputs_not_ready.py
@@ -9,9 +9,9 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from src.taipy.config import Config
 from src.taipy.core.common.warn_if_inputs_not_ready import _warn_if_inputs_not_ready
 from src.taipy.core.data._data_manager_factory import _DataManagerFactory
-from taipy.config import Config
 
 
 def test_warn_inputs_all_not_ready(caplog):

--- a/tests/core/config/checkers/test_config_id_checker.py
+++ b/tests/core/config/checkers/test_config_id_checker.py
@@ -11,8 +11,8 @@
 
 import pytest
 
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.config import Config
+from src.taipy.config.checker.issue_collector import IssueCollector
+from src.taipy.config.config import Config
 
 
 class TestConfigIdChecker:

--- a/tests/core/config/checkers/test_core_section_checker.py
+++ b/tests/core/config/checkers/test_core_section_checker.py
@@ -9,10 +9,10 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from src.taipy.config import Config
+from src.taipy.config.checker.issue_collector import IssueCollector
 from src.taipy.core.config.checkers._core_section_checker import _CoreSectionChecker
 from src.taipy.core.config.core_section import CoreSection
-from taipy.config import Config
-from taipy.config.checker.issue_collector import IssueCollector
 
 
 class TestCoreSectionChecker:

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -14,10 +14,10 @@ from datetime import timedelta
 
 import pytest
 
+from src.taipy.config import Config
+from src.taipy.config.checker.issue_collector import IssueCollector
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.config.data_node_config import DataNodeConfig
-from taipy.config import Config
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.common.scope import Scope
 
 
 class MyCustomClass:

--- a/tests/core/config/checkers/test_job_config_checker.py
+++ b/tests/core/config/checkers/test_job_config_checker.py
@@ -11,9 +11,9 @@
 
 import pytest
 
+from src.taipy.config.checker.issue_collector import IssueCollector
+from src.taipy.config.config import Config
 from src.taipy.core.config.job_config import JobConfig
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.config import Config
 
 
 class TestJobConfigChecker:

--- a/tests/core/config/checkers/test_migration_config_checker.py
+++ b/tests/core/config/checkers/test_migration_config_checker.py
@@ -13,10 +13,10 @@ from unittest.mock import patch
 
 import pytest
 
+from src.taipy.config.config import Config
 from src.taipy.core import Core
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core.config import MigrationConfig
-from taipy.config.config import Config
 
 
 def mock_func():

--- a/tests/core/config/checkers/test_scenario_config_checker.py
+++ b/tests/core/config/checkers/test_scenario_config_checker.py
@@ -12,13 +12,12 @@
 from copy import copy
 
 import pytest
-
+from src.taipy.config.checker.issue_collector import IssueCollector
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.config import Config
 from src.taipy.core.config import ScenarioConfig
 from src.taipy.core.config.data_node_config import DataNodeConfig
 from src.taipy.core.config.task_config import TaskConfig
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.common.frequency import Frequency
-from taipy.config.config import Config
 
 
 def subtraction(n1, n2):

--- a/tests/core/config/checkers/test_task_config_checker.py
+++ b/tests/core/config/checkers/test_task_config_checker.py
@@ -12,11 +12,10 @@
 from copy import copy
 
 import pytest
-
+from src.taipy.config.checker.issue_collector import IssueCollector
+from src.taipy.config.config import Config
 from src.taipy.core.config import TaskConfig
 from src.taipy.core.config.data_node_config import DataNodeConfig
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.config import Config
 
 
 class TestTaskConfigChecker:

--- a/tests/core/config/test_config.py
+++ b/tests/core/config/test_config.py
@@ -11,8 +11,8 @@
 
 from datetime import timedelta
 
-from taipy.config import Config
-from taipy.config.common.scope import Scope
+from src.taipy.config import Config
+from src.taipy.config.common.scope import Scope
 
 
 class TestConfig:

--- a/tests/core/config/test_config_serialization.py
+++ b/tests/core/config/test_config_serialization.py
@@ -12,11 +12,11 @@
 import datetime
 import json
 
+from src.taipy.config import Config
+from src.taipy.config._serializer._json_serializer import _JsonSerializer
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.config import CoreSection, DataNodeConfig, JobConfig, MigrationConfig, ScenarioConfig, TaskConfig
-from taipy.config import Config
-from taipy.config._serializer._json_serializer import _JsonSerializer
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -12,9 +12,9 @@
 import json
 from datetime import timedelta
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core.common.mongo_default_document import MongoDefaultDocument
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 def test_set_default_data_node_configuration():

--- a/tests/core/config/test_core_section.py
+++ b/tests/core/config/test_core_section.py
@@ -11,9 +11,9 @@
 
 from unittest.mock import patch
 
+from src.taipy.config import Config
 from src.taipy.core import Core
 from src.taipy.core._version._version_manager_factory import _VersionManagerFactory
-from taipy.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/config/test_core_version.py
+++ b/tests/core/config/test_core_version.py
@@ -13,10 +13,10 @@ from unittest.mock import patch
 
 import pytest
 
+from src.taipy.config.config import Config
 from src.taipy.core._init_version import _read_version
 from src.taipy.core.config.core_section import CoreSection
 from src.taipy.core.exceptions import ConfigCoreVersionMismatched
-from taipy.config.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 _MOCK_CORE_VERSION = "3.1.1"

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -14,14 +14,13 @@ import os
 from unittest import mock
 
 import pytest
-
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from src.taipy.core import MongoDefaultDocument
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config import DataNodeConfig
 from src.taipy.core.config.job_config import JobConfig
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 
 
 def test_data_node_config_default_parameter():

--- a/tests/core/config/test_default_config.py
+++ b/tests/core/config/test_default_config.py
@@ -8,16 +8,16 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+from src.taipy.config._config import _Config
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.global_app.global_app_config import GlobalAppConfig
 from src.taipy.core.config import CoreSection
 from src.taipy.core.config.data_node_config import DataNodeConfig
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.config.migration_config import MigrationConfig
 from src.taipy.core.config.scenario_config import ScenarioConfig
 from src.taipy.core.config.task_config import TaskConfig
-from taipy.config._config import _Config
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.global_app.global_app_config import GlobalAppConfig
 
 
 def _test_default_job_config(job_config: JobConfig):

--- a/tests/core/config/test_file_config.py
+++ b/tests/core/config/test_file_config.py
@@ -13,11 +13,11 @@ import os
 from datetime import timedelta
 from unittest import mock
 
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core.config import DataNodeConfig, ScenarioConfig, TaskConfig
 from src.taipy.core.config.core_section import CoreSection
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/config/test_job_config.py
+++ b/tests/core/config/test_job_config.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from taipy.config.config import Config
+from src.taipy.config.config import Config
 
 
 def test_job_config():

--- a/tests/core/config/test_migration_config.py
+++ b/tests/core/config/test_migration_config.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config.config import Config
+from src.taipy.config.config import Config
 
 
 def migrate_pickle_path(dn):

--- a/tests/core/config/test_override_config.py
+++ b/tests/core/config/test_override_config.py
@@ -14,8 +14,8 @@ from unittest import mock
 
 import pytest
 
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import InconsistentEnvVariableError, MissingEnvVariableError
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import InconsistentEnvVariableError, MissingEnvVariableError
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/config/test_scenario_config.py
+++ b/tests/core/config/test_scenario_config.py
@@ -12,8 +12,8 @@
 import os
 from unittest import mock
 
-from taipy.config.common.frequency import Frequency
-from taipy.config.config import Config
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/config/test_task_config.py
+++ b/tests/core/config/test_task_config.py
@@ -12,9 +12,9 @@
 import os
 from unittest import mock
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core.config import DataNodeConfig
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -19,6 +19,14 @@ import pandas as pd
 import pytest
 from sqlalchemy import create_engine, text
 
+from src.taipy.config import _inject_section
+from src.taipy.config._config import _Config
+from src.taipy.config._serializer._toml_serializer import _TomlSerializer
+from src.taipy.config.checker._checker import _Checker
+from src.taipy.config.checker.issue_collector import IssueCollector
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._core import Core
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core._repository.db._sql_connection import _SQLConnection
@@ -60,14 +68,6 @@ from src.taipy.core.submission._submission_manager_factory import _SubmissionMan
 from src.taipy.core.submission._submission_model import _SubmissionModel
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task
-from taipy.config import _inject_section
-from taipy.config._config import _Config
-from taipy.config._serializer._toml_serializer import _TomlSerializer
-from taipy.config.checker._checker import _Checker
-from taipy.config.checker.issue_collector import IssueCollector
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 current_time = datetime.now()
 _OrchestratorFactory._build_orchestrator()

--- a/tests/core/cycle/test_cycle.py
+++ b/tests/core/cycle/test_cycle.py
@@ -11,10 +11,10 @@
 import datetime
 from datetime import timedelta
 
+from src.taipy.config.common.frequency import Frequency
 from src.taipy.core import CycleId
 from src.taipy.core.cycle._cycle_manager import _CycleManager
 from src.taipy.core.cycle.cycle import Cycle
-from taipy.config.common.frequency import Frequency
 
 
 def test_create_cycle_entity(current_datetime):

--- a/tests/core/cycle/test_cycle_manager.py
+++ b/tests/core/cycle/test_cycle_manager.py
@@ -11,6 +11,9 @@
 
 from datetime import datetime
 
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.cycle._cycle_manager import _CycleManager
@@ -21,9 +24,6 @@ from src.taipy.core.job._job_manager import _JobManager
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 def test_save_and_get_cycle_entity(tmpdir, cycle, current_datetime):

--- a/tests/core/cycle/test_cycle_manager_with_sql_repo.py
+++ b/tests/core/cycle/test_cycle_manager_with_sql_repo.py
@@ -11,6 +11,9 @@
 
 from datetime import datetime
 
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.cycle._cycle_manager import _CycleManager
@@ -23,9 +26,6 @@ from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 def test_save_and_get_cycle_entity(init_sql_repo, cycle, current_datetime):

--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -21,14 +21,14 @@ import pytest
 from modin.pandas.test.utils import df_equals
 from pandas.testing import assert_frame_equal
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.csv import CSVDataNode
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.operator import JoinOperator, Operator
 from src.taipy.core.exceptions.exceptions import InvalidExposedType, NoData
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -13,6 +13,8 @@ import pathlib
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core.config.data_node_config import DataNodeConfig
 from src.taipy.core.data._data_manager import _DataManager
@@ -21,8 +23,6 @@ from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.in_memory import InMemoryDataNode
 from src.taipy.core.data.pickle import PickleDataNode
 from src.taipy.core.exceptions.exceptions import InvalidDataNodeType, ModelNotFound
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/data/test_data_manager_with_sql_repo.py
+++ b/tests/core/data/test_data_manager_with_sql_repo.py
@@ -14,6 +14,8 @@ import pathlib
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core.config.data_node_config import DataNodeConfig
 from src.taipy.core.data._data_manager import _DataManager
@@ -22,8 +24,6 @@ from src.taipy.core.data.csv import CSVDataNode
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.in_memory import InMemoryDataNode
 from src.taipy.core.exceptions.exceptions import InvalidDataNodeType, ModelNotFound
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 def file_exists(file_path: str) -> bool:

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -15,8 +15,10 @@ from time import sleep
 from unittest import mock
 
 import pytest
-
 import src.taipy.core as tp
+from src.taipy.config import Config
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.data._data_manager import _DataManager
@@ -25,9 +27,6 @@ from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.in_memory import InMemoryDataNode
 from src.taipy.core.exceptions.exceptions import DataNodeIsBeingEdited, NoData
 from src.taipy.core.job.job_id import JobId
-from taipy.config import Config
-from taipy.config.common.scope import Scope
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 from .utils import FakeDataNode
 

--- a/tests/core/data/test_excel_data_node.py
+++ b/tests/core/data/test_excel_data_node.py
@@ -22,6 +22,8 @@ import pytest
 from modin.pandas.test.utils import df_equals
 from pandas.testing import assert_frame_equal
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.excel import ExcelDataNode
@@ -33,8 +35,6 @@ from src.taipy.core.exceptions.exceptions import (
     NonExistingExcelSheet,
     SheetNameLengthMismatch,
 )
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/core/data/test_generic_data_node.py
+++ b/tests/core/data/test_generic_data_node.py
@@ -10,13 +10,12 @@
 # specific language governing permissions and limitations under the License.
 
 import pytest
-
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.data.data_node import DataNode
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.generic import GenericDataNode
 from src.taipy.core.exceptions.exceptions import MissingReadFunction, MissingRequiredProperty, MissingWriteFunction
-from taipy.config.common.scope import Scope
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 def read_fct():

--- a/tests/core/data/test_in_memory_data_node.py
+++ b/tests/core/data/test_in_memory_data_node.py
@@ -11,11 +11,11 @@
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.in_memory import InMemoryDataNode
 from src.taipy.core.exceptions.exceptions import NoData
-from taipy.config.common.scope import Scope
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 class TestInMemoryDataNodeEntity:

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -20,15 +20,14 @@ from time import sleep
 import numpy as np
 import pandas as pd
 import pytest
-
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.json import JSONDataNode
 from src.taipy.core.data.operator import JoinOperator, Operator
 from src.taipy.core.exceptions.exceptions import NoData
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/core/data/test_mongo_data_node.py
+++ b/tests/core/data/test_mongo_data_node.py
@@ -19,14 +19,13 @@ import pymongo
 import pytest
 from bson import ObjectId
 from bson.errors import InvalidDocument
-
+from src.taipy.config.common.scope import Scope
 from src.taipy.core import MongoDefaultDocument
 from src.taipy.core.common._mongo_connector import _connect_mongodb
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.mongo import MongoCollectionDataNode
 from src.taipy.core.data.operator import JoinOperator, Operator
 from src.taipy.core.exceptions.exceptions import InvalidCustomDocument, MissingRequiredProperty
-from taipy.config.common.scope import Scope
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -22,6 +22,9 @@ import pytest
 from modin.pandas.test.utils import df_equals
 from pandas.testing import assert_frame_equal
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.operator import JoinOperator, Operator
@@ -32,9 +35,6 @@ from src.taipy.core.exceptions.exceptions import (
     UnknownCompressionAlgorithm,
     UnknownParquetEngine,
 )
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -500,7 +500,6 @@ class TestParquetDataNode:
         dn.write(df)
 
         assert set(pd.read_parquet(temp_file_path).columns) == {"id", "integer", "text"}
-        print(dn.read())
         assert set(dn.read().columns) == set(read_kwargs["columns"])
 
         # !!! filter doesn't work with `fastparquet` without partition_cols

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -18,12 +18,12 @@ import modin.pandas as modin_pd
 import pandas as pd
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.pickle import PickleDataNode
 from src.taipy.core.exceptions.exceptions import NoData
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -18,12 +18,11 @@ import pandas as pd
 import pytest
 from modin.pandas.test.utils import df_equals
 from pandas.testing import assert_frame_equal
-
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.operator import JoinOperator, Operator
 from src.taipy.core.data.sql import SQLDataNode
 from src.taipy.core.exceptions.exceptions import MissingAppendQueryBuilder, MissingRequiredProperty
-from taipy.config.common.scope import Scope
 
 
 class MyCustomObject:

--- a/tests/core/data/test_sql_table_data_node.py
+++ b/tests/core/data/test_sql_table_data_node.py
@@ -18,12 +18,11 @@ import pandas as pd
 import pytest
 from modin.pandas.test.utils import df_equals
 from pandas.testing import assert_frame_equal
-
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.data.data_node_id import DataNodeId
 from src.taipy.core.data.operator import JoinOperator, Operator
 from src.taipy.core.data.sql_table import SQLTableDataNode
 from src.taipy.core.exceptions.exceptions import InvalidExposedType, MissingRequiredProperty
-from taipy.config.common.scope import Scope
 
 
 class MyCustomObject:

--- a/tests/core/data/utils.py
+++ b/tests/core/data/utils.py
@@ -9,9 +9,9 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.data.data_node import DataNode
 from src.taipy.core.data.in_memory import InMemoryDataNode
-from taipy.config.common.scope import Scope
 
 
 class FakeDataNode(InMemoryDataNode):

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import JobId, Sequence, SequenceId, TaskId
 from src.taipy.core._orchestrator._dispatcher._development_job_dispatcher import _DevelopmentJobDispatcher
 from src.taipy.core._orchestrator._dispatcher._standalone_job_dispatcher import _StandaloneJobDispatcher
@@ -31,8 +33,6 @@ from src.taipy.core.submission._submission_manager_factory import _SubmissionMan
 from src.taipy.core.submission.submission import Submission
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 @pytest.fixture

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -16,7 +16,6 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-
 from src.taipy.config.common.scope import Scope
 from src.taipy.config.config import Config
 from src.taipy.core import JobId, Sequence, SequenceId, TaskId
@@ -119,7 +118,7 @@ def test_comparison(task):
 
 
 def test_status_job(task):
-    submission = _SubmissionManagerFactory._build_manager()._create(task.id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX)
     job = Job("job_id", task, submission.id, "SCENARIO_scenario_config")
     submission.jobs = [job]
 
@@ -150,7 +149,7 @@ def test_status_job(task):
 
 def test_notification_job(task):
     subscribe = MagicMock()
-    submission = _SubmissionManagerFactory._build_manager()._create(task.id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX)
     job = Job("job_id", task, submission.id, "SCENARIO_scenario_config")
     submission.jobs = [job]
 
@@ -170,7 +169,7 @@ def test_notification_job(task):
 
 def test_handle_exception_in_user_function(task_id, job_id):
     task = Task(config_id="name", properties={}, input=[], function=_error, output=[], id=task_id)
-    submission = _SubmissionManagerFactory._build_manager()._create(task.id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX)
     job = Job(job_id, task, submission.id, "scenario_entity_id")
     submission.jobs = [job]
 
@@ -184,7 +183,7 @@ def test_handle_exception_in_user_function(task_id, job_id):
 def test_handle_exception_in_input_data_node(task_id, job_id):
     data_node = InMemoryDataNode("data_node", scope=Scope.SCENARIO)
     task = Task(config_id="name", properties={}, input=[data_node], function=print, output=[], id=task_id)
-    submission = _SubmissionManagerFactory._build_manager()._create(task.id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX)
     job = Job(job_id, task, submission.id, "scenario_entity_id")
     submission.jobs = [job]
 
@@ -198,7 +197,7 @@ def test_handle_exception_in_input_data_node(task_id, job_id):
 def test_handle_exception_in_ouptut_data_node(replace_in_memory_write_fct, task_id, job_id):
     data_node = InMemoryDataNode("data_node", scope=Scope.SCENARIO)
     task = Task(config_id="name", properties={}, input=[], function=_foo, output=[data_node], id=task_id)
-    submission = _SubmissionManagerFactory._build_manager()._create(task.id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX)
     job = Job(job_id, task, submission.id, "scenario_entity_id")
     submission.jobs = [job]
 
@@ -213,7 +212,7 @@ def test_handle_exception_in_ouptut_data_node(replace_in_memory_write_fct, task_
 def test_auto_set_and_reload(current_datetime, job_id):
     task_1 = Task(config_id="name_1", properties={}, function=_foo, id=TaskId("task_1"))
     task_2 = Task(config_id="name_2", properties={}, function=_foo, id=TaskId("task_2"))
-    submission = _SubmissionManagerFactory._build_manager()._create(task_1.id)
+    submission = _SubmissionManagerFactory._build_manager()._create(task_1.id, task_1._ID_PREFIX)
     job_1 = Job(job_id, task_1, submission.id, "scenario_entity_id")
     submission.jobs = [job_1]
 

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -18,6 +18,8 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
@@ -31,8 +33,6 @@ from src.taipy.core.job.status import Status
 from src.taipy.core.submission._submission_manager_factory import _SubmissionManagerFactory
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils import assert_true_after_time
 
 

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -17,7 +17,6 @@ from time import sleep
 from unittest import mock
 
 import pytest
-
 from src.taipy.config.common.scope import Scope
 from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
@@ -30,6 +29,7 @@ from src.taipy.core.exceptions.exceptions import JobNotDeletedException
 from src.taipy.core.job._job_manager import _JobManager
 from src.taipy.core.job.job_id import JobId
 from src.taipy.core.job.status import Status
+from src.taipy.core.scenario.scenario import Scenario
 from src.taipy.core.submission._submission_manager_factory import _SubmissionManagerFactory
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
@@ -349,8 +349,8 @@ def test_cancel_subsequent_jobs():
     task_3 = Task("task_config_3", {}, print, [dn_4], id="task_3")
 
     # Can't get tasks under 1 scenario due to partial not serializable
-    submission_1 = submission_manager._create("scenario_id")
-    submission_2 = submission_manager._create("scenario_id")
+    submission_1 = submission_manager._create("scenario_id", Scenario._ID_PREFIX)
+    submission_2 = submission_manager._create("scenario_id", Scenario._ID_PREFIX)
 
     _DataManager._set(dn_1)
     _DataManager._set(dn_2)

--- a/tests/core/job/test_job_manager_with_sql_repo.py
+++ b/tests/core/job/test_job_manager_with_sql_repo.py
@@ -17,6 +17,8 @@ from time import sleep
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import Task
 from src.taipy.core._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
@@ -32,8 +34,6 @@ from src.taipy.core.job.job_id import JobId
 from src.taipy.core.job.status import Status
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils import assert_true_after_time
 
 

--- a/tests/core/notification/test_core_event_consumer.py
+++ b/tests/core/notification/test_core_event_consumer.py
@@ -11,11 +11,12 @@
 
 from queue import SimpleQueue
 
+from src.taipy.config import Config
+from src.taipy.config.common.frequency import Frequency
 from src.taipy.core import taipy as tp
 from src.taipy.core.notification.core_event_consumer import CoreEventConsumerBase
 from src.taipy.core.notification.event import Event, EventEntityType, EventOperation
 from src.taipy.core.notification.notifier import Notifier
-from taipy.config import Config, Frequency
 from tests.core.utils import assert_true_after_time
 
 

--- a/tests/core/notification/test_event.py
+++ b/tests/core/notification/test_event.py
@@ -11,9 +11,9 @@
 
 import pytest
 
+from src.taipy.config.common.frequency import Frequency
 from src.taipy.core.exceptions.exceptions import InvalidEventAttributeName, InvalidEventOperation
 from src.taipy.core.notification.event import Event, EventEntityType, EventOperation
-from taipy.config.common.frequency import Frequency
 
 
 def test_event_creation_cycle():

--- a/tests/core/notification/test_events_published.py
+++ b/tests/core/notification/test_events_published.py
@@ -15,13 +15,14 @@ from queue import SimpleQueue
 
 from colorama import init
 
+from src.taipy.config import Config
+from src.taipy.config.common.frequency import Frequency
 from src.taipy.core import taipy as tp
 from src.taipy.core.config import scenario_config
 from src.taipy.core.job.status import Status
 from src.taipy.core.notification.core_event_consumer import CoreEventConsumerBase
 from src.taipy.core.notification.event import Event, EventEntityType, EventOperation
 from src.taipy.core.notification.notifier import Notifier
-from taipy.config import Config, Frequency
 from tests.core.utils import assert_true_after_time
 
 

--- a/tests/core/notification/test_notifier.py
+++ b/tests/core/notification/test_notifier.py
@@ -11,12 +11,13 @@
 
 from queue import SimpleQueue
 
+from src.taipy.config import Config
+from src.taipy.config.common.frequency import Frequency
 from src.taipy.core import taipy as tp
 from src.taipy.core.notification import EventEntityType, EventOperation
 from src.taipy.core.notification._topic import _Topic
 from src.taipy.core.notification.event import Event
 from src.taipy.core.notification.notifier import Notifier
-from taipy.config import Config, Frequency
 
 
 def test_register():

--- a/tests/core/notification/test_notifier.py
+++ b/tests/core/notification/test_notifier.py
@@ -109,8 +109,6 @@ def test_register():
 
     Notifier.unregister(registration_id_1)
     assert len(Notifier._topics_registrations_list.keys()) == 2
-
-    print(Notifier._topics_registrations_list.keys())
     assert all(topic not in Notifier._topics_registrations_list.keys() for topic in [topic_0, topic_1])
 
     Notifier.unregister(registration_id_2)

--- a/tests/core/repository/mocks.py
+++ b/tests/core/repository/mocks.py
@@ -19,11 +19,11 @@ from sqlalchemy.dialects import sqlite
 from sqlalchemy.orm import declarative_base, registry
 from sqlalchemy.schema import CreateTable
 
+from src.taipy.config.config import Config
 from src.taipy.core._repository._abstract_converter import _AbstractConverter
 from src.taipy.core._repository._filesystem_repository import _FileSystemRepository
 from src.taipy.core._repository._sql_repository import _SQLRepository
 from src.taipy.core._version._version_manager import _VersionManager
-from taipy.config.config import Config
 
 
 class Base:

--- a/tests/core/repository/test_repositories.py
+++ b/tests/core/repository/test_repositories.py
@@ -15,9 +15,8 @@ import pathlib
 import shutil
 
 import pytest
-
+from src.taipy.config.config import Config
 from src.taipy.core.exceptions.exceptions import InvalidExportPath
-from taipy.config.config import Config
 
 from .mocks import MockConverter, MockFSRepository, MockModel, MockObj, MockSQLRepository
 

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -13,7 +13,9 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
-
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.common._utils import _Subscriber
 from src.taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
 from src.taipy.core.cycle.cycle import Cycle, CycleId
@@ -28,9 +30,6 @@ from src.taipy.core.sequence.sequence import Sequence
 from src.taipy.core.sequence.sequence_id import SequenceId
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task, TaskId
-from taipy.config import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 def test_create_primary_scenario(cycle):

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -15,6 +15,9 @@ from unittest.mock import ANY, patch
 
 import pytest
 
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import Job
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
@@ -47,9 +50,6 @@ from src.taipy.core.sequence.sequence_id import SequenceId
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
 from src.taipy.core.task.task_id import TaskId
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils import assert_true_after_time
 from tests.core.utils.NotifyMock import NotifyMock
 

--- a/tests/core/scenario/test_scenario_manager_with_sql_repo.py
+++ b/tests/core/scenario/test_scenario_manager_with_sql_repo.py
@@ -12,7 +12,9 @@
 from datetime import datetime, timedelta
 
 import pytest
-
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core.config.job_config import JobConfig
@@ -34,9 +36,6 @@ from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task
 from src.taipy.core.task.task_id import TaskId
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.conftest import init_managers
 
 

--- a/tests/core/sequence/test_sequence.py
+++ b/tests/core/sequence/test_sequence.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.common._utils import _Subscriber
 from src.taipy.core.data._data_manager_factory import _DataManagerFactory
 from src.taipy.core.data.data_node import DataNode
@@ -25,7 +26,6 @@ from src.taipy.core.sequence.sequence import Sequence
 from src.taipy.core.sequence.sequence_id import SequenceId
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task, TaskId
-from taipy.config.common.scope import Scope
 
 
 def test_create_sequence():

--- a/tests/core/sequence/test_sequence_manager.py
+++ b/tests/core/sequence/test_sequence_manager.py
@@ -16,7 +16,8 @@ from unittest import mock
 from unittest.mock import ANY
 
 import pytest
-
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core._version._version_manager import _VersionManager
@@ -42,8 +43,6 @@ from src.taipy.core.sequence.sequence_id import SequenceId
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
 from src.taipy.core.task.task_id import TaskId
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.utils.NotifyMock import NotifyMock
 
 

--- a/tests/core/sequence/test_sequence_manager_with_sql_repo.py
+++ b/tests/core/sequence/test_sequence_manager_with_sql_repo.py
@@ -11,6 +11,8 @@
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core.config.job_config import JobConfig
@@ -24,8 +26,6 @@ from src.taipy.core.sequence.sequence_id import SequenceId
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
 from src.taipy.core.task.task_id import TaskId
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.conftest import init_managers
 
 

--- a/tests/core/submission/test_submission.py
+++ b/tests/core/submission/test_submission.py
@@ -29,7 +29,7 @@ from src.taipy.core.task.task import Task
 
 
 def test_create_submission(scenario, job, current_datetime):
-    submission_1 = Submission(scenario.id)
+    submission_1 = Submission(scenario.id, scenario._ID_PREFIX)
 
     assert submission_1.id is not None
     assert submission_1.entity_id == scenario.id
@@ -39,7 +39,13 @@ def test_create_submission(scenario, job, current_datetime):
     assert submission_1._version is not None
 
     submission_2 = Submission(
-        scenario.id, "submission_id", [job], current_datetime, SubmissionStatus.COMPLETED, "version_id"
+        scenario.id,
+        scenario._ID_PREFIX,
+        "submission_id",
+        [job],
+        current_datetime,
+        SubmissionStatus.COMPLETED,
+        "version_id",
     )
 
     assert submission_2.id == "submission_id"
@@ -106,7 +112,7 @@ def __test_update_submission_status(job_ids, expected_submission_status):
             return_value=(mock_get_jobs(job_ids)),
         )
     ):
-        submission = Submission("submission_id")
+        submission = Submission("submission_id", "ENTITY_TYPE")
         submission._update_submission_status(None)
         assert submission.submission_status == expected_submission_status
 
@@ -263,7 +269,7 @@ def test_update_submission_status_with_wrong_case_abandoned_without_cancel_or_fa
 
 def test_auto_set_and_reload():
     task = Task(config_id="name_1", properties={}, function=print, id=TaskId("task_1"))
-    submission_1 = Submission(task.id)
+    submission_1 = Submission(task.id, task._ID_PREFIX)
     job_1 = Job("job_1", task, submission_1.id, submission_1.entity_id)
     job_2 = Job("job_2", task, submission_1.id, submission_1.entity_id)
 

--- a/tests/core/submission/test_submission_manager.py
+++ b/tests/core/submission/test_submission_manager.py
@@ -20,7 +20,7 @@ from src.taipy.core.task.task import Task
 
 
 def test_create_submission(scenario):
-    submission_1 = _SubmissionManagerFactory._build_manager()._create(scenario.id)
+    submission_1 = _SubmissionManagerFactory._build_manager()._create(scenario.id, scenario._ID_PREFIX)
 
     assert submission_1.id is not None
     assert submission_1.entity_id == scenario.id
@@ -34,7 +34,7 @@ def test_get_submission():
 
     assert submission_manager._get("random_submission_id") is None
 
-    submission_1 = submission_manager._create("entity_id")
+    submission_1 = submission_manager._create("entity_id", "ENTITY_TYPE")
     submission_2 = submission_manager._get(submission_1.id)
 
     assert submission_1.id == submission_2.id
@@ -69,22 +69,22 @@ def test_get_latest_submission():
     task_2 = Task("task_config_2", {}, print, id="task_id_2")
 
     submission_manager = _SubmissionManagerFactory._build_manager()
-    submission_1 = submission_manager._create(task_1.id)
+    submission_1 = submission_manager._create(task_1.id, task_1._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_1
     assert submission_manager._get_latest(task_2) is None
 
     sleep(0.01)  # Comparison is based on time, precision on Windows is not enough important
-    submission_2 = submission_manager._create(task_2.id)
+    submission_2 = submission_manager._create(task_2.id, task_2._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_1
     assert submission_manager._get_latest(task_2) == submission_2
 
     sleep(0.01)  # Comparison is based on time, precision on Windows is not enough important
-    submission_3 = submission_manager._create(task_1.id)
+    submission_3 = submission_manager._create(task_1.id, task_1._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_3
     assert submission_manager._get_latest(task_2) == submission_2
 
     sleep(0.01)  # Comparison is based on time, precision on Windows is not enough important
-    submission_4 = submission_manager._create(task_2.id)
+    submission_4 = submission_manager._create(task_2.id, task_2._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_3
     assert submission_manager._get_latest(task_2) == submission_4
 

--- a/tests/core/submission/test_submission_manager_with_sql_repo.py
+++ b/tests/core/submission/test_submission_manager_with_sql_repo.py
@@ -28,7 +28,7 @@ def init_managers():
 def test_create_submission(scenario, init_sql_repo):
     init_managers()
 
-    submission_1 = _SubmissionManagerFactory._build_manager()._create(scenario.id)
+    submission_1 = _SubmissionManagerFactory._build_manager()._create(scenario.id, scenario._ID_PREFIX)
 
     assert submission_1.id is not None
     assert submission_1.entity_id == scenario.id
@@ -42,7 +42,7 @@ def test_get_submission(init_sql_repo):
 
     submission_manager = _SubmissionManagerFactory._build_manager()
 
-    submission_1 = submission_manager._create("entity_id")
+    submission_1 = submission_manager._create("entity_id", "ENTITY_TYPE")
     submission_2 = submission_manager._get(submission_1.id)
 
     assert submission_1.id == submission_2.id
@@ -80,22 +80,22 @@ def test_get_latest_submission(init_sql_repo):
     task_2 = Task("task_config_2", {}, print, id="task_id_2")
 
     submission_manager = _SubmissionManagerFactory._build_manager()
-    submission_1 = submission_manager._create(task_1.id)
+    submission_1 = submission_manager._create(task_1.id, task_1._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_1
     assert submission_manager._get_latest(task_2) is None
 
     sleep(0.01)  # Comparison is based on time, precision on Windows is not enough important
-    submission_2 = submission_manager._create(task_2.id)
+    submission_2 = submission_manager._create(task_2.id, task_2._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_1
     assert submission_manager._get_latest(task_2) == submission_2
 
     sleep(0.01)  # Comparison is based on time, precision on Windows is not enough important
-    submission_3 = submission_manager._create(task_1.id)
+    submission_3 = submission_manager._create(task_1.id, task_1._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_3
     assert submission_manager._get_latest(task_2) == submission_2
 
     sleep(0.01)  # Comparison is based on time, precision on Windows is not enough important
-    submission_4 = submission_manager._create(task_2.id)
+    submission_4 = submission_manager._create(task_2.id, task_2._ID_PREFIX)
     assert submission_manager._get_latest(task_1) == submission_3
     assert submission_manager._get_latest(task_2) == submission_4
 

--- a/tests/core/submission/test_submission_repositories.py
+++ b/tests/core/submission/test_submission_repositories.py
@@ -42,7 +42,7 @@ class TestSubmissionRepository:
         job._task = task
         _JobManagerFactory._build_manager()._repository._save(job)
 
-        submission = Submission(task.id)
+        submission = Submission(task.id, task._ID_PREFIX)
         submission_repository = _SubmissionManagerFactory._build_manager()._repository
         submission_repository._save(submission)
         submission.jobs = [job]
@@ -54,7 +54,7 @@ class TestSubmissionRepository:
     def test_exists(self, configure_repo):
         configure_repo()
 
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
         submission_repository = _SubmissionManagerFactory._build_manager()._repository
         submission_repository._save(submission)
 
@@ -66,7 +66,7 @@ class TestSubmissionRepository:
         configure_repo()
 
         repository = _SubmissionManagerFactory._build_manager()._repository
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
         for i in range(10):
             submission.id = f"submission-{i}"
             repository._save(submission)
@@ -80,7 +80,7 @@ class TestSubmissionRepository:
 
         repository = _SubmissionManagerFactory._build_manager()._repository
 
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
         repository._save(submission)
 
         repository._delete(submission.id)
@@ -93,7 +93,7 @@ class TestSubmissionRepository:
         configure_repo()
 
         submission_repository = _SubmissionManagerFactory._build_manager()._repository
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
 
         for i in range(10):
             submission.id = f"submission-{i}"
@@ -109,7 +109,7 @@ class TestSubmissionRepository:
     def test_delete_many(self, configure_repo):
         configure_repo()
 
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
         submission_repository = _SubmissionManagerFactory._build_manager()._repository
 
         for i in range(10):
@@ -129,7 +129,7 @@ class TestSubmissionRepository:
 
         # Create 5 entities with version 1.0 and 5 entities with version 2.0
         submission_repository = _SubmissionManagerFactory._build_manager()._repository
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
 
         for i in range(10):
             submission.id = f"submission-{i}"
@@ -147,7 +147,7 @@ class TestSubmissionRepository:
         configure_repo()
 
         submission_repository = _SubmissionManagerFactory._build_manager()._repository
-        submission = Submission("entity_id", version="random_version_number")
+        submission = Submission("entity_id", "ENTITY_TYPE", version="random_version_number")
         for i in range(10):
             submission.id = f"submission-{i}"
             submission_repository._save(submission)
@@ -169,7 +169,7 @@ class TestSubmissionRepository:
         configure_repo()
 
         repository = _SubmissionManagerFactory._build_manager()._repository
-        submission = Submission("entity_id")
+        submission = Submission("entity_id", "ENTITY_TYPE")
         repository._save(submission)
 
         repository._export(submission.id, tmpdir.strpath)

--- a/tests/core/submission/test_submission_repositories.py
+++ b/tests/core/submission/test_submission_repositories.py
@@ -12,7 +12,7 @@
 import os
 
 import pytest
-
+from src.taipy.config.config import Config
 from src.taipy.core.data._data_manager_factory import _DataManagerFactory
 from src.taipy.core.exceptions import ModelNotFound
 from src.taipy.core.job._job_manager_factory import _JobManagerFactory
@@ -20,7 +20,6 @@ from src.taipy.core.submission._submission_manager_factory import _SubmissionMan
 from src.taipy.core.submission.submission import Submission
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task
-from taipy.config.config import Config
 from tests.core.conftest import init_sql_repo
 
 

--- a/tests/core/task/test_task.py
+++ b/tests/core/task/test_task.py
@@ -13,6 +13,9 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import InvalidConfigurationId
 from src.taipy.core.config.data_node_config import DataNodeConfig
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.csv import CSVDataNode
@@ -20,9 +23,6 @@ from src.taipy.core.data.data_node import DataNode
 from src.taipy.core.data.in_memory import InMemoryDataNode
 from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task.task import Task
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import InvalidConfigurationId
 
 
 @pytest.fixture

--- a/tests/core/task/test_task_manager.py
+++ b/tests/core/task/test_task_manager.py
@@ -13,7 +13,8 @@ import uuid
 from unittest import mock
 
 import pytest
-
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import taipy
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._version._version_manager import _VersionManager
@@ -24,8 +25,6 @@ from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task
 from src.taipy.core.task.task_id import TaskId
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 def test_create_and_save():

--- a/tests/core/task/test_task_manager_with_sql_repo.py
+++ b/tests/core/task/test_task_manager_with_sql_repo.py
@@ -14,6 +14,8 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core.data._data_manager import _DataManager
@@ -25,8 +27,6 @@ from src.taipy.core.task._task_manager import _TaskManager
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task
 from src.taipy.core.task.task_id import TaskId
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 
 
 def init_managers():

--- a/tests/core/task/test_task_model.py
+++ b/tests/core/task/test_task_model.py
@@ -9,10 +9,10 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from src.taipy.config.common.scope import Scope
 from src.taipy.core.data import InMemoryDataNode
 from src.taipy.core.data._data_manager_factory import _DataManagerFactory
 from src.taipy.core.task._task_model import _TaskModel
-from taipy.config.common.scope import Scope
 
 
 def test_none_properties_attribute_compatible():

--- a/tests/core/test_complex_application.py
+++ b/tests/core/test_complex_application.py
@@ -17,10 +17,10 @@ from unittest.mock import patch
 import pandas as pd
 
 import src.taipy.core.taipy as tp
+from src.taipy.config import Config
 from src.taipy.core import Core, Status
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
-from taipy.config import Config
 
 # ################################  USER FUNCTIONS  ##################################
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -13,14 +13,14 @@ from unittest.mock import patch
 
 import pytest
 
+from src.taipy.config import Config
+from src.taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from src.taipy.core import Core
 from src.taipy.core._orchestrator._dispatcher import _DevelopmentJobDispatcher, _StandaloneJobDispatcher
 from src.taipy.core._orchestrator._orchestrator import _Orchestrator
 from src.taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.exceptions.exceptions import CoreServiceIsAlreadyRunning
-from taipy.config import Config
-from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 
 
 class TestCore:

--- a/tests/core/test_core_cli.py
+++ b/tests/core/test_core_cli.py
@@ -13,6 +13,9 @@ from unittest.mock import patch
 
 import pytest
 
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import Core
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core._version._version_manager_factory import _VersionManagerFactory
@@ -24,9 +27,6 @@ from src.taipy.core.job._job_manager import _JobManager
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.conftest import init_config
 from tests.core.utils import assert_true_after_time
 

--- a/tests/core/test_core_cli_with_sql_repo.py
+++ b/tests/core/test_core_cli_with_sql_repo.py
@@ -12,7 +12,9 @@
 from unittest.mock import patch
 
 import pytest
-
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import Core
 from src.taipy.core._version._version_manager import _VersionManager
 from src.taipy.core._version._version_manager_factory import _VersionManagerFactory
@@ -24,9 +26,6 @@ from src.taipy.core.job._job_manager import _JobManager
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.conftest import init_config, init_managers
 from tests.core.utils import assert_true_after_time
 

--- a/tests/core/test_taipy.py
+++ b/tests/core/test_taipy.py
@@ -18,6 +18,10 @@ from unittest import mock
 import pytest
 
 import src.taipy.core.taipy as tp
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
+from src.taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from src.taipy.core import (
     Core,
     Cycle,
@@ -45,10 +49,6 @@ from src.taipy.core.job.job import Job
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 
 
 class TestTaipy:

--- a/tests/core/version/test_production_version_migration.py
+++ b/tests/core/version/test_production_version_migration.py
@@ -12,10 +12,10 @@
 import multiprocessing
 from unittest.mock import patch
 
+from src.taipy.config.config import Config
 from src.taipy.core import Core, taipy
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
-from taipy.config.config import Config
 from tests.core.conftest import init_config
 from tests.core.utils import assert_true_after_time
 

--- a/tests/core/version/test_version.py
+++ b/tests/core/version/test_version.py
@@ -9,8 +9,8 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from src.taipy.config.config import Config
 from src.taipy.core._version._version import _Version
-from taipy.config.config import Config
 
 
 def test_create_version():

--- a/tests/core/version/test_version_cli.py
+++ b/tests/core/version/test_version_cli.py
@@ -14,6 +14,9 @@ from unittest.mock import patch
 
 import pytest
 
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import Core
 from src.taipy.core._version._cli._version_cli import _VersionCLI
 from src.taipy.core._version._version_manager import _VersionManager
@@ -22,9 +25,6 @@ from src.taipy.core.job._job_manager import _JobManager
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.conftest import init_config
 
 

--- a/tests/core/version/test_version_cli_with_sql_repo.py
+++ b/tests/core/version/test_version_cli_with_sql_repo.py
@@ -13,7 +13,9 @@ from time import sleep
 from unittest.mock import patch
 
 import pytest
-
+from src.taipy.config.common.frequency import Frequency
+from src.taipy.config.common.scope import Scope
+from src.taipy.config.config import Config
 from src.taipy.core import Core
 from src.taipy.core._version._cli._version_cli import _VersionCLI
 from src.taipy.core._version._version_manager import _VersionManager
@@ -23,9 +25,6 @@ from src.taipy.core.scenario._scenario_manager import _ScenarioManager
 from src.taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
 from src.taipy.core.sequence._sequence_manager import _SequenceManager
 from src.taipy.core.task._task_manager import _TaskManager
-from taipy.config.common.frequency import Frequency
-from taipy.config.common.scope import Scope
-from taipy.config.config import Config
 from tests.core.conftest import init_config
 
 

--- a/tests/core/version/test_version_manager.py
+++ b/tests/core/version/test_version_manager.py
@@ -10,10 +10,9 @@
 # specific language governing permissions and limitations under the License.
 
 import pytest
-
+from src.taipy.config.config import Config
 from src.taipy.core._version._version import _Version
 from src.taipy.core._version._version_manager import _VersionManager
-from taipy.config.config import Config
 
 
 def test_save_and_get_version_entity(tmpdir):


### PR DESCRIPTION
## Purpose:

This PR is an attempt to improve the submission status change algorithm performance.

## Changes:

Instead of looping over all jobs of a submission entity when 1 job status is updated, we will update the submission status based only on the recently updated job status.

## Remaing tasks:

- Looking into adding check for submission status in `test_orchestrator.py`

## Result

Previously, when running `pytest tests/enterprise/core/test_end_to_end.py::test_without_authorization_standalone` on my local (the previous test used during our discussion), it took 22.55s to run, after applying this changes, it now takes only 5.39s to run!

**Results from running profiling:**

### ------------ Old version ------------
![Web capture_27-11-2023_202952_127 0 0 1](https://github.com/Avaiga/taipy-core/assets/93168955/5f53ad03-4b9f-4796-b1b3-b60202633298)

### ------------ New version ------------
![Web capture_27-11-2023_202959_127 0 0 1](https://github.com/Avaiga/taipy-core/assets/93168955/ed98dc1e-f3f2-4fb6-a39a-6309766e193d)

