### PR TITLE
Shutdown ProcesspoolExecutor when calling Core().stop()

### DIFF
--- a/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -52,3 +52,7 @@ class _StandaloneJobDispatcher(_JobDispatcher):
     def _update_job_status_from_future(self, job: Job, ft):
         self._pop_dispatched_process(job.id)  # type: ignore
         self._update_job_status(job, ft.result())
+
+    def stop(self):
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        super().stop()

--- a/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-
+import sys
 from concurrent.futures import Executor, ProcessPoolExecutor
 from functools import partial
 from typing import Callable, Optional
@@ -55,4 +55,7 @@ class _StandaloneJobDispatcher(_JobDispatcher):
 
     def stop(self):
         super().stop()
-        self._executor.shutdown(wait=True, cancel_futures=True)
+        if sys.version_info >= (3, 9):
+            self._executor.shutdown(wait=True, cancel_futures=False)
+        else:
+            self._executor.shutdown(wait=True)  # cancel_futures is not available in Python 3.8

--- a/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -54,5 +54,5 @@ class _StandaloneJobDispatcher(_JobDispatcher):
         self._update_job_status(job, ft.result())
 
     def stop(self):
-        self._executor.shutdown(wait=True, cancel_futures=True)
         super().stop()
+        self._executor.shutdown(wait=True, cancel_futures=True)


### PR DESCRIPTION
After stoping the standalone job dispatcher run loop, we now shutdown all the ProcessPoolExecutor. 