### PR TITLE
table cell action when value is a button

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
@@ -110,7 +110,7 @@ const Row = ({
         onRowSelection,
         onRowClick,
         lineStyle,
-        nanValue,
+        nanValue
     },
 }: {
     index: number;
@@ -450,12 +450,14 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
     );
 
     const onRowSelection: OnRowSelection = useCallback(
-        (rowIndex: number, colName?: string) =>
+        (rowIndex: number, colName?: string, value?: string) =>
             dispatch(
                 createSendActionNameAction(updateVarName, module, {
                     action: onAction,
                     index: getRowIndex(rows[rowIndex], rowIndex),
                     col: colName === undefined ? null : colName,
+                    value,
+                    reason: value === undefined ? "click": "button",
                     user_data: userData,
                 })
             ),
@@ -502,7 +504,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
             onRowSelection: active && onAction ? onRowSelection : undefined,
             onRowClick: active && onAction ? onRowClick : undefined,
             lineStyle: props.lineStyle,
-            nanValue: props.nanValue,
+            nanValue: props.nanValue
         }),
         [
             rows,
@@ -521,7 +523,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
             onRowClick,
             props.lineStyle,
             props.nanValue,
-            size,
+            size
         ]
     );
 

--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.spec.tsx
@@ -122,6 +122,33 @@ const editableColumns = JSON.stringify({
     Code: { dfid: "Code", type: "str", index: 3 },
 });
 
+const buttonValue = {
+    "0--1-bool,int,float,Code--asc": {
+        data: [
+            {
+                bool: true,
+                int: 856,
+                float: 1.5,
+                Code: "[Button Label](button action)",
+            },
+            {
+                bool: false,
+                int: 823,
+                float: 2.5,
+                Code: "ZZZ",
+            },
+        ],
+        rowcount: 2,
+        start: 0,
+    },
+};
+const buttonColumns = JSON.stringify({
+    bool: { dfid: "bool", type: "bool", index: 0 },
+    int: { dfid: "int", type: "int", index: 1 },
+    float: { dfid: "float", type: "float", index: 2 },
+    Code: { dfid: "Code", type: "str", index: 3 },
+});
+
 describe("PaginatedTable Component", () => {
     it("renders", async () => {
         const { getByText } = render(<PaginatedTable data={undefined} defaultColumns={tableColumns} />);
@@ -539,6 +566,45 @@ describe("PaginatedTable Component", () => {
                 args: [],
                 col: "int",
                 index: 1,
+                reason: "click",
+                value: undefined
+            },
+            type: "SEND_ACTION_ACTION",
+        });
+    });
+    it("can click on button", async () => {
+        const dispatch = jest.fn();
+        const state: TaipyState = INITIAL_STATE;
+        const { getByText, rerender } = render(
+            <TaipyContext.Provider value={{ state, dispatch }}>
+                <PaginatedTable data={undefined} defaultColumns={editableColumns} showAll={true} onAction="onSelect" />
+            </TaipyContext.Provider>
+        );
+
+        rerender(
+            <TaipyContext.Provider value={{ state: { ...state }, dispatch }}>
+                <PaginatedTable
+                    data={buttonValue as TableValueType}
+                    defaultColumns={buttonColumns}
+                    showAll={true}
+                    onAction="onSelect"
+                />
+            </TaipyContext.Provider>
+        );
+
+        dispatch.mockClear();
+        const elt = getByText("Button Label");
+        expect(elt.tagName).toBe("BUTTON");
+        await userEvent.click(elt);
+        expect(dispatch).toHaveBeenCalledWith({
+            name: "",
+            payload: {
+                action: "onSelect",
+                args: [],
+                col: "Code",
+                index: 0,
+                reason: "button",
+                value: "button action"
             },
             type: "SEND_ACTION_ACTION",
         });

--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
@@ -393,12 +393,14 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
     );
 
     const onRowSelection: OnRowSelection = useCallback(
-        (rowIndex: number, colName?: string) =>
+        (rowIndex: number, colName?: string, value?: string) =>
             dispatch(
                 createSendActionNameAction(updateVarName, module, {
                     action: onAction,
                     index: getRowIndex(rows[rowIndex], rowIndex, startIndex),
                     col: colName === undefined ? null : colName,
+                    value,
+                    reason: value === undefined ? "click": "button",
                     user_data: userData,
                 })
             ),

--- a/frontend/taipy-gui/src/components/Taipy/tableUtils.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/tableUtils.tsx
@@ -308,30 +308,30 @@ export const EditableCell = (props: EditableCellProps) => {
     const onCheckClick = useCallback(
         (evt?: MouseEvent<HTMLElement>) => {
             evt && evt.stopPropagation();
-            let castedVal = val;
+            let castVal = val;
             switch (colDesc.type) {
                 case "bool":
-                    castedVal = isBooleanTrue(val as RowValue);
+                    castVal = isBooleanTrue(val as RowValue);
                     break;
                 case "int":
                     try {
-                        castedVal = parseInt(val as string, 10);
+                        castVal = parseInt(val as string, 10);
                     } catch (e) {
                         // ignore
                     }
                     break;
                 case "float":
                     try {
-                        castedVal = parseFloat(val as string);
+                        castVal = parseFloat(val as string);
                     } catch (e) {
                         // ignore
                     }
                     break;
                 case "datetime":
                     if (val === null) {
-                        castedVal = val;
+                        castVal = val;
                     } else if (isValid(val)) {
-                        castedVal = dateToString(
+                        castVal = dateToString(
                             getTimeZonedDate(val as Date, formatConfig.timeZone, withTime),
                             withTime
                         );
@@ -342,7 +342,7 @@ export const EditableCell = (props: EditableCellProps) => {
             }
             onValidation &&
                 onValidation(
-                    castedVal as RowValue,
+                    castVal as RowValue,
                     rowIndex,
                     colDesc.dfid,
                     val as string,

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1111,7 +1111,7 @@
           {
             "name": "on_action",
             "type": "str",
-            "doc": "The name of a function that is triggered when the user selects a row.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>This dictionary has the following keys:\n<ul>\n<li>action: the name of the action that triggered this callback.</li>\n<li>index (int): the row index.</li>\n<li>col (str): the column name.</li></ul></li></ul>.",
+            "doc": "The name of a function that is triggered when the user selects a row.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>This dictionary has the following keys:\n<ul>\n<li>action: the name of the action that triggered this callback.</li>\n<li>index (int): the row index.</li>\n<li>col (str): the column name.</li>\n<li>reason (str): the origin of the action: cmick or button.</li>\n<li>value (str): the value associated with the button when reason == button and original value is [label](button value).</li></ul></li></ul>.",
             "signature": [["state", "State"], ["var_name", "str"], ["payload", "dict"]]
           },
           {

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1111,7 +1111,7 @@
           {
             "name": "on_action",
             "type": "str",
-            "doc": "The name of a function that is triggered when the user selects a row.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>This dictionary has the following keys:\n<ul>\n<li>action: the name of the action that triggered this callback.</li>\n<li>index (int): the row index.</li>\n<li>col (str): the column name.</li>\n<li>reason (str): the origin of the action: cmick or button.</li>\n<li>value (str): the value associated with the button when reason == button and original value is [label](button value).</li></ul></li></ul>.",
+            "doc": "The name of a function that is triggered when the user selects a row.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>This dictionary has the following keys:\n<ul>\n<li>action: the name of the action that triggered this callback.</li>\n<li>index (int): the row index.</li>\n<li>col (str): the column name.</li>\n<li>reason (str): the origin of the action: \"click\", or \"button\" if the cell contains a Markdown link syntax.</li>\n<li>value (str): the *link value* indicated in the cell when using a Markdown link syntax (that is, <i>reason</i> is set to \"button\").</li></ul></li></ul>.",
             "signature": [["state", "State"], ["var_name", "str"], ["payload", "dict"]]
           },
           {


### PR DESCRIPTION
- a button is shown when cell value is \[button label](button value)
- fix lov clear selection
resolves #945
resolves #947
```

import pandas as pd

from taipy.gui import Gui, State

data = {
    "label": ["red", "white"],
    "timedelta": [pd.Timedelta(days=1), pd.Timedelta(days=2)],
    "links": ["[link 1](a value)", "[another link](http://www.google.com)"],
}

col_lov = ["value 1", "value 2", "value 3"]

def on_action(state: State, var_name: str, payload: dict):
    print(f"on_action(state, var_name: {var_name}, payload: {payload})")


def on_edit(state: State, var_name: str, payload: dict):
    print(f"on_edit(state, var_name: {var_name}, payload: {payload})")

md = """
<|{data}|table|lov[label]={col_lov}|on_action=on_action|on_edit=on_edit|>
"""

Gui(md).run()

```