### PR TITLE
✅ Adding submission event data and unit tests

### DIFF
--- a/taipy/core/notification/event.py
+++ b/taipy/core/notification/event.py
@@ -50,7 +50,12 @@ class EventEntityType(_ReprEnum):
 
 
 _NO_ATTRIBUTE_NAME_OPERATIONS = set([EventOperation.CREATION, EventOperation.DELETION, EventOperation.SUBMISSION])
-_UNSUBMITTABLE_ENTITY_TYPES = (EventEntityType.CYCLE, EventEntityType.DATA_NODE, EventEntityType.JOB)
+_UNSUBMITTABLE_ENTITY_TYPES = (
+    EventEntityType.CYCLE,
+    EventEntityType.DATA_NODE,
+    EventEntityType.JOB,
+    EventEntityType.SUBMISSION,
+)
 _ENTITY_TO_EVENT_ENTITY_TYPE = {
     "scenario": EventEntityType.SCENARIO,
     "sequence": EventEntityType.SEQUENCE,

--- a/taipy/core/submission/submission.py
+++ b/taipy/core/submission/submission.py
@@ -211,7 +211,14 @@ def _make_event_for_submission(
     attribute_value: Optional[Any] = None,
     **kwargs,
 ) -> Event:
-    metadata = {"creation_date": submission.creation_date, "version": submission._version, **kwargs}
+    metadata = {
+        "origin_entity_id": submission.entity_id,
+        "origin_entity_type": submission.entity_type,
+        "origin_entity_config_id": submission.entity_config_id,
+        "creation_date": submission.creation_date,
+        "version": submission._version,
+        **kwargs,
+    }
     return Event(
         entity_type=EventEntityType.SUBMISSION,
         entity_id=submission.id,

--- a/tests/core/notification/test_event.py
+++ b/tests/core/notification/test_event.py
@@ -13,7 +13,8 @@ import pytest
 
 from taipy.config.common.frequency import Frequency
 from taipy.core.exceptions.exceptions import InvalidEventAttributeName, InvalidEventOperation
-from taipy.core.notification.event import Event, EventEntityType, EventOperation
+from taipy.core.notification.event import Event, EventEntityType, EventOperation, _make_event
+from taipy.core.submission.submission import Submission
 
 
 def test_event_creation_cycle():
@@ -360,3 +361,39 @@ def test_event_creation_job():
             operation=EventOperation.SUBMISSION,
             attribute_name="force",
         )
+
+
+def test_event_creation_submission():
+    event_1 = Event(
+        entity_type=EventEntityType.SUBMISSION, entity_id="submission_id", operation=EventOperation.CREATION
+    )
+    assert event_1.creation_date is not None
+    assert event_1.entity_type == EventEntityType.SUBMISSION
+    assert event_1.entity_id == "submission_id"
+    assert event_1.operation == EventOperation.CREATION
+    assert event_1.attribute_name is None
+
+    with pytest.raises(InvalidEventAttributeName):
+        _ = Event(
+            entity_type=EventEntityType.SUBMISSION,
+            entity_id="submission_id",
+            operation=EventOperation.DELETION,
+            attribute_name="force",
+        )
+
+    with pytest.raises(InvalidEventOperation):
+        _ = Event(
+            entity_type=EventEntityType.SUBMISSION, entity_id="submission_id", operation=EventOperation.SUBMISSION
+        )
+
+
+def test_make_event_from_submission():
+    submission = Submission("submission_id", entity_type="task", entity_config_id="task_config_id_1")
+    event = _make_event(submission, EventOperation.CREATION)
+
+    assert event.operation == EventOperation.CREATION
+    assert event.entity_id
+    assert event.entity_type == EventEntityType.SUBMISSION
+    assert event.metadata["origin_entity_id"] == "submission_id"
+    assert event.metadata["origin_entity_type"] == "task"
+    assert event.metadata["origin_entity_config_id"] == "task_config_id_1"


### PR DESCRIPTION
# Goal
* Add submission data to event metada: the original entity ID, type and config_id.

# Changes
* Improve the function `_make_event_for_submission`
* Make the `Submission` type... unsubmittable (sic!)
* Add some unit tests for it