### PR TITLE
Improve error message readability

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -623,7 +623,23 @@ class Gui:
                         self.__handle_ws_app_id(message)
                 self.__send_ack(message.get("ack_id"))
         except Exception as e:  # pragma: no cover
-            _warn(f"Decoding Message has failed: {message}", e)
+            if isinstance(e, AttributeError) and (name := message.get("name")):
+                try:
+                    names = self._get_real_var_name(name)
+                    var_name = names[0] if isinstance(names, tuple) else names
+                    var_context = names[1] if isinstance(names, tuple) else None
+                    if var_name.startswith("tpec_"):
+                        var_name = var_name[5:]
+                    if var_name.startswith("TpExPr_"):
+                        var_name = var_name[7:]
+                    _warn(
+                        f"A problem occured while resolving variable '{var_name}'"
+                        + (f" in module '{var_context}'." if var_context else ".")
+                    )
+                except Exception as e1:
+                    _warn(f"Resolving  name '{name}' failed", e1)
+            else:
+                _warn(f"Decoding Message has failed: {message}", e)
 
     def __front_end_update(
         self,
@@ -2017,7 +2033,7 @@ class Gui:
 
     def _bind_custom_page_variables(self, page: CustomPage, client_id: t.Optional[str]):
         """Handle the bindings of custom page variables"""
-        with self.get_flask_app().app_context() if has_app_context() else contextlib.nullcontext(): # type: ignore[attr-defined]
+        with self.get_flask_app().app_context() if has_app_context() else contextlib.nullcontext():  # type: ignore[attr-defined]
             self.__set_client_id_in_context(client_id)
             with self._set_locals_context(page._get_module_name()):
                 for k in self._get_locals_bind().keys():

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -633,7 +633,7 @@ class Gui:
                     if var_name.startswith("TpExPr_"):
                         var_name = var_name[7:]
                     _warn(
-                        f"A problem occured while resolving variable '{var_name}'"
+                        f"A problem occurred while resolving variable '{var_name}'"
                         + (f" in module '{var_context}'." if var_context else ".")
                     )
                 except Exception as e1:


### PR DESCRIPTION
In case of message like `'types.SimpleNamespace' object has no attribute '_TpLv_tpec_TpExPr_selected_q_question_TPMDL_1'`
we would now show ` A problem occurred while resolving variable 'selected_q_question' in module '__main__'`

resolves #560