### PR TITLE
Move specific attributes from job_dispatcher to standalone job dispatcher

### DIFF
--- a/taipy/core/_orchestrator/_abstract_orchestrator.py
+++ b/taipy/core/_orchestrator/_abstract_orchestrator.py
@@ -21,6 +21,16 @@ from ..task.task import Task
 class _AbstractOrchestrator:
     """Creates, enqueues, and orchestrates jobs as instances of `Job^` class."""
 
+    @property
+    @abstractmethod
+    def jobs_to_run(self):
+        pass
+
+    @property
+    @abstractmethod
+    def blocked_jobs(self):
+        pass
+
     @classmethod
     @abstractmethod
     def initialize(cls):

--- a/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
@@ -50,5 +50,5 @@ class _DevelopmentJobDispatcher(_JobDispatcher):
     def _is_dispatched(self, job_id: str) -> bool:
         return False
 
-    def _remove_job(self, job_id: str):
+    def _remove_dispatched_job(self, job_id: str):
         pass

--- a/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
@@ -23,6 +23,9 @@ class _DevelopmentJobDispatcher(_JobDispatcher):
     def __init__(self, orchestrator: _AbstractOrchestrator):
         super().__init__(orchestrator)
 
+    def _can_execute(self) -> bool:
+        return True
+
     def start(self):
         raise NotImplementedError
 
@@ -43,3 +46,9 @@ class _DevelopmentJobDispatcher(_JobDispatcher):
         """
         rs = _TaskFunctionWrapper(job.id, job.task).execute()
         self._update_job_status(job, rs)
+
+    def _is_dispatched(self, job_id: str) -> bool:
+        return False
+
+    def _remove_job(self, job_id: str):
+        pass

--- a/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_development_job_dispatcher.py
@@ -46,9 +46,3 @@ class _DevelopmentJobDispatcher(_JobDispatcher):
         """
         rs = _TaskFunctionWrapper(job.id, job.task).execute()
         self._update_job_status(job, rs)
-
-    def _is_dispatched(self, job_id: str) -> bool:
-        return False
-
-    def _remove_dispatched_job(self, job_id: str):
-        pass

--- a/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -29,6 +29,8 @@ class _JobDispatcher(threading.Thread):
     """Manages job dispatching (instances of `Job^` class) on executors."""
 
     _STOP_FLAG = False
+    stop_wait = True
+    stop_timeout = None
     _logger = _TaipyLogger._get_logger()
 
     def __init__(self, orchestrator: _AbstractOrchestrator):
@@ -53,10 +55,9 @@ class _JobDispatcher(threading.Thread):
             wait (bool): If True, the method will wait for the dispatcher to stop.
             timeout (Optional[float]): The maximum time to wait. If None, the method will wait indefinitely.
         """
+        self.stop_wait = wait
+        self.stop_timeout = timeout
         self._STOP_FLAG = True
-        if wait and self.is_alive():
-            self._logger.debug("Waiting for the dispatcher thread to stop...")
-            self.join(timeout=timeout)
 
     def run(self):
         self._logger.debug("Job dispatcher started.")
@@ -75,6 +76,9 @@ class _JobDispatcher(threading.Thread):
             except Exception as e:
                 self._logger.exception(e)
                 pass
+        if self.stop_wait:
+            self._logger.debug("Waiting for the dispatcher thread to stop...")
+            self.join(timeout=self.stop_timeout)
         self._logger.debug("Job dispatcher stopped.")
 
     @abstractmethod

--- a/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -146,5 +146,5 @@ class _JobDispatcher(threading.Thread):
         raise NotImplementedError
 
     @abstractmethod
-    def _remove_job(self, job_id: str):
+    def _remove_dispatched_job(self, job_id: str):
         raise NotImplementedError

--- a/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -144,11 +144,3 @@ class _JobDispatcher(threading.Thread):
     def _update_job_status(job: Job, exceptions):
         job.update_status(exceptions)
         _JobManagerFactory._build_manager()._set(job)
-
-    @abstractmethod
-    def _is_dispatched(self, job_id: str) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    def _remove_dispatched_job(self, job_id: str):
-        raise NotImplementedError

--- a/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -42,7 +42,7 @@ class _StandaloneJobDispatcher(_JobDispatcher):
     def run(self):
         with self._executor:
             super().run()
-        self._logger.info("Standalone job dispatcher: Pool executor shut down")
+        self._logger.debug("Standalone job dispatcher: Pool executor shut down")
 
     def _dispatch(self, job: Job):
         """Dispatches the given `Job^` on an available worker for execution.

