### PR TITLE
Make job and submission editable

### DIFF
--- a/taipy/core/_manager/_manager.py
+++ b/taipy/core/_manager/_manager.py
@@ -167,3 +167,7 @@ class _Manager(Generic[EntityType]):
     @classmethod
     def _is_readable(cls, entity: Union[EntityType, str]) -> bool:
         return True
+
+    @classmethod
+    def _is_deletable(cls, entity: Union[EntityType, str]) -> bool:
+        return True

--- a/taipy/core/_manager/_manager.py
+++ b/taipy/core/_manager/_manager.py
@@ -167,7 +167,3 @@ class _Manager(Generic[EntityType]):
     @classmethod
     def _is_readable(cls, entity: Union[EntityType, str]) -> bool:
         return True
-
-    @classmethod
-    def _is_deletable(cls, entity: Union[EntityType, str]) -> bool:
-        return True

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -89,10 +89,6 @@ class _JobManager(_Manager[Job], _VersionMixin):
     def _is_deletable(cls, job: Union[Job, JobId]) -> bool:
         if isinstance(job, str):
             job = cls._get(job)
-        if job.is_finished():
-            return True
-        return False
-
-    @classmethod
-    def _is_editable(cls, entity: Union[Job, str]) -> bool:
-        return False
+        if not job.is_finished():
+            return False
+        return True

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -86,7 +86,7 @@ class _JobManager(_Manager[Job], _VersionMixin):
             return max(jobs_of_task)
 
     @classmethod
-    def _is_deletable(cls, job: Union[Job, JobId]) -> bool:
+    def _is_deletable(cls, job: Union[Job, JobId]) -> bool:  # type: ignore
         if isinstance(job, str):
             job = cls._get(job)
         if not job.is_finished():

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -86,7 +86,7 @@ class _JobManager(_Manager[Job], _VersionMixin):
             return max(jobs_of_task)
 
     @classmethod
-    def _is_deletable(cls, job: Union[Job, JobId]) -> bool:  # type: ignore
+    def _is_deletable(cls, job: Union[Job, JobId]) -> bool:
         if isinstance(job, str):
             job = cls._get(job)
         if not job.is_finished():

--- a/taipy/core/submission/_submission_manager.py
+++ b/taipy/core/submission/_submission_manager.py
@@ -86,7 +86,7 @@ class _SubmissionManager(_Manager[Submission], _VersionMixin):
         return entity_ids
 
     @classmethod
-    def _is_deletable(cls, submission: Union[Submission, SubmissionId]) -> bool:
+    def _is_deletable(cls, submission: Union[Submission, SubmissionId]) -> bool:  # type: ignore
         if isinstance(submission, str):
             submission = cls._get(submission)
         return submission.is_finished() or submission.submission_status == SubmissionStatus.UNDEFINED

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -479,55 +479,6 @@ def test_is_deletable():
     assert not _JobManager._is_deletable(job)
     assert not _JobManager._is_deletable(job.id)
 
-def test_is_deletable():
-    assert len(_JobManager._get_all()) == 0
-    task = _create_task(print, 0, "task")
-    job = _OrchestratorFactory._orchestrator.submit_task(task).jobs[0]
-
-    assert job.is_completed()
-    assert _JobManager._is_deletable(job)
-    assert _JobManager._is_deletable(job.id)
-
-    job.abandoned()
-    assert job.is_abandoned()
-    assert _JobManager._is_deletable(job)
-    assert _JobManager._is_deletable(job.id)
-
-    job.canceled()
-    assert job.is_canceled()
-    assert _JobManager._is_deletable(job)
-    assert _JobManager._is_deletable(job.id)
-
-    job.failed()
-    assert job.is_failed()
-    assert _JobManager._is_deletable(job)
-    assert _JobManager._is_deletable(job.id)
-
-    job.skipped()
-    assert job.is_skipped()
-    assert _JobManager._is_deletable(job)
-    assert _JobManager._is_deletable(job.id)
-
-    job.blocked()
-    assert job.is_blocked()
-    assert not _JobManager._is_deletable(job)
-    assert not _JobManager._is_deletable(job.id)
-
-    job.running()
-    assert job.is_running()
-    assert not _JobManager._is_deletable(job)
-    assert not _JobManager._is_deletable(job.id)
-
-    job.pending()
-    assert job.is_pending()
-    assert not _JobManager._is_deletable(job)
-    assert not _JobManager._is_deletable(job.id)
-
-    job.status = Status.SUBMITTED
-    assert job.is_submitted()
-    assert not _JobManager._is_deletable(job)
-    assert not _JobManager._is_deletable(job.id)
-
 def _create_task(function, nb_outputs=1, name=None):
     input1_dn_config = Config.configure_data_node("input1", "pickle", Scope.SCENARIO, default_data=21)
     input2_dn_config = Config.configure_data_node("input2", "pickle", Scope.SCENARIO, default_data=2)

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -60,7 +60,7 @@ def test_create_jobs():
     assert job_1.submit_id == "submit_id"
     assert job_1.submit_entity_id == "secnario_id"
     assert job_1.force
-    assert not _JobManager._is_editable(job_1)
+    assert _JobManager._is_editable(job_1)
 
     job_2 = _JobManager._create(task, [print], "submit_id_1", "secnario_id", False)
     assert _JobManager._get(job_2.id) == job_2
@@ -70,7 +70,7 @@ def test_create_jobs():
     assert job_2.submit_id == "submit_id_1"
     assert job_2.submit_entity_id == "secnario_id"
     assert not job_2.force
-    assert not _JobManager._is_editable(job_2)
+    assert _JobManager._is_editable(job_2)
 
 
 def test_get_job():
@@ -479,6 +479,54 @@ def test_is_deletable():
     assert not _JobManager._is_deletable(job)
     assert not _JobManager._is_deletable(job.id)
 
+def test_is_deletable():
+    assert len(_JobManager._get_all()) == 0
+    task = _create_task(print, 0, "task")
+    job = _OrchestratorFactory._orchestrator.submit_task(task).jobs[0]
+
+    assert job.is_completed()
+    assert _JobManager._is_deletable(job)
+    assert _JobManager._is_deletable(job.id)
+
+    job.abandoned()
+    assert job.is_abandoned()
+    assert _JobManager._is_deletable(job)
+    assert _JobManager._is_deletable(job.id)
+
+    job.canceled()
+    assert job.is_canceled()
+    assert _JobManager._is_deletable(job)
+    assert _JobManager._is_deletable(job.id)
+
+    job.failed()
+    assert job.is_failed()
+    assert _JobManager._is_deletable(job)
+    assert _JobManager._is_deletable(job.id)
+
+    job.skipped()
+    assert job.is_skipped()
+    assert _JobManager._is_deletable(job)
+    assert _JobManager._is_deletable(job.id)
+
+    job.blocked()
+    assert job.is_blocked()
+    assert not _JobManager._is_deletable(job)
+    assert not _JobManager._is_deletable(job.id)
+
+    job.running()
+    assert job.is_running()
+    assert not _JobManager._is_deletable(job)
+    assert not _JobManager._is_deletable(job.id)
+
+    job.pending()
+    assert job.is_pending()
+    assert not _JobManager._is_deletable(job)
+    assert not _JobManager._is_deletable(job.id)
+
+    job.status = Status.SUBMITTED
+    assert job.is_submitted()
+    assert not _JobManager._is_deletable(job)
+    assert not _JobManager._is_deletable(job.id)
 
 def _create_task(function, nb_outputs=1, name=None):
     input1_dn_config = Config.configure_data_node("input1", "pickle", Scope.SCENARIO, default_data=21)

--- a/tests/core/test_taipy.py
+++ b/tests/core/test_taipy.py
@@ -163,7 +163,7 @@ class TestTaipy:
         assert tp.is_editable(sequence)
         assert tp.is_editable(task)
         assert tp.is_editable(cycle)
-        assert not tp.is_editable(job)
+        assert tp.is_editable(job)
         assert tp.is_editable(submission)
         assert tp.is_editable(dn)
 


### PR DESCRIPTION
A behavior change was introduced previously to make jobs and submissions not editable.
We want to keep these entities editable.

related #696 
The PR 696 should be merged first to fix some linter issues.
