### PR TITLE
Add name to shared bundle for easier import

### DIFF
--- a/frontend/taipy-gui/base/webpack.config.js
+++ b/frontend/taipy-gui/base/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
     optimization: {
         splitChunks: {
             chunks: 'all',
+            name: "shared",
         },
     },
     module: {

--- a/frontend/taipy-gui/webpack.config.js
+++ b/frontend/taipy-gui/webpack.config.js
@@ -194,6 +194,7 @@ module.exports = (env, options) => {
         optimization: {
             splitChunks: {
                 chunks: 'all',
+                name: "shared",
             },
         },
         module: {


### PR DESCRIPTION
chunk created by optimization will not be imported by the default entry --> an easier name is needed for 3rd party to import the shared chunk