### PR TITLE
🐛 `_on_status_changed` triggers reload of non persisted job

### DIFF
--- a/taipy/core/job/job.py
+++ b/taipy/core/job/job.py
@@ -308,9 +308,6 @@ class Job(_Entity, _Labeled):
         function = functions.pop()
         self._subscribers.append(function)
 
-        if self.status != Status.SUBMITTED:
-            function(self)
-
         if functions:
             self._on_status_change(*functions)
 


### PR DESCRIPTION
# Context

When we create a job, the "job manager" set the callback **before** the job is saved.
See https://github.com/Avaiga/taipy/blob/develop/taipy/core/job/_job_manager.py#L54

When the `_on_status_changed` is called, it currently check if the status is not "SUBMITTED" which, by accessing the `status` property, triggers a reload via the "self reloader". 
See https://github.com/Avaiga/taipy/blob/develop/taipy/core/job/job.py#L311

This eventually causes an error in the log: 

```
[2024-01-22 14:05:22][Taipy][ERROR] Job not found: JOB_score_task_737ac665-5cd2-49ca-b235-d5d1cccb0642
```

The `_on_status_change` callback setter can safely avoid to reload by not checking the status field at all and not calling any callback anyway.

# Changes

* [removed] The status field is not checked anymore and the callbacks are no longer called directly here.