### PR TITLE
🐛 Fix orchestrator being initialised at each call

### DIFF
--- a/taipy/core/_orchestrator/_orchestrator_factory.py
+++ b/taipy/core/_orchestrator/_orchestrator_factory.py
@@ -32,6 +32,8 @@ class _OrchestratorFactory:
 
     @classmethod
     def _build_orchestrator(cls) -> Type[_AbstractOrchestrator]:
+        if cls._orchestrator:
+            return cls._orchestrator
         if util.find_spec(cls._TAIPY_ENTERPRISE_MODULE) is not None:
             cls._orchestrator = _load_fct(
                 cls._TAIPY_ENTERPRISE_CORE_ORCHESTRATOR_MODULE,

--- a/taipy/core/_orchestrator/_orchestrator_factory.py
+++ b/taipy/core/_orchestrator/_orchestrator_factory.py
@@ -33,7 +33,7 @@ class _OrchestratorFactory:
     @classmethod
     def _build_orchestrator(cls) -> Type[_AbstractOrchestrator]:
         if cls._orchestrator:
-            return cls._orchestrator
+            return cls._orchestrator  # type: ignore
         if util.find_spec(cls._TAIPY_ENTERPRISE_MODULE) is not None:
             cls._orchestrator = _load_fct(
                 cls._TAIPY_ENTERPRISE_CORE_ORCHESTRATOR_MODULE,

--- a/tests/core/_orchestrator/test_orchestrator_factory.py
+++ b/tests/core/_orchestrator/test_orchestrator_factory.py
@@ -29,6 +29,7 @@ def test_build_orchestrator():
     with mock.patch("taipy.core._orchestrator._orchestrator_factory._OrchestratorFactory._build_dispatcher") as bd:
         with mock.patch("taipy.core._orchestrator._orchestrator._Orchestrator.initialize") as initialize:
             orchestrator = _OrchestratorFactory._build_orchestrator()
+            _OrchestratorFactory._build_orchestrator()  # Call it one more time!
             assert orchestrator == _Orchestrator
             assert _OrchestratorFactory._orchestrator == _Orchestrator
             initialize.assert_called_once()


### PR DESCRIPTION
# Context

In Taipy Enterprise, the orchestrator implementation is using state to try to recover from a crash.
This works only if the orchestrator is a singleton and is not initialised every time we call `_build_orchestrator()`.

# Changes
* Add a check in the "orchestrator factory" to return a previously built orchestrator

# Important note
The `_OrchestratorFactory._build_orchestrator()` is not thread safe and should be called only from the main thread.