### PR TITLE
✨ Add API to manually set job's stacktrace

### DIFF
--- a/taipy/core/job/job.py
+++ b/taipy/core/job/job.py
@@ -132,7 +132,7 @@ class Job(_Entity, _Labeled):
     def creation_date(self, val):
         self._creation_date = val
 
-    @property
+    @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
     def stacktrace(self) -> List[str]:
         return self._stacktrace

--- a/taipy/core/job/job.py
+++ b/taipy/core/job/job.py
@@ -136,6 +136,11 @@ class Job(_Entity, _Labeled):
     def stacktrace(self) -> List[str]:
         return self._stacktrace
 
+    @stacktrace.setter  # type: ignore
+    @_self_setter(_MANAGER_NAME)
+    def stacktrace(self, val):
+        self._stacktrace = val
+
     @property
     def version(self):
         return self._version

--- a/taipy/core/job/job.py
+++ b/taipy/core/job/job.py
@@ -133,6 +133,7 @@ class Job(_Entity, _Labeled):
         self._creation_date = val
 
     @property
+    @_self_reload(_MANAGER_NAME)
     def stacktrace(self) -> List[str]:
         return self._stacktrace
 

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -147,6 +147,19 @@ def test_status_job(task):
     assert job.is_skipped()
 
 
+def test_stacktrace_job(task):
+    submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX, task.config_id)
+    job = Job("job_id", task, submission.id, "SCENARIO_scenario_config")
+
+    fake_stacktrace = """Traceback (most recent call last):
+File "<stdin>", line 1, in <module>
+ZeroDivisionError: division by zero""".splitlines()
+
+    job.stacktrace = fake_stacktrace
+    assert len(job.stacktrace) == 3
+    assert all(st == fake_stacktrace[idx] for idx, st in enumerate(job.stacktrace))
+
+
 def test_notification_job(task):
     subscribe = MagicMock()
     submission = _SubmissionManagerFactory._build_manager()._create(task.id, task._ID_PREFIX, task.config_id)

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -156,8 +156,7 @@ File "<stdin>", line 1, in <module>
 ZeroDivisionError: division by zero""".splitlines()
 
     job.stacktrace = fake_stacktrace
-    assert len(job.stacktrace) == 3
-    assert all(st == fake_stacktrace[idx] for idx, st in enumerate(job.stacktrace))
+    assert job.stacktrace == fake_stacktrace
 
 
 def test_notification_job(task):


### PR DESCRIPTION
# Goals

The development of a "Taipy enterprise" specific feature requires to be able to manually set a job's stack trace.

# Changes
* Add a `stacktrace` setter on `Job` class
* Add unit test 