--- a/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -11,7 +11,7 @@
 
 from concurrent.futures import Executor, ProcessPoolExecutor
 from functools import partial
-from typing import Any, Callable, Dict, Optional
+from typing import Callable, Optional
 
 from taipy.config._serializer._toml_serializer import _TomlSerializer
 from taipy.config.config import Config

--- a/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_standalone_job_dispatcher.py
@@ -76,5 +76,5 @@ class _StandaloneJobDispatcher(_JobDispatcher):
     def _is_dispatched(self, job_id: str) -> bool:
         return job_id in self._dispatched_processes.keys()
 
-    def _remove_job(self, job_id: str):
+    def _remove_dispatched_job(self, job_id: str):
         self._pop_dispatched_process(job_id)

--- a/taipy/core/_orchestrator/_orchestrator.py
+++ b/taipy/core/_orchestrator/_orchestrator.py
@@ -329,6 +329,3 @@ class _Orchestrator(_AbstractOrchestrator):
 
         if dispatcher := _OrchestratorFactory._dispatcher:
             dispatcher._execute_jobs_synchronously()
-
-    def is_dispatched(self, job_id: JobId) -> bool:
-        raise NotImplementedError

--- a/taipy/core/_orchestrator/_orchestrator.py
+++ b/taipy/core/_orchestrator/_orchestrator.py
@@ -308,10 +308,9 @@ class _Orchestrator(_AbstractOrchestrator):
 
     @classmethod
     def _cancel_jobs(cls, job_id_to_cancel: JobId, jobs: Set[Job]):
-        from ._orchestrator_factory import _OrchestratorFactory
 
         for job in jobs:
-            if _OrchestratorFactory._dispatcher._is_dispatched(job.id):  # type: ignore
+            if job.is_running():
                 cls.__logger.info(f"{job.id} is running and cannot be canceled.")
             elif job.is_completed():
                 cls.__logger.info(f"{job.id} has already been completed and cannot be canceled.")

--- a/taipy/core/_orchestrator/_orchestrator.py
+++ b/taipy/core/_orchestrator/_orchestrator.py
@@ -311,7 +311,7 @@ class _Orchestrator(_AbstractOrchestrator):
         from ._orchestrator_factory import _OrchestratorFactory
 
         for job in jobs:
-            if _OrchestratorFactory._dispatcher._is_dispatched(job.id):
+            if _OrchestratorFactory._dispatcher._is_dispatched(job.id):  # type: ignore
                 cls.__logger.info(f"{job.id} is running and cannot be canceled.")
             elif job.is_completed():
                 cls.__logger.info(f"{job.id} has already been completed and cannot be canceled.")

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -63,7 +63,7 @@ class _JobManager(_Manager[Job], _VersionMixin):
             super()._delete(job.id)
             from .._orchestrator._orchestrator_factory import _OrchestratorFactory
 
-            _OrchestratorFactory._dispatcher._remove_job(job.id)  # type: ignore
+            _OrchestratorFactory._dispatcher._remove_dispatched_job(job.id)  # type: ignore
         else:
             err = JobNotDeletedException(job.id)
             cls._logger.error(err)

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -61,9 +61,9 @@ class _JobManager(_Manager[Job], _VersionMixin):
     def _delete(cls, job: Job, force=False):
         if cls._is_deletable(job) or force:
             super()._delete(job.id)
-            from .._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
+            from .._orchestrator._orchestrator_factory import _OrchestratorFactory
 
-            _JobDispatcher._pop_dispatched_process(job.id)
+            _OrchestratorFactory._dispatcher._remove_job(job.id)
         else:
             err = JobNotDeletedException(job.id)
             cls._logger.error(err)

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -63,7 +63,7 @@ class _JobManager(_Manager[Job], _VersionMixin):
             super()._delete(job.id)
             from .._orchestrator._orchestrator_factory import _OrchestratorFactory
 
-            _OrchestratorFactory._dispatcher._remove_job(job.id)
+            _OrchestratorFactory._dispatcher._remove_job(job.id)  # type: ignore
         else:
             err = JobNotDeletedException(job.id)
             cls._logger.error(err)

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -61,9 +61,6 @@ class _JobManager(_Manager[Job], _VersionMixin):
     def _delete(cls, job: Job, force=False):
         if cls._is_deletable(job) or force:
             super()._delete(job.id)
