### PR TITLE
GUI: Update login close action

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Login.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Login.tsx
@@ -66,12 +66,9 @@ const Login = (props: LoginProps) => {
 
     const handleAction = useCallback(
         (evt: MouseEvent<HTMLElement>) => {
-            if (!user || !password) {
-                return;
-            }
             const { close } = evt?.currentTarget.dataset || {};
             const args = close
-                ? ["", "", document.location.pathname.substring(1)]
+                ? [null, null, document.location.pathname.substring(1)]
                 : [user, password, document.location.pathname.substring(1)];
             setShowProgress(true);
             dispatch(createSendActionNameAction(id, module, onAction, ...args));
@@ -112,7 +109,7 @@ const Login = (props: LoginProps) => {
     }, []);
 
     return onlyOne ? (
-        <Dialog id={id} onClose={handleAction} open={true} className={className}>
+        <Dialog id={id} open={true} className={className}>
             <DialogTitle sx={titleSx}>
                 {title}
                 <IconButton aria-label="close" onClick={handleAction} sx={closeSx} title="close" data-close>


### PR DESCRIPTION
Allow python to recoginize the click of the close button on the login control

```python
from taipy.gui import Gui, State
from taipy.gui.gui_actions import navigate

username = ""

def on_login(s: State, id, login_args):
    print(f"{login_args=}")
    payload = login_args["args"]
    if payload[0] is None:
        return navigate(s, "default")
    s.username = payload[0]
    navigate(s, "home")

def on_navigate(s, page_name):
    return "default" if page_name == "home" and s.username == "" else page_name

def logout(s):
    s.username = ""
    navigate(s, "default")

page = """# Login
<|Join Taipy!|login|id=login11|message=Hello from Taipy|>
"""

gui = Gui()
gui.add_page("default", "# Taipy App\n\n[Login](/login)")
gui.add_page("login", page)
gui.add_page("home", "# Home\n\nWelcome to Taipy, <|{username}|>\n\n<|Logout|button|on_action=logout|>")

gui.run()


```