### PR TITLE
Rename and update sequence

### DIFF
--- a/taipy/config/common/_validate_id.py
+++ b/taipy/config/common/_validate_id.py
@@ -17,9 +17,9 @@ __INVALID_TAIPY_ID_TERMS = ["CYCLE", "SCENARIO", "SEQUENCE", "TASK", "DATANODE"]
 
 
 def _validate_id(name: str):
-    for invalid_taipy_id_term in __INVALID_TAIPY_ID_TERMS:
-        if invalid_taipy_id_term in name:
-            raise InvalidConfigurationId(f"'{name}' is not a valid identifier. '{invalid_taipy_id_term}' is restricted.")
+    for invalid__id_term in __INVALID_TAIPY_ID_TERMS:
+        if invalid__id_term in name:
+            raise InvalidConfigurationId(f"'{name}' is not a valid identifier. '{invalid__id_term}' is restricted.")
 
     if name.isidentifier() and not keyword.iskeyword(name):
         return name

--- a/taipy/config/common/_validate_id.py
+++ b/taipy/config/common/_validate_id.py
@@ -19,9 +19,9 @@ __INVALID_TAIPY_ID_TERMS = ["CYCLE", "SCENARIO", "SEQUENCE", "TASK", "DATANODE"]
 def _validate_id(name: str):
     for invalid_taipy_id_term in __INVALID_TAIPY_ID_TERMS:
         if invalid_taipy_id_term in name:
-            raise InvalidConfigurationId(f"{name} is not a valid identifier. {invalid_taipy_id_term} is restricted.")
+            raise InvalidConfigurationId(f"'{name}' is not a valid identifier. '{invalid_taipy_id_term}' is restricted.")
 
     if name.isidentifier() and not keyword.iskeyword(name):
         return name
 
-    raise InvalidConfigurationId(f"{name} is not a valid identifier.")
+    raise InvalidConfigurationId(f"'{name}' is not a valid identifier.")

--- a/taipy/core/exceptions/exceptions.py
+++ b/taipy/core/exceptions/exceptions.py
@@ -186,8 +186,18 @@ class InvalidSequence(Exception):
 class NonExistingSequence(Exception):
     """Raised if a requested Sequence is not known by the Sequence Manager."""
 
-    def __init__(self, sequence_id: str):
-        self.message = f"Sequence: {sequence_id} does not exist."
+    def __init__(self, sequence_id: str, scenario_id: str=None):
+        if scenario_id:
+            self.message = f"Sequence: {sequence_id} does not exist in scenario {scenario_id}."
+        else:
+            self.message = f"Sequence: {sequence_id} does not exist."
+
+
+class SequenceAlreadyExists(Exception):
+    """Raised if a Sequence already exists."""
+
+    def __init__(self, sequence_name: str, scenario_id: str):
+        self.message = f"Sequence: {sequence_name} already exists in scenario {scenario_id}."
 
 
 class SequenceBelongsToNonExistingScenario(Exception):

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -244,9 +244,9 @@ class Scenario(_Entity, Submittable, _Labeled):
                 }
             }
         )
-        self.sequences = _sequences  # type: ignore
-        if not self.sequences[name]._is_consistent():
+        if not _sequences[name]._is_consistent():
             raise InvalidSequence(name)
+        self.sequences = _sequences  # type: ignore
 
     def add_sequences(self, sequences: Dict[str, Union[List[Task], List[TaskId]]]):
         """Add multiple sequences to the scenario.
@@ -313,6 +313,8 @@ class Scenario(_Entity, Submittable, _Labeled):
         Raises:
             SequenceAlreadyExists^: If a sequence with the same name already exists in the scenario.
         """
+        if old_name == new_name:
+            return
         if new_name in self.sequences:
             raise SequenceAlreadyExists(new_name, self.id)
         self._sequences[new_name] = self._sequences[old_name]

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -236,6 +236,12 @@ class Scenario(_Entity, Submittable, _Labeled):
         _scenario_task_ids = set(task.id if isinstance(task, Task) else task for task in _scenario._tasks)
         _sequence_task_ids: Set[TaskId] = set(task.id if isinstance(task, Task) else task for task in tasks)
         self.__check_sequence_tasks_exist_in_scenario_tasks(name, _sequence_task_ids, self.id, _scenario_task_ids)
+        from taipy.core.sequence._sequence_manager_factory import _SequenceManagerFactory
+        seq_manager = _SequenceManagerFactory._build_manager()
+        seq = seq_manager._create(name, tasks, properties or {}, subscribers or [], self.id, self.version)
+        if not seq._is_consistent():
+            raise InvalidSequence(name)
+
         _sequences = _Reloader()._reload(self._MANAGER_NAME, self)._sequences
         _sequences.update(
             {
@@ -246,8 +252,6 @@ class Scenario(_Entity, Submittable, _Labeled):
                 }
             }
         )
-        if not _sequences[name]._is_consistent():
-            raise InvalidSequence(name)
         self.sequences = _sequences  # type: ignore
 
     def add_sequences(self, sequences: Dict[str, Union[List[Task], List[TaskId]]]):

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -198,8 +198,8 @@ class Scenario(_Entity, Submittable, _Labeled):
         """
         if name in self.sequences:
             raise SequenceAlreadyExists(name, self.id)
-        self._set_sequence(name, tasks, properties, subscribers)
-        Notifier.publish(_make_event(self.sequences[name], EventOperation.CREATION))
+        seq = self._set_sequence(name, tasks, properties, subscribers)
+        Notifier.publish(_make_event(seq, EventOperation.CREATION))
 
     def update_sequence(
         self,
@@ -222,8 +222,8 @@ class Scenario(_Entity, Submittable, _Labeled):
         """
         if name not in self.sequences:
             raise NonExistingSequence(name, self.id)
-        self._set_sequence(name, tasks, properties, subscribers)
-        Notifier.publish(_make_event(self.sequences[name], EventOperation.UPDATE))
+        seq = self._set_sequence(name, tasks, properties, subscribers)
+        Notifier.publish(_make_event(seq, EventOperation.UPDATE))
 
     def _set_sequence(
         self,
@@ -231,7 +231,7 @@ class Scenario(_Entity, Submittable, _Labeled):
         tasks: Union[List[Task], List[TaskId]],
         properties: Optional[Dict] = None,
         subscribers: Optional[List[_Subscriber]] = None,
-    ):
+    ) -> Sequence:
         _scenario = _Reloader()._reload(self._MANAGER_NAME, self)
         _scenario_task_ids = set(task.id if isinstance(task, Task) else task for task in _scenario._tasks)
         _sequence_task_ids: Set[TaskId] = set(task.id if isinstance(task, Task) else task for task in tasks)
@@ -253,6 +253,7 @@ class Scenario(_Entity, Submittable, _Labeled):
             }
         )
         self.sequences = _sequences  # type: ignore
+        return seq
 
     def add_sequences(self, sequences: Dict[str, Union[List[Task], List[TaskId]]]):
         """Add multiple sequences to the scenario.

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -36,7 +36,7 @@ from ..exceptions.exceptions import (
     NonExistingDataNode,
     NonExistingSequence,
     NonExistingTask,
-    SequenceTaskDoesNotExistInScenario, SequenceAlreadyExists,
+    SequenceAlreadyExists, SequenceTaskDoesNotExistInScenario
 )
 from ..job.job import Job
 from ..notification import Event, EventEntityType, EventOperation, Notifier, _make_event

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -238,7 +238,7 @@ class Scenario(_Entity, Submittable, _Labeled):
         self.__check_sequence_tasks_exist_in_scenario_tasks(name, _sequence_task_ids, self.id, _scenario_task_ids)
         from taipy.core.sequence._sequence_manager_factory import _SequenceManagerFactory
         seq_manager = _SequenceManagerFactory._build_manager()
-        seq = seq_manager._create(name, tasks, properties or {}, subscribers or [], self.id, self.version)
+        seq = seq_manager._create(name, tasks, subscribers or [], properties or {}, self.id, self.version)
         if not seq._is_consistent():
             raise InvalidSequence(name)
 

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -10,11 +10,12 @@
 # specific language governing permissions and limitations under the License.
 from __future__ import annotations
 
-import networkx as nx
 import pathlib
 import uuid
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Set, Union
+
+import networkx as nx
 
 from taipy.config.common._template_handler import _TemplateHandler as _tpl
 from taipy.config.common._validate_id import _validate_id
@@ -35,7 +36,8 @@ from ..exceptions.exceptions import (
     NonExistingDataNode,
     NonExistingSequence,
     NonExistingTask,
-    SequenceAlreadyExists, SequenceTaskDoesNotExistInScenario
+    SequenceAlreadyExists,
+    SequenceTaskDoesNotExistInScenario,
 )
 from ..job.job import Job
 from ..notification import Event, EventEntityType, EventOperation, Notifier, _make_event

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -225,12 +225,17 @@ class Scenario(_Entity, Submittable, _Labeled):
         self._set_sequence(name, tasks, properties, subscribers)
         Notifier.publish(_make_event(self.sequences[name], EventOperation.UPDATE))
 
-    def _set_sequence(self, name, tasks, properties, subscribers):
+    def _set_sequence(
+        self,
+        name: str,
+        tasks: Union[List[Task], List[TaskId]],
+        properties: Optional[Dict] = None,
+        subscribers: Optional[List[_Subscriber]] = None,
+    ):
         _scenario = _Reloader()._reload(self._MANAGER_NAME, self)
-        if tasks:
-            _scenario_task_ids = set(task.id if isinstance(task, Task) else task for task in _scenario._tasks)
-            _sequence_task_ids: Set[TaskId] = set(task.id if isinstance(task, Task) else task for task in tasks)
-            self.__check_sequence_tasks_exist_in_scenario_tasks(name, _sequence_task_ids, self.id, _scenario_task_ids)
+        _scenario_task_ids = set(task.id if isinstance(task, Task) else task for task in _scenario._tasks)
+        _sequence_task_ids: Set[TaskId] = set(task.id if isinstance(task, Task) else task for task in tasks)
+        self.__check_sequence_tasks_exist_in_scenario_tasks(name, _sequence_task_ids, self.id, _scenario_task_ids)
         _sequences = _Reloader()._reload(self._MANAGER_NAME, self)._sequences
         _sequences.update(
             {

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -11,12 +11,11 @@
 
 from __future__ import annotations
 
+import networkx as nx
 import pathlib
 import uuid
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Set, Union
-
-import networkx as nx
 
 from taipy.config.common._template_handler import _TemplateHandler as _tpl
 from taipy.config.common._validate_id import _validate_id

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -8,7 +8,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-
 from __future__ import annotations
 
 import networkx as nx

--- a/taipy/core/sequence/sequence.py
+++ b/taipy/core/sequence/sequence.py
@@ -74,7 +74,8 @@ class Sequence(_Entity, Submittable, _Labeled):
 
     @staticmethod
     def _new_id(sequence_name: str, scenario_id) -> SequenceId:
-        return SequenceId(Sequence._SEPARATOR.join([Sequence._ID_PREFIX, _validate_id(sequence_name), scenario_id]))
+        seq_id = sequence_name.replace(" ", "_")
+        return SequenceId(Sequence._SEPARATOR.join([Sequence._ID_PREFIX, _validate_id(seq_id), scenario_id]))
 
     def __hash__(self):
         return hash(self.id)

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -8,9 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-import typing
 from datetime import datetime, timedelta
-from typing import Set
 from unittest import mock
 
 import pytest
@@ -369,7 +367,7 @@ def test_renaming_existing_sequence_raises_exception(data_node):
 
     scenario.add_sequence("sequence_1", [task_1])
     scenario.add_sequence("sequence_2", [task_2])
-    with pytest.raises(SequenceAlreadyExists) as err:
+    with pytest.raises(SequenceAlreadyExists):
         scenario.rename_sequence("sequence_1", "sequence_2")
 
 

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -22,7 +22,7 @@ from taipy.core.cycle.cycle import Cycle, CycleId
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.in_memory import DataNode, InMemoryDataNode
 from taipy.core.data.pickle import PickleDataNode
-from taipy.core.exceptions.exceptions import SequenceTaskDoesNotExistInScenario, SequenceAlreadyExists
+from taipy.core.exceptions.exceptions import SequenceAlreadyExists, SequenceTaskDoesNotExistInScenario
 from taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
 from taipy.core.scenario.scenario import Scenario
 from taipy.core.scenario.scenario_id import ScenarioId

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -413,23 +413,23 @@ def test_add_rename_and_remove_sequences():
     scenario.remove_sequences(["seq_1"])
     assert scenario.sequences == {"seq_2": sequence_2}
 
-    scenario.add_sequences({"seq_1": [task_1], "seq_3": [task_1, task_5, task_3]})
-    assert scenario.sequences == {"seq_2": sequence_2, "seq_1": sequence_1, "seq_3": sequence_3}
+    scenario.add_sequences({"seq_1": [task_1], "seq 3": [task_1, task_5, task_3]})
+    assert scenario.sequences == {"seq_2": sequence_2, "seq_1": sequence_1, "seq 3": sequence_3}
 
-    scenario.remove_sequences(["seq_2", "seq_3"])
+    scenario.remove_sequences(["seq_2", "seq 3"])
     assert scenario.sequences == {"seq_1": sequence_1}
 
     scenario.add_sequence("seq_2", [task_1, task_2])
     assert scenario.sequences == {"seq_1": sequence_1, "seq_2": sequence_2}
 
-    scenario.add_sequence("seq_3", [task_1.id, task_5.id, task_3.id])
-    assert scenario.sequences == {"seq_1": sequence_1, "seq_2": sequence_2, "seq_3": sequence_3}
+    scenario.add_sequence("seq 3", [task_1.id, task_5.id, task_3.id])
+    assert scenario.sequences == {"seq_1": sequence_1, "seq_2": sequence_2, "seq 3": sequence_3}
 
     scenario.remove_sequence("seq_1")
-    assert scenario.sequences == {"seq_2": sequence_2, "seq_3": sequence_3}
+    assert scenario.sequences == {"seq_2": sequence_2, "seq 3": sequence_3}
 
     scenario.rename_sequence("seq_2", "new_seq_2")
-    assert scenario.sequences == {"new_seq_2": new_seq_2, "seq_3": sequence_3}
+    assert scenario.sequences == {"new_seq_2": new_seq_2, "seq 3": sequence_3}
 
 
 def test_update_sequence(data_node):

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -446,6 +446,29 @@ def test_update_sequence(data_node):
     assert scenario.sequences["seq_1"].properties["new_key"] == "new_value"
 
 
+def test_add_rename_and_remove_sequences_within_context(data_node):
+    task_1 = Task("task_1", {}, print, output=[data_node])
+    task_2 = Task("task_2", {}, print, input=[data_node])
+    _TaskManagerFactory._build_manager()._set(task_1)
+    scenario = Scenario(config_id="scenario", tasks={task_1, task_2}, properties={})
+    _ScenarioManagerFactory._build_manager()._set(scenario)
+
+    with scenario as sc:
+        sc.add_sequence("seq_name", [task_1])
+    assert len(scenario.sequences) == 1
+    assert scenario.sequences["seq_name"].tasks == {"task_1": task_1}
+
+    with scenario as sc:
+        sc.update_sequence("seq_name", [task_2])
+    assert len(scenario.sequences) == 1
+    assert scenario.sequences["seq_name"].tasks == {"task_2": task_2}
+
+    with scenario as sc:
+        sc.remove_sequence("seq_name")
+    assert len(scenario.sequences) == 0
+
+
+
 def test_add_property_to_scenario():
     scenario = Scenario("foo", set(), {"key": "value"})
     assert scenario.properties == {"key": "value"}

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -8,8 +8,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-
+import typing
 from datetime import datetime, timedelta
+from typing import Set
 from unittest import mock
 
 import pytest
@@ -23,7 +24,7 @@ from taipy.core.cycle.cycle import Cycle, CycleId
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.in_memory import DataNode, InMemoryDataNode
 from taipy.core.data.pickle import PickleDataNode
-from taipy.core.exceptions.exceptions import SequenceTaskDoesNotExistInScenario
+from taipy.core.exceptions.exceptions import SequenceTaskDoesNotExistInScenario, SequenceAlreadyExists
 from taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
 from taipy.core.scenario.scenario import Scenario
 from taipy.core.scenario.scenario_id import ScenarioId
@@ -83,7 +84,7 @@ def test_create_scenario_with_task_and_additional_dn_and_sequence():
     dn_2 = PickleDataNode("abc", Scope.SCENARIO)
     task = Task("qux", {}, print, [dn_1])
 
-    scenario = Scenario("quux", set([task]), {}, set([dn_2]), sequences={"acb": {"tasks": [task]}})
+    scenario = Scenario("quux", {task}, {}, {dn_2}, sequences={"acb": {"tasks": [task]}})
     sequence = scenario.sequences["acb"]
     assert scenario.id is not None
     assert scenario.config_id == "quux"
@@ -101,7 +102,7 @@ def test_create_scenario_with_task_and_additional_dn_and_sequence():
 
 def test_create_scenario_invalid_config_id():
     with pytest.raises(InvalidConfigurationId):
-        Scenario("foo bar", [], {})
+        Scenario("foo bar", set(), {})
 
 
 def test_create_scenario_and_add_sequences():
@@ -123,7 +124,7 @@ def test_create_scenario_and_add_sequences():
     task_manager._set(task_1)
     task_manager._set(task_2)
 
-    scenario = Scenario("scenario", set([task_1]), {})
+    scenario = Scenario("scenario", {task_1}, {})
     scenario.sequences = {"sequence_1": {"tasks": [task_1]}, "sequence_2": {"tasks": []}}
     assert scenario.id is not None
     assert scenario.config_id == "scenario"
@@ -160,7 +161,7 @@ def test_create_scenario_overlapping_sequences():
     task_manager._set(task_1)
     task_manager._set(task_2)
 
-    scenario = Scenario("scenario", set([task_1, task_2]), {})
+    scenario = Scenario("scenario", {task_1, task_2}, {})
     scenario.add_sequence("sequence_1", [task_1])
     scenario.add_sequence("sequence_2", [task_1, task_2])
     assert scenario.id is not None
@@ -204,7 +205,7 @@ def test_create_scenario_one_additional_dn():
     task_manager._set(task_1)
     task_manager._set(task_2)
 
-    scenario = Scenario("scenario", set(), {}, set([additional_dn_1]))
+    scenario = Scenario("scenario", set(), {}, {additional_dn_1})
     assert scenario.id is not None
     assert scenario.config_id == "scenario"
     assert len(scenario.tasks) == 0
@@ -235,7 +236,7 @@ def test_create_scenario_wth_additional_dns():
     task_manager._set(task_1)
     task_manager._set(task_2)
 
-    scenario = Scenario("scenario", set(), {}, set([additional_dn_1, additional_dn_2]))
+    scenario = Scenario("scenario", set(), {}, {additional_dn_1, additional_dn_2})
     assert scenario.id is not None
     assert scenario.config_id == "scenario"
     assert len(scenario.tasks) == 0
@@ -251,7 +252,7 @@ def test_create_scenario_wth_additional_dns():
         additional_dn_2.config_id: additional_dn_2,
     }
 
-    scenario_1 = Scenario("scenario_1", set([task_1]), {}, set([additional_dn_1]))
+    scenario_1 = Scenario("scenario_1", {task_1}, {}, {additional_dn_1})
     assert scenario_1.id is not None
     assert scenario_1.config_id == "scenario_1"
     assert len(scenario_1.tasks) == 1
@@ -267,7 +268,7 @@ def test_create_scenario_wth_additional_dns():
         additional_dn_1.config_id: additional_dn_1,
     }
 
-    scenario_2 = Scenario("scenario_2", set([task_1, task_2]), {}, set([additional_dn_1, additional_dn_2]))
+    scenario_2 = Scenario("scenario_2", {task_1, task_2}, {}, {additional_dn_1, additional_dn_2})
     assert scenario_2.id is not None
     assert scenario_2.config_id == "scenario_2"
     assert len(scenario_2.tasks) == 2
@@ -293,7 +294,7 @@ def test_raise_sequence_tasks_not_in_scenario(data_node):
     task_2 = Task("task_2", {}, print, input=[data_node])
 
     with pytest.raises(SequenceTaskDoesNotExistInScenario) as err:
-        Scenario("scenario", [], {}, sequences={"sequence": {"tasks": [task_1]}}, scenario_id="SCENARIO_scenario")
+        Scenario("scenario", set(), {}, sequences={"sequence": {"tasks": [task_1]}}, scenario_id="SCENARIO_scenario")
     assert err.value.args == ([task_1.id], "sequence", "SCENARIO_scenario")
 
     with pytest.raises(SequenceTaskDoesNotExistInScenario) as err:
@@ -306,7 +307,7 @@ def test_raise_sequence_tasks_not_in_scenario(data_node):
         )
     assert err.value.args == ([task_2.id], "sequence", "SCENARIO_scenario")
 
-    Scenario("scenario", [task_1], {}, sequences={"sequence": {"tasks": [task_1]}})
+    Scenario("scenario", {task_1}, {}, sequences={"sequence": {"tasks": [task_1]}})
     Scenario(
         "scenario",
         [task_1, task_2],
@@ -315,7 +316,7 @@ def test_raise_sequence_tasks_not_in_scenario(data_node):
     )
 
 
-def test_raise_tasks_not_in_scenario_with_add_sequence_api(data_node):
+def test_adding_sequence_raises_tasks_not_in_scenario(data_node):
     task_1 = Task("task_1", {}, print, output=[data_node])
     task_2 = Task("task_2", {}, print, input=[data_node])
     scenario = Scenario("scenario", [task_1], {})
@@ -345,8 +346,110 @@ def test_raise_tasks_not_in_scenario_with_add_sequence_api(data_node):
     scenario.add_sequence("sequence_6", [task_1, task_2])
 
 
+def test_adding_existing_sequence_raises_exception(data_node):
+    task_1 = Task("task_1", {}, print, output=[data_node])
+    _TaskManagerFactory._build_manager()._set(task_1)
+    task_2 = Task("task_2", {}, print, input=[data_node])
+    _TaskManagerFactory._build_manager()._set(task_2)
+    scenario = Scenario("scenario", tasks={task_1, task_2}, properties={})
+    _ScenarioManagerFactory._build_manager()._set(scenario)
+
+    scenario.add_sequence("sequence_1", [task_1])
+    with pytest.raises(SequenceAlreadyExists):
+        scenario.add_sequence("sequence_1", [task_2])
+
+
+def test_renaming_existing_sequence_raises_exception(data_node):
+    task_1 = Task("task_1", {}, print, output=[data_node])
+    _TaskManagerFactory._build_manager()._set(task_1)
+    task_2 = Task("task_2", {}, print, input=[data_node])
+    _TaskManagerFactory._build_manager()._set(task_2)
+    scenario = Scenario("scenario", {task_1, task_2}, {})
+    _ScenarioManagerFactory._build_manager()._set(scenario)
+
+    scenario.add_sequence("sequence_1", [task_1])
+    scenario.add_sequence("sequence_2", [task_2])
+    with pytest.raises(SequenceAlreadyExists) as err:
+        scenario.rename_sequence("sequence_1", "sequence_2")
+
+
+def test_add_rename_and_remove_sequences():
+    data_node_1 = InMemoryDataNode("foo", Scope.SCENARIO, "s1")
+    data_node_2 = InMemoryDataNode("bar", Scope.SCENARIO, "s2")
+    data_node_3 = InMemoryDataNode("qux", Scope.SCENARIO, "s3")
+    data_node_4 = InMemoryDataNode("quux", Scope.SCENARIO, "s4")
+    data_node_5 = InMemoryDataNode("quuz", Scope.SCENARIO, "s5")
+    task_1 = Task("grault",{}, print,[data_node_1, data_node_2],[data_node_3], TaskId("t1"))
+    task_2 = Task("garply", {}, print, [data_node_3], id=TaskId("t2"))
+    task_3 = Task("waldo", {}, print, [data_node_3], None, id=TaskId("t3"))
+    task_4 = Task("fred", {}, print, [data_node_3], [data_node_4], TaskId("t4"))
+    task_5 = Task("bob", {}, print, [data_node_5], [data_node_3], TaskId("t5"))
+    scenario = Scenario("quest", {task_1, task_2, task_3, task_4, task_5}, {}, [], scenario_id=ScenarioId("s1"))
+
+    sequence_1 = Sequence({"name": "seq_1"}, [task_1], SequenceId(f"SEQUENCE_seq_1_{scenario.id}"))
+    sequence_2 = Sequence({"name": "seq_2"}, [task_1, task_2], SequenceId(f"SEQUENCE_seq_2_{scenario.id}"))
+    new_seq_2 = Sequence({"name": "seq_2"}, [task_1, task_2], SequenceId(f"SEQUENCE_new_seq_2_{scenario.id}"))
+    sequence_3 = Sequence({"name": "seq_3"}, [task_1, task_5, task_3], SequenceId(f"SEQUENCE_seq_3_{scenario.id}"))
+
+    task_manager = _TaskManagerFactory._build_manager()
+    data_manager = _DataManagerFactory._build_manager()
+    scenario_manager = _ScenarioManagerFactory._build_manager()
+    for dn in [data_node_1, data_node_2, data_node_3, data_node_4, data_node_5]:
+        data_manager._set(dn)
+    for t in [task_1, task_2, task_3, task_4, task_5]:
+        task_manager._set(t)
+    scenario_manager._set(scenario)
+
+    assert scenario.get_inputs() == {data_node_1, data_node_2, data_node_5}
+    assert scenario._get_set_of_tasks() == {task_1, task_2, task_3, task_4, task_5}
+    assert len(scenario.sequences) == 0
+
+    scenario.sequences = {"seq_1": {"tasks": [task_1]}}
+    assert scenario.sequences == {"seq_1": sequence_1}
+
+    scenario.add_sequences({"seq_2": [task_1, task_2]})
+    assert scenario.sequences == {"seq_1": sequence_1, "seq_2": sequence_2}
+
+    scenario.remove_sequences(["seq_1"])
+    assert scenario.sequences == {"seq_2": sequence_2}
+
+    scenario.add_sequences({"seq_1": [task_1], "seq_3": [task_1, task_5, task_3]})
+    assert scenario.sequences == {"seq_2": sequence_2, "seq_1": sequence_1, "seq_3": sequence_3}
+
+    scenario.remove_sequences(["seq_2", "seq_3"])
+    assert scenario.sequences == {"seq_1": sequence_1}
+
+    scenario.add_sequence("seq_2", [task_1, task_2])
+    assert scenario.sequences == {"seq_1": sequence_1, "seq_2": sequence_2}
+
+    scenario.add_sequence("seq_3", [task_1.id, task_5.id, task_3.id])
+    assert scenario.sequences == {"seq_1": sequence_1, "seq_2": sequence_2, "seq_3": sequence_3}
+
+    scenario.remove_sequence("seq_1")
+    assert scenario.sequences == {"seq_2": sequence_2, "seq_3": sequence_3}
+
+    scenario.rename_sequence("seq_2", "new_seq_2")
+    assert scenario.sequences == {"new_seq_2": new_seq_2, "seq_3": sequence_3}
+
+
+def test_update_sequence(data_node):
+    task_1 = Task("foo",{}, print,[data_node],[], TaskId("t1"))
+    task_2 = Task("bar", {}, print, [], [data_node], id=TaskId("t2"))
+    scenario = Scenario("baz", {task_1, task_2}, {})
+    scenario.add_sequence("seq_1", [task_1])
+
+    assert len(scenario.sequences) == 1
+    assert scenario.sequences["seq_1"].tasks == {"foo": task_1}
+    assert scenario.sequences["seq_1"].name == "seq_1"
+    scenario.update_sequence("seq_1", [task_2], {"new_key": "new_value"}, [])
+    assert len(scenario.sequences) == 1
+    assert scenario.sequences["seq_1"].tasks == {"bar": task_2}
+    assert scenario.sequences["seq_1"].name == "seq_1"
+    assert scenario.sequences["seq_1"].properties["new_key"] == "new_value"
+
+
 def test_add_property_to_scenario():
-    scenario = Scenario("foo", [], {"key": "value"})
+    scenario = Scenario("foo", set(), {"key": "value"})
     assert scenario.properties == {"key": "value"}
     assert scenario.key == "value"
 
@@ -358,7 +461,7 @@ def test_add_property_to_scenario():
 
 
 def test_add_cycle_to_scenario(cycle):
-    scenario = Scenario("foo", [], {})
+    scenario = Scenario("foo", set(), {})
     assert scenario.cycle is None
     _CycleManagerFactory._build_manager()._set(cycle)
     scenario.cycle = cycle
@@ -367,7 +470,7 @@ def test_add_cycle_to_scenario(cycle):
 
 
 def test_add_and_remove_subscriber():
-    scenario = Scenario("foo", [], {})
+    scenario = Scenario("foo", set(), {})
 
     scenario._add_subscriber(print)
     assert len(scenario.subscribers) == 1
@@ -377,7 +480,7 @@ def test_add_and_remove_subscriber():
 
 
 def test_add_and_remove_tag():
-    scenario = Scenario("foo", [], {})
+    scenario = Scenario("foo", set(), {})
 
     assert len(scenario.tags) == 0
     scenario._add_tag("tag")
@@ -705,42 +808,42 @@ def test_auto_set_and_reload_properties():
 
 def test_is_deletable():
     with mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._is_deletable") as mock_submit:
-        scenario = Scenario("foo", [], {})
+        scenario = Scenario("foo", set(), {})
         scenario.is_deletable()
         mock_submit.assert_called_once_with(scenario)
 
 
 def test_submit_scenario():
     with mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._submit") as mock_submit:
-        scenario = Scenario("foo", [], {})
+        scenario = Scenario("foo", set(), {})
         scenario.submit(force=False)
         mock_submit.assert_called_once_with(scenario, None, False, False, None)
 
 
 def test_subscribe_scenario():
     with mock.patch("taipy.core.subscribe_scenario") as mock_subscribe:
-        scenario = Scenario("foo", [], {})
+        scenario = Scenario("foo", set(), {})
         scenario.subscribe(None)
         mock_subscribe.assert_called_once_with(None, None, scenario)
 
 
 def test_unsubscribe_scenario():
     with mock.patch("taipy.core.unsubscribe_scenario") as mock_unsubscribe:
-        scenario = Scenario("foo", [], {})
+        scenario = Scenario("foo", set(), {})
         scenario.unsubscribe(None)
         mock_unsubscribe.assert_called_once_with(None, None, scenario)
 
 
 def test_add_tag_scenario():
     with mock.patch("taipy.core.tag") as mock_add_tag:
-        scenario = Scenario("foo", [], {})
+        scenario = Scenario("foo", set(), {})
         scenario.add_tag("tag")
         mock_add_tag.assert_called_once_with(scenario, "tag")
 
 
 def test_remove_tag_scenario():
     with mock.patch("taipy.core.untag") as mock_remove_tag:
-        scenario = Scenario("foo", [], {})
+        scenario = Scenario("foo", set(), {})
         scenario.remove_tag("tag")
         mock_remove_tag.assert_called_once_with(scenario, "tag")
 
@@ -1225,65 +1328,6 @@ def test_get_sorted_tasks():
     assert scenario_8.get_inputs() == {data_node_1, data_node_2, data_node_5}
     assert scenario_8._get_set_of_tasks() == {task_1, task_2, task_3, task_4, task_5}
     _assert_equal(scenario_8._get_sorted_tasks(), [[task_5, task_2, task_1], [task_3, task_4]])
-
-
-def test_add_and_remove_sequences():
-    data_node_1 = InMemoryDataNode("foo", Scope.SCENARIO, "s1")
-    data_node_2 = InMemoryDataNode("bar", Scope.SCENARIO, "s2")
-    data_node_3 = InMemoryDataNode("qux", Scope.SCENARIO, "s3")
-    data_node_4 = InMemoryDataNode("quux", Scope.SCENARIO, "s4")
-    data_node_5 = InMemoryDataNode("quuz", Scope.SCENARIO, "s5")
-    task_1 = Task(
-        "grault",
-        {},
-        print,
-        [data_node_1, data_node_2],
-        [data_node_3],
-        TaskId("t1"),
-    )
-    task_2 = Task("garply", {}, print, [data_node_3], id=TaskId("t2"))
-    task_3 = Task("waldo", {}, print, [data_node_3], None, id=TaskId("t3"))
-    task_4 = Task("fred", {}, print, [data_node_3], [data_node_4], TaskId("t4"))
-    task_5 = Task("bob", {}, print, [data_node_5], [data_node_3], TaskId("t5"))
-    scenario_1 = Scenario("quest", [task_1, task_2, task_3, task_4, task_5], {}, [], scenario_id=ScenarioId("s1"))
-
-    sequence_1 = Sequence({"name": "sequence_1"}, [task_1], SequenceId(f"SEQUENCE_sequence_1_{scenario_1.id}"))
-    sequence_2 = Sequence({"name": "sequence_2"}, [task_1, task_2], SequenceId(f"SEQUENCE_sequence_2_{scenario_1.id}"))
-    sequence_3 = Sequence(
-        {"name": "sequence_3"}, [task_1, task_5, task_3], SequenceId(f"SEQUENCE_sequence_3_{scenario_1.id}")
-    )
-
-    task_manager = _TaskManagerFactory._build_manager()
-    data_manager = _DataManagerFactory._build_manager()
-    scenario_manager = _ScenarioManagerFactory._build_manager()
-    for dn in [data_node_1, data_node_2, data_node_3, data_node_4, data_node_5]:
-        data_manager._set(dn)
-    for t in [task_1, task_2, task_3, task_4, task_5]:
-        task_manager._set(t)
-    scenario_manager._set(scenario_1)
-
-    assert scenario_1.get_inputs() == {data_node_1, data_node_2, data_node_5}
-    assert scenario_1._get_set_of_tasks() == {task_1, task_2, task_3, task_4, task_5}
-    assert len(scenario_1.sequences) == 0
-
-    scenario_1.sequences = {"sequence_1": {"tasks": [task_1]}}
-    assert scenario_1.sequences == {"sequence_1": sequence_1}
-
-    scenario_1.add_sequences({"sequence_2": [task_1, task_2]})
-    assert scenario_1.sequences == {"sequence_1": sequence_1, "sequence_2": sequence_2}
-
-    scenario_1.remove_sequences(["sequence_1"])
-    assert scenario_1.sequences == {"sequence_2": sequence_2}
-
-    scenario_1.add_sequences({"sequence_1": [task_1], "sequence_3": [task_1, task_5, task_3]})
-    assert scenario_1.sequences == {
-        "sequence_2": sequence_2,
-        "sequence_1": sequence_1,
-        "sequence_3": sequence_3,
-    }
-
-    scenario_1.remove_sequences(["sequence_2", "sequence_3"])
-    assert scenario_1.sequences == {"sequence_1": sequence_1}
 
 
 def test_check_consistency():

--- a/tests/core/sequence/test_sequence_manager.py
+++ b/tests/core/sequence/test_sequence_manager.py
@@ -31,7 +31,7 @@ from taipy.core.exceptions.exceptions import (
     InvalidSequenceId,
     ModelNotFound,
     NonExistingSequence,
-    SequenceBelongsToNonExistingScenario, SequenceAlreadyExists,
+    SequenceAlreadyExists, SequenceBelongsToNonExistingScenario,
 )
 from taipy.core.job._job_manager import _JobManager
 from taipy.core.scenario._scenario_manager import _ScenarioManager

--- a/tests/core/sequence/test_sequence_manager.py
+++ b/tests/core/sequence/test_sequence_manager.py
@@ -31,7 +31,8 @@ from taipy.core.exceptions.exceptions import (
     InvalidSequenceId,
     ModelNotFound,
     NonExistingSequence,
-    SequenceAlreadyExists, SequenceBelongsToNonExistingScenario,
+    SequenceAlreadyExists,
+    SequenceBelongsToNonExistingScenario,
 )
 from taipy.core.job._job_manager import _JobManager
 from taipy.core.scenario._scenario_manager import _ScenarioManager

--- a/tests/core/sequence/test_sequence_manager_with_sql_repo.py
+++ b/tests/core/sequence/test_sequence_manager_with_sql_repo.py
@@ -18,6 +18,7 @@ from taipy.core._version._version_manager import _VersionManager
 from taipy.core.config.job_config import JobConfig
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data.in_memory import InMemoryDataNode
+from taipy.core.exceptions import SequenceAlreadyExists
 from taipy.core.job._job_manager import _JobManager
 from taipy.core.scenario._scenario_manager import _ScenarioManager
 from taipy.core.scenario.scenario import Scenario
@@ -74,8 +75,9 @@ def test_set_and_get_sequence(init_sql_repo, init_managers):
     assert _SequenceManager._get(sequence_2).id == sequence_2.id
     assert len(_SequenceManager._get(sequence_2).tasks) == 1
 
-    # We save the first sequence again. We expect nothing to change
-    scenario.add_sequences({sequence_name_1: {}})
+    # We save the first sequence again. We expect an exception and nothing to change
+    with pytest.raises(SequenceAlreadyExists):
+        scenario.add_sequences({sequence_name_1: {}})
     sequence_1 = scenario.sequences[sequence_name_1]
     assert _SequenceManager._get(sequence_id_1).id == sequence_1.id
     assert len(_SequenceManager._get(sequence_id_1).tasks) == 0
@@ -85,21 +87,6 @@ def test_set_and_get_sequence(init_sql_repo, init_managers):
     assert len(_SequenceManager._get(sequence_id_2).tasks) == 1
     assert _SequenceManager._get(sequence_2).id == sequence_2.id
     assert len(_SequenceManager._get(sequence_2).tasks) == 1
-
-    # We save a third sequence with same id as the first one.
-    # We expect the first sequence to be updated
-    scenario.add_sequences({sequence_name_1: [task]})
-    sequence_3 = scenario.sequences[sequence_name_1]
-    assert _SequenceManager._get(sequence_id_1).id == sequence_1.id
-    assert _SequenceManager._get(sequence_id_1).id == sequence_3.id
-    assert len(_SequenceManager._get(sequence_id_1).tasks) == 1
-    assert _SequenceManager._get(sequence_1).id == sequence_1.id
-    assert len(_SequenceManager._get(sequence_1).tasks) == 1
-    assert _SequenceManager._get(sequence_id_2).id == sequence_2.id
-    assert len(_SequenceManager._get(sequence_id_2).tasks) == 1
-    assert _SequenceManager._get(sequence_2).id == sequence_2.id
-    assert len(_SequenceManager._get(sequence_2).tasks) == 1
-    assert _TaskManager._get(task.id).id == task.id
 
 
 def test_get_all_on_multiple_versions_environment(init_sql_repo, init_managers):


### PR DESCRIPTION
Resolves #812 

- Opened a new API at the scenario level to rename a sequence
- Opened a new API at the scenario level to update an existing sequence
- Updated the `add_sequence` method to check if a sequence already exists with the same name.
- Updated the `NonExistingSequence` exception message.
- Accept spaces in sequence names.