-            from .._orchestrator._orchestrator_factory import _OrchestratorFactory
-
-            _OrchestratorFactory._dispatcher._remove_dispatched_job(job.id)  # type: ignore
         else:
             err = JobNotDeletedException(job.id)
             cls._logger.error(err)

--- a/tests/core/_entity/test_migrate_cli.py
+++ b/tests/core/_entity/test_migrate_cli.py
@@ -26,6 +26,8 @@ from taipy.core._entity._migrate_cli import _MigrateCLI
 def clean_data_folder():
     if os.path.exists("tests/core/_entity/.data"):
         shutil.rmtree("tests/core/_entity/.data")
+    if os.path.exists("tests/core/_entity/.taipy"):
+        shutil.rmtree("tests/core/_entity/.taipy")
     yield
 
 

--- a/tests/core/_orchestrator/_dispatcher/mock_standalone_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/mock_standalone_dispatcher.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from concurrent.futures import Executor, Future
-from typing import List
+from typing import Dict, List
 
 from taipy.core import Job
 from taipy.core._orchestrator._abstract_orchestrator import _AbstractOrchestrator
@@ -38,6 +38,9 @@ class MockStandaloneDispatcher(_StandaloneJobDispatcher):
     def __init__(self, orchestrator: _AbstractOrchestrator):
         super(_StandaloneJobDispatcher, self).__init__(orchestrator)
         self._executor: Executor = MockProcessPoolExecutor()
+        self._dispatched_processes: Dict = {}
+        self._nb_available_workers = 1
+
         self.dispatch_calls: List = []
         self.release_worker_calls: List = []
         self.set_dispatch_processes_calls: List = []

--- a/tests/core/_orchestrator/_dispatcher/mock_standalone_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/mock_standalone_dispatcher.py
@@ -38,13 +38,10 @@ class MockStandaloneDispatcher(_StandaloneJobDispatcher):
     def __init__(self, orchestrator: _AbstractOrchestrator):
         super(_StandaloneJobDispatcher, self).__init__(orchestrator)
         self._executor: Executor = MockProcessPoolExecutor()
-        self._dispatched_processes: Dict = {}
         self._nb_available_workers = 1
 
         self.dispatch_calls: List = []
         self.release_worker_calls: List = []
-        self.set_dispatch_processes_calls: List = []
-        self.pop_dispatch_processes_calls: List = []
         self.update_job_status_from_future_calls: List = []
 
     def mock_exception_for_job(self, task_id, e: Exception):
@@ -53,14 +50,6 @@ class MockStandaloneDispatcher(_StandaloneJobDispatcher):
     def _dispatch(self, job: Job):
         self.dispatch_calls.append(job)
         super()._dispatch(job)
-
-    def _set_dispatched_processes(self, job_id, future):
-        self.set_dispatch_processes_calls.append((job_id, future))
-        super()._set_dispatched_processes(job_id, future)
-
-    def _pop_dispatched_process(self, job_id, default=None):
-        self.pop_dispatch_processes_calls.append(job_id)
-        return super()._pop_dispatched_process(job_id, default)
 
     def _release_worker(self, _):
         self.release_worker_calls.append(None)

--- a/tests/core/_orchestrator/_dispatcher/mock_standalone_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/mock_standalone_dispatcher.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from concurrent.futures import Executor, Future
-from typing import Dict, List
+from typing import List
 
 from taipy.core import Job
 from taipy.core._orchestrator._abstract_orchestrator import _AbstractOrchestrator

--- a/tests/core/_orchestrator/_dispatcher/test_development_job_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/test_development_job_dispatcher.py
@@ -13,6 +13,7 @@ import traceback
 from unittest.mock import patch
 
 from taipy.core import JobId
+from taipy.core._orchestrator._dispatcher import _DevelopmentJobDispatcher
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.job.job import Job
 from taipy.core.task._task_manager_factory import _TaskManagerFactory
@@ -61,3 +62,8 @@ def test_dispatch_executes_the_function_with_exceptions():
     assert job.stacktrace[1] == "".join(traceback.format_exception(type(e_2), value=e_2, tb=e_2.__traceback__))
     assert job.stacktrace[0] == "".join(traceback.format_exception(type(e_1), value=e_1, tb=e_1.__traceback__))
     assert job.is_failed()
+
+
+def test_can_execute():
+    dispatcher = _DevelopmentJobDispatcher(_OrchestratorFactory._orchestrator)
+    assert dispatcher._can_execute()

--- a/tests/core/_orchestrator/_dispatcher/test_dispatcher__execute_job.py
+++ b/tests/core/_orchestrator/_dispatcher/test_dispatcher__execute_job.py
@@ -33,18 +33,6 @@ def create_scenario():
     return taipy.create_scenario(sc_conf)
 
 
-def test_can_execute():
-    dispatcher = _JobDispatcher(_OrchestratorFactory._orchestrator)
-    assert dispatcher._nb_available_workers == 1
-    assert dispatcher._can_execute()
-    dispatcher._nb_available_workers = 0
-    assert not dispatcher._can_execute()
-    dispatcher._nb_available_workers = -1
-    assert not dispatcher._can_execute()
-    dispatcher._nb_available_workers = 1
-    assert dispatcher._can_execute()
-
-
 def test_execute_job():
     scenario = create_scenario()
     scenario.t1.skippable = True  # make the job skippable

--- a/tests/core/_orchestrator/_dispatcher/test_standalone_job_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/test_standalone_job_dispatcher.py
@@ -84,6 +84,18 @@ def test_dispatch_job():
     assert dispatcher.update_job_status_from_future_calls[0][1] == dispatcher._executor.f[0]
 
 
+def test_can_execute():
+    dispatcher = _StandaloneJobDispatcher(_OrchestratorFactory._orchestrator)
+    assert dispatcher._nb_available_workers == 1
+    assert dispatcher._can_execute()
+    dispatcher._nb_available_workers = 0
+    assert not dispatcher._can_execute()
+    dispatcher._nb_available_workers = -1
+    assert not dispatcher._can_execute()
+    dispatcher._nb_available_workers = 1
+    assert dispatcher._can_execute()
+
+
 def test_release_worker():
     dispatcher = _StandaloneJobDispatcher(_OrchestratorFactory._orchestrator)
 

--- a/tests/core/_orchestrator/_dispatcher/test_standalone_job_dispatcher.py
+++ b/tests/core/_orchestrator/_dispatcher/test_standalone_job_dispatcher.py
@@ -70,11 +70,6 @@ def test_dispatch_job():
     assert submit_first_call[1] == ()
     assert submit_first_call[2]["config_as_string"] == _TomlSerializer()._serialize(Config._applied_config)
 
-    # test that the proc of the job is added to the list of dispatched jobs
-    assert len(dispatcher.set_dispatch_processes_calls) == 1
-    assert dispatcher.set_dispatch_processes_calls[0][0] == job.id
-    assert dispatcher.set_dispatch_processes_calls[0][1] == dispatcher._executor.f[0]
-
     # test that the worker is released after the job is done
     assert len(dispatcher.release_worker_calls) == 1
 
@@ -113,11 +108,7 @@ def test_update_job_status_from_future():
     dispatcher = _StandaloneJobDispatcher(orchestrator)
     ft = Future()
     ft.set_result(None)
-    dispatcher._set_dispatched_processes(job.id, ft)  # the job is dispatched to a process
-
     dispatcher._update_job_status_from_future(job, ft)
-
-    assert len(dispatcher._dispatched_processes) == 0  # the job process is not stored anymore
     assert job.is_completed()
 
 

--- a/tests/core/_orchestrator/_dispatcher/test_task_function_wrapper.py
+++ b/tests/core/_orchestrator/_dispatcher/test_task_function_wrapper.py
@@ -17,7 +17,6 @@ from taipy.config._serializer._toml_serializer import _TomlSerializer
 from taipy.config.common.scope import Scope
 from taipy.config.exceptions import ConfigurationUpdateBlocked
 from taipy.core._orchestrator._dispatcher._task_function_wrapper import _TaskFunctionWrapper
-from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.task.task import Task
 

--- a/tests/core/_orchestrator/_dispatcher/test_task_function_wrapper.py
+++ b/tests/core/_orchestrator/_dispatcher/test_task_function_wrapper.py
@@ -84,9 +84,7 @@ def test_execute_task_that_returns_single_iterable_output():
     _TaskFunctionWrapper("job_id_list", task_with_list).execute()
 
     assert task_with_tuple.output[f"{task_with_tuple.config_id}_output0"].read() == (42, 21)
-    assert len(_OrchestratorFactory._dispatcher._dispatched_processes) == 0
     assert task_with_list.output[f"{task_with_list.config_id}_output0"].read() == [42, 21]
-    assert len(_OrchestratorFactory._dispatcher._dispatched_processes) == 0
 
 
 def test_data_node_not_written_due_to_wrong_result_nb():

--- a/tests/core/_orchestrator/test_orchestrator__cancel_jobs.py
+++ b/tests/core/_orchestrator/test_orchestrator__cancel_jobs.py
@@ -8,10 +8,12 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+from typing import cast
 
 from taipy import Job, JobId, Status
 from taipy.config import Config
 from taipy.core import taipy
+from taipy.core._orchestrator._orchestrator import _Orchestrator
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.job._job_manager_factory import _JobManagerFactory
 from taipy.core.task._task_manager_factory import _TaskManagerFactory
@@ -89,11 +91,10 @@ def test_cancel_job_with_subsequent_jobs_and_parallel_jobs():
     job3 = orchestrator._lock_dn_output_and_create_job(scenario.t3, "s_id", "e_id")
     job2bis = orchestrator._lock_dn_output_and_create_job(scenario.t2bis, "s_id", "e_id")
     job1.completed()
-
-    job2.running()
+    job2.pending()
     job3.blocked()
     job2bis.pending()
-    orchestrator.blocked_jobs = [job3]
+    cast(_Orchestrator, orchestrator).blocked_jobs = [job3]
 
     orchestrator.cancel_job(job2)
 

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -20,7 +20,6 @@ import pytest
 
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
-from taipy.core._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.config.job_config import JobConfig
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -160,11 +160,11 @@ def test_raise_when_trying_to_delete_unfinished_job():
     task = Task(
         "task_config_1", {}, partial(lock_multiply, lock), [dn_1, dn_2], [dn_3], id="raise_when_delete_unfinished"
     )
-    _OrchestratorFactory._build_dispatcher()
+    dispatcher = _OrchestratorFactory._build_dispatcher()
     with lock:
         job = _OrchestratorFactory._orchestrator.submit_task(task)._jobs[0]
 
-        assert_true_after_time(lambda: len(_JobDispatcher._dispatched_processes) == 1)
+        assert_true_after_time(lambda: len(dispatcher._dispatched_processes) == 1)
         assert_true_after_time(job.is_running)
         with pytest.raises(JobNotDeletedException):
             _JobManager._delete(job)
@@ -203,18 +203,17 @@ def test_cancel_single_job():
 
     task = _create_task(multiply, name="cancel_single_job")
 
-    _OrchestratorFactory._build_dispatcher()
+    dispatcher = _OrchestratorFactory._build_dispatcher()
 
-    assert_true_after_time(_OrchestratorFactory._dispatcher.is_running)
-    _OrchestratorFactory._dispatcher.stop()
-    assert_true_after_time(lambda: not _OrchestratorFactory._dispatcher.is_running())
+    assert_true_after_time(dispatcher.is_running)
+    dispatcher.stop()
+    assert_true_after_time(lambda: not dispatcher.is_running())
 
     job = _OrchestratorFactory._orchestrator.submit_task(task).jobs[0]
 
     assert_true_after_time(job.is_pending)
-    assert_true_after_time(lambda: len(_JobDispatcher._dispatched_processes) == 0)
+    assert_true_after_time(lambda: len(dispatcher._dispatched_processes) == 0)
     _JobManager._cancel(job.id)
-    assert_true_after_time(job.is_canceled)
     assert_true_after_time(job.is_canceled)
 
 
@@ -228,11 +227,11 @@ def test_cancel_canceled_abandoned_failed_jobs(cancel_jobs, orchestrated_job):
 
     task = _create_task(multiply, name="test_cancel_canceled_abandoned_failed_jobs")
 
-    _OrchestratorFactory._build_dispatcher()
+    dispatcher = _OrchestratorFactory._build_dispatcher()
 
-    assert_true_after_time(_OrchestratorFactory._dispatcher.is_running)
-    _OrchestratorFactory._dispatcher.stop()
-    assert_true_after_time(lambda: not _OrchestratorFactory._dispatcher.is_running())
+    assert_true_after_time(dispatcher.is_running)
+    dispatcher.stop()
+    assert_true_after_time(lambda: not dispatcher.is_running())
 
     job = _OrchestratorFactory._orchestrator.submit_task(task).jobs[0]
     job.canceled()
@@ -265,11 +264,11 @@ def test_cancel_completed_skipped_jobs(cancel_jobs, orchestrated_job):
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=1)
     task = _create_task(multiply, name="cancel_single_job")
 
-    _OrchestratorFactory._build_dispatcher()
+    dispatcher = _OrchestratorFactory._build_dispatcher()
 
-    assert_true_after_time(_OrchestratorFactory._dispatcher.is_running)
-    _OrchestratorFactory._dispatcher.stop()
-    assert_true_after_time(lambda: not _OrchestratorFactory._dispatcher.is_running())
+    assert_true_after_time(dispatcher.is_running)
+    dispatcher.stop()
+    assert_true_after_time(lambda: not dispatcher.is_running())
 
     job = _OrchestratorFactory._orchestrator.submit_task(task).jobs[0]
     job.completed()
@@ -307,21 +306,21 @@ def test_cancel_single_running_job():
     dnm._set(dn_3)
     task = Task("task_config_1", {}, partial(lock_multiply, lock), [dn_1, dn_2], [dn_3], id="cancel_single_job")
 
-    _OrchestratorFactory._build_dispatcher()
+    dispatcher = _OrchestratorFactory._build_dispatcher()
 
-    assert_true_after_time(_OrchestratorFactory._dispatcher.is_running)
-    assert_true_after_time(lambda: _OrchestratorFactory._dispatcher._nb_available_workers == 2)
+    assert_true_after_time(dispatcher.is_running)
+    assert_true_after_time(lambda: dispatcher._nb_available_workers == 2)
 
     with lock:
         job = _OrchestratorFactory._orchestrator.submit_task(task)._jobs[0]
 
-        assert_true_after_time(lambda: len(_JobDispatcher._dispatched_processes) == 1)
-        assert_true_after_time(lambda: _OrchestratorFactory._dispatcher._nb_available_workers == 1)
+        assert_true_after_time(lambda: len(dispatcher._dispatched_processes) == 1)
+        assert_true_after_time(lambda: dispatcher._nb_available_workers == 1)
         assert_true_after_time(job.is_running)
         _JobManager._cancel(job)
         assert_true_after_time(job.is_running)
-    assert_true_after_time(lambda: len(_JobDispatcher._dispatched_processes) == 0)
-    assert_true_after_time(lambda: _OrchestratorFactory._dispatcher._nb_available_workers == 2)
+    assert_true_after_time(lambda: len(dispatcher._dispatched_processes) == 0)
+    assert_true_after_time(lambda: dispatcher._nb_available_workers == 2)
     assert_true_after_time(job.is_completed)
 
 

--- a/tests/core/job/test_job_manager_with_sql_repo.py
+++ b/tests/core/job/test_job_manager_with_sql_repo.py
@@ -14,12 +14,14 @@ import random
 import string
 from functools import partial
 from time import sleep
+from typing import cast
 
 import pytest
 
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 from taipy.core import Task
+from taipy.core._orchestrator._dispatcher import _StandaloneJobDispatcher
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.config.job_config import JobConfig
 from taipy.core.data import InMemoryDataNode
@@ -145,12 +147,12 @@ def test_raise_when_trying_to_delete_unfinished_job(init_sql_repo):
     proc_manager = multiprocessing.Manager()
     lock = proc_manager.Lock()
     task = Task("task_cfg", {}, partial(lock_multiply, lock), [dn_1, dn_2], [dn_3], id="raise_when_delete_unfinished")
-    dispatcher = _OrchestratorFactory._build_dispatcher()
+    dispatcher = cast(_StandaloneJobDispatcher, _OrchestratorFactory._build_dispatcher(force_restart=True))
 
     with lock:
         job = _OrchestratorFactory._orchestrator.submit_task(task)._jobs[0]
-        assert_true_after_time(lambda: len(dispatcher._dispatched_processes) == 1)
         assert_true_after_time(job.is_running)
+        assert dispatcher._nb_available_workers == 2
         with pytest.raises(JobNotDeletedException):
             _JobManager._delete(job)
         with pytest.raises(JobNotDeletedException):

--- a/tests/core/job/test_job_manager_with_sql_repo.py
+++ b/tests/core/job/test_job_manager_with_sql_repo.py
@@ -20,7 +20,6 @@ import pytest
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 from taipy.core import Task
-from taipy.core._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.config.job_config import JobConfig
 from taipy.core.data import InMemoryDataNode


### PR DESCRIPTION
Move `dispatched_processes` and `nb_of_available_workers`

This is in preparation of a better subprocess pid management proposal.