### PR TITLE
💚 Fix CI build (python 3.12)

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -27,7 +27,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install pipenv
-      run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      run: pip install pipenv --upgrade
       shell: bash
 
     - name: Install minimum supported dependencies


### PR DESCRIPTION
# Goal of this PR

Installation of Pipenv using the `get-pipenv` script no longer works with Python 3.12.
Let's install it using `pip install pipenv` which will not fail.

# Changes
* Updated the "Install Pipenv" CI step