### PR TITLE
chore: update pyarrow to latest version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ marshmallow = "==3.20.1"
 networkx = "==2.6"
 openpyxl = "==3.1.2"
 pandas = "==2.0.0"
-pyarrow = "==10.0.1"
+pyarrow = "==14.0.2"
 pymongo = {extras = ["srv"], version = "==4.2.0"}
 python-dotenv = "==1.0.0"
 python-magic = {version = "==0.4.24", markers="sys_platform != 'win32'"}

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ extras_require = {
         "python-magic-bin>=0.4.14,<0.5;platform_system=='Windows'",
     ],
     "rdp": ["rdp>=0.8"],
-    "arrow": ["pyarrow>=10.0.1,<11.0"],
+    "arrow": ["pyarrow>=14.0.2,<15.0"],
     "mssql": ["pyodbc>=4"],
 }
 

--- a/taipy/core/Pipfile
+++ b/taipy/core/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 pandas = "==2.0.0"
 networkx = "==2.6"
 openpyxl = "==3.1.2"
-pyarrow = "==10.0.1"
+pyarrow = "==14.0.2"
 pymongo = {extras = ["srv"], version = "==4.2.0"}
 sqlalchemy = "==2.0.16"
 toml = "==0.10"

--- a/taipy/core/setup.py
+++ b/taipy/core/setup.py
@@ -28,7 +28,7 @@ with open(version_path) as version_file:
         version_string = f"{version_string}.{vext}"
 
 requirements = [
-    "pyarrow>=10.0.1,<11.0",
+    "pyarrow>=14.0.2,<15.0",
     "networkx>=2.6,<3.0",
     "openpyxl>=3.1.2,<3.2",
     "pandas>=2.0.0,<3.0",

--- a/taipy/gui/Pipfile
+++ b/taipy/gui/Pipfile
@@ -13,7 +13,7 @@ gevent-websocket = "==0.10.1"
 kthread = "==0.2.3"
 markdown = "==3.4.4"
 pandas = "==2.0.0"
-pyarrow = "==10.0.1"
+pyarrow = "==14.0.2"
 pyngrok = "==5.1"
 python-dotenv = "==1.0.0"
 python-magic = {version = "==0.4.24", markers="sys_platform != 'win32'"}

--- a/taipy/gui/setup.py
+++ b/taipy/gui/setup.py
@@ -56,7 +56,7 @@ extras_require = {
         "python-magic>=0.4.24,<0.5;platform_system!='Windows'",
         "python-magic-bin>=0.4.14,<0.5;platform_system=='Windows'",
     ],
-    "arrow": ["pyarrow>=10.0.1,<11.0"],
+    "arrow": ["pyarrow>=14.0.2,<15.0"],
 }
 
 

--- a/tools/packages/taipy-core/setup.requirements.txt
+++ b/tools/packages/taipy-core/setup.requirements.txt
@@ -1,4 +1,4 @@
-pyarrow>=10.0.1,<11.0
+pyarrow>=14.0.2,<15.0
 networkx>=2.6,<3.0
 openpyxl>=3.1.2,<3.2
 pandas>=2.0.0,<3.0

--- a/tools/packages/taipy-gui/setup.py
+++ b/tools/packages/taipy-gui/setup.py
@@ -41,7 +41,7 @@ extras_require = {
         "python-magic>=0.4.24,<0.5;platform_system!='Windows'",
         "python-magic-bin>=0.4.14,<0.5;platform_system=='Windows'",
     ],
-    "arrow": ["pyarrow>=10.0.1,<11.0"],
+    "arrow": ["pyarrow>=14.0.2,<15.0"],
 }
 
 

--- a/tools/packages/taipy/setup.py
+++ b/tools/packages/taipy/setup.py
@@ -41,7 +41,7 @@ extras_require = {
         "python-magic-bin>=0.4.14,<0.5;platform_system=='Windows'",
     ],
     "rdp": ["rdp>=0.8"],
-    "arrow": ["pyarrow>=10.0.1,<11.0"],
+    "arrow": ["pyarrow>=14.0.2,<15.0"],
     "mssql": ["pyodbc>=4"],
 }
 


### PR DESCRIPTION
resolves #627 

This PR updates pyarrow to version 14.0.2 (latest) to resolve a vulnerability of the previous version that we were using on taipy, and also the update is a requirement to be able to install taipy on python 3.12