### PR TITLE
evaluate datatype without pandas for strings (#601)

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Field.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Field.tsx
@@ -53,9 +53,7 @@ const Field = (props: TaipyFieldProps) => {
     return (
         <Tooltip title={hover || ""}>
             {mode == "pre" ? (
-                <pre className={className} id={id}>
-                    {value}
-                </pre>
+                <pre className={className} id={id}>{value}</pre>
             ) : mode == "markdown" || mode == "md" ? (
                 <Markdown className={className}>{value}</Markdown>
             ) : raw || mode == "raw" ? (

--- a/taipy/gui/utils/datatype.py
+++ b/taipy/gui/utils/datatype.py
@@ -15,10 +15,11 @@ import pandas as pd
 
 
 def _get_data_type(value):
-    if pd.api.types.is_bool_dtype(value):
-        return "bool"
-    elif pd.api.types.is_integer_dtype(value):
-        return "int"
-    elif pd.api.types.is_float_dtype(value):
-        return "float"
+    if not isinstance(value, str):
+        if pd.api.types.is_bool_dtype(value):
+            return "bool"
+        elif pd.api.types.is_integer_dtype(value):
+            return "int"
+        elif pd.api.types.is_float_dtype(value):
+            return "float"
     return re.match(r"^<class '(.*\.)?(.*?)(\d\d)?'>", str(type(value))).group(2)


### PR DESCRIPTION
```
from taipy.gui import Gui

some_text = "b"

Gui("<|{some_text}|>").run()

```