### PR TITLE
Make _TaskFunctionWrapper an object class

### DIFF
--- a/src/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
@@ -13,6 +13,7 @@ from typing import Optional
 from ...job.job import Job
 from .._abstract_orchestrator import _AbstractOrchestrator
 from ._job_dispatcher import _JobDispatcher
+from ._task_function_wrapper import _TaskFunctionWrapper
 
 
 class _DevelopmentJobDispatcher(_JobDispatcher):
@@ -39,5 +40,5 @@ class _DevelopmentJobDispatcher(_JobDispatcher):
         Parameters:
             job (Job^): The job to submit on an executor with an available worker.
         """
-        rs = self._wrapped_function(job.id, job.task)
+        rs = _TaskFunctionWrapper(job.id, job.task).execute()
         self._update_job_status(job, rs)

--- a/src/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -21,10 +21,9 @@ from ...job._job_manager_factory import _JobManagerFactory
 from ...job.job import Job
 from ...task.task import Task
 from .._abstract_orchestrator import _AbstractOrchestrator
-from ._task_function_wrapper import _TaskFunctionWrapper
 
 
-class _JobDispatcher(threading.Thread, _TaskFunctionWrapper):
+class _JobDispatcher(threading.Thread):
     """Manages job dispatching (instances of `Job^` class) on executors."""
 
     _STOP_FLAG = False

--- a/src/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -19,6 +19,7 @@ from taipy.config.config import Config
 from ...job.job import Job
 from .._abstract_orchestrator import _AbstractOrchestrator
 from ._job_dispatcher import _JobDispatcher
+from ._task_function_wrapper import _TaskFunctionWrapper
 
 
 class _StandaloneJobDispatcher(_JobDispatcher):
@@ -38,7 +39,7 @@ class _StandaloneJobDispatcher(_JobDispatcher):
         self._nb_available_workers -= 1
 
         config_as_string = _TomlSerializer()._serialize(Config._applied_config)
-        future = self._executor.submit(self._wrapped_function_with_config_load, config_as_string, job.id, job.task)
+        future = self._executor.submit(_TaskFunctionWrapper(job.id, job.task), config_as_string=config_as_string)
 
         self._set_dispatched_processes(job.id, future)  # type: ignore
         future.add_done_callback(self._release_worker)

--- a/src/taipy/core/_orchestrator/_dispatcher/_task_function_wrapper.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_task_function_wrapper.py
@@ -47,22 +47,22 @@ class _TaskFunctionWrapper:
             inputs = list(self.task.input.values())
             outputs = list(self.task.output.values())
 
-            arguments = self.__read_inputs(inputs)
-            results = self.__execute_fct(arguments)
-            return self.__write_data(outputs, results, self.job_id)
+            arguments = self._read_inputs(inputs)
+            results = self._execute_fct(arguments)
+            return self._write_data(outputs, results, self.job_id)
         except Exception as e:
             logger.error("Error during task function execution!", exc_info=1)
             return [e]
 
-    def __read_inputs(self, inputs: List[DataNode]) -> List[Any]:
+    def _read_inputs(self, inputs: List[DataNode]) -> List[Any]:
         data_manager = _DataManagerFactory._build_manager()
         return [data_manager._get(dn.id).read_or_raise() for dn in inputs]
 
-    def __write_data(self, outputs: List[DataNode], results, job_id: JobId):
+    def _write_data(self, outputs: List[DataNode], results, job_id: JobId):
         data_manager = _DataManagerFactory._build_manager()
         try:
             if outputs:
-                _results = self.__extract_results(outputs, results)
+                _results = self._extract_results(outputs, results)
                 exceptions = []
                 for res, dn in zip(_results, outputs):
                     try:
@@ -76,10 +76,10 @@ class _TaskFunctionWrapper:
         except Exception as e:
             return [e]
 
-    def __execute_fct(self, arguments: List[Any]) -> Any:
+    def _execute_fct(self, arguments: List[Any]) -> Any:
         return self.task.function(*arguments)
 
-    def __extract_results(self, outputs: List[DataNode], results: Any) -> List[Any]:
+    def _extract_results(self, outputs: List[DataNode], results: Any) -> List[Any]:
         _results: List[Any] = [results] if len(outputs) == 1 else results
         if len(_results) != len(outputs):
             raise DataNodeWritingError("Error: wrong number of result or task output")


### PR DESCRIPTION
# Goals
We need to add authorisation and telemetry at certain specific spot of the code when a task function is executed.
The current implementation of `_TaskFunctionWrapper` is based on class methods and is not overridable.

# Changes
* We make `_TaskFunctionWrapper` a real class. All methods are now instance methods, no more "classmethods".
* The execution of the function is encapsulated into a `__execute_fct` method which can be overridden in Taipy-enterprise.
* We basically replaced inheritance by composition in `JobDispatcher` and subclasses.