### PR TITLE
Event Creation: Add version and make sure we don't call autoreload attributes

### DIFF
--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -567,7 +567,7 @@ def make_event_for_datanode(
     attribute_value: Optional[Any] = None,
     **kwargs,
 ) -> Event:
-    metadata = {"config_id": data_node.config_id, **kwargs}
+    metadata = {"config_id": data_node.config_id, "version": data_node._version, **kwargs}
     return Event(
         entity_type=EventEntityType.DATA_NODE,
         entity_id=data_node.id,

--- a/src/taipy/core/job/job.py
+++ b/src/taipy/core/job/job.py
@@ -366,12 +366,17 @@ def _make_event_for_job(
     attribute_value: Optional[Any] = None,
     **kwargs,
 ) -> Event:
-    metadata = {"creation_date": job.creation_date, "task_config_id": job._task.config_id}
+    metadata = {
+        "creation_date": job._creation_date,
+        "task_config_id": job._task.config_id,
+        "version": job._version,
+        **kwargs,
+    }
     return Event(
         entity_type=EventEntityType.JOB,
         entity_id=job.id,
         operation=operation,
         attribute_name=attribute_name,
         attribute_value=attribute_value,
-        metadata={**metadata, **kwargs},
+        metadata=metadata,
     )

--- a/src/taipy/core/scenario/scenario.py
+++ b/src/taipy/core/scenario/scenario.py
@@ -603,7 +603,7 @@ def _make_event_for_scenario(
     attribute_value: Optional[Any] = None,
     **kwargs,
 ) -> Event:
-    metadata = {"config_id": scenario.config_id, "version": scenario.version, **kwargs}
+    metadata = {"config_id": scenario.config_id, "version": scenario._version, **kwargs}
     return Event(
         entity_type=EventEntityType.SCENARIO,
         entity_id=scenario.id,

--- a/src/taipy/core/submission/submission.py
+++ b/src/taipy/core/submission/submission.py
@@ -191,12 +191,12 @@ def _make_event_for_submission(
     attribute_value: Optional[Any] = None,
     **kwargs,
 ) -> Event:
-    metadata = {"creation_date": submission.creation_date, "version": submission._version}
+    metadata = {"creation_date": submission.creation_date, "version": submission._version, **kwargs}
     return Event(
         entity_type=EventEntityType.SUBMISSION,
         entity_id=submission.id,
         operation=operation,
         attribute_name=attribute_name,
         attribute_value=attribute_value,
-        metadata={**metadata, **kwargs},
+        metadata=metadata,
     )


### PR DESCRIPTION
# Goal
* Make sure all events are created without accessing fields that would "auto reload" the entity (and thus could create performance issues)
* Add `version` in metadata of entities 

# Changed
* Data_node: add `_version`
* Job: Use internal fields to by-pass autoreload
* Scenario: Use internal fields to by-pass autoreload
* Submission: small refactoring
* Cycle: no change, there is no version for it?