### PR TITLE
Fix/#497 - Unique section init should not use default values

### DIFF
--- a/taipy/config/config.pyi
+++ b/taipy/config/config.pyi
@@ -848,8 +848,8 @@ class Config:
 
         Parameters:
             mode (Optional[str]): The job execution mode.
-                Possible values are: *"standalone"* (the default value) or *"development"*.
-            max_nb_of_workers (Optional[int, str]): Parameter used only in default *"standalone"* mode.
+                Possible values are: *"standalone"* or *"development"*.
+            max_nb_of_workers (Optional[int, str]): Parameter used only in *"standalone"* mode.
                 This indicates the maximum number of jobs able to run in parallel.<br/>
                 The default value is 2.<br/>
                 A string can be provided to dynamically set the value using an environment

--- a/taipy/core/config/checkers/_job_config_checker.py
+++ b/taipy/core/config/checkers/_job_config_checker.py
@@ -30,6 +30,7 @@ class _JobConfigChecker(_ConfigChecker):
                 cast(JobConfig, job_config),
                 cast(Dict[str, DataNodeConfig], data_node_configs),
             )
+            self._check_job_execution_mode(cast(JobConfig, job_config))
         return self._collector
 
     def _check_multiprocess_mode(self, job_config: JobConfig, data_node_configs: Dict[str, DataNodeConfig]):
@@ -42,3 +43,11 @@ class _JobConfigChecker(_ConfigChecker):
                         f"DataNode `{cfg_id}`: In-memory storage type can ONLY be used in "
                         f"{JobConfig._DEVELOPMENT_MODE} mode.",
                     )
+
+    def _check_job_execution_mode(self, job_config: JobConfig):
+        if job_config.mode not in JobConfig._MODES:
+            self._error(
+                job_config._MODE_KEY,
+                job_config.mode,
+                f"`Job execution mode must be either {', '.join(JobConfig._MODES)}.",
+            )

--- a/taipy/core/config/core_section.py
+++ b/taipy/core/config/core_section.py
@@ -101,10 +101,8 @@ class CoreSection(UniqueSection):
         self._storage_folder = storage_folder
         self._taipy_storage_folder = taipy_storage_folder
         self._repository_type = repository_type
-        self._repository_properties = repository_properties or {}
-        self._read_entity_retry = (
-            read_entity_retry if read_entity_retry is not None else self._DEFAULT_READ_ENTITY_RETRY
-        )
+        self._repository_properties = repository_properties
+        self._read_entity_retry = read_entity_retry
         self._mode = mode
         self._version_number = version_number
         self._force = force
@@ -298,7 +296,14 @@ class CoreSection(UniqueSection):
         self._storage_folder = as_dict.pop(self._STORAGE_FOLDER_KEY, self._storage_folder)
         self._taipy_storage_folder = as_dict.pop(self._STORAGE_FOLDER_TP_KEY, self._taipy_storage_folder)
         self._repository_type = as_dict.pop(self._REPOSITORY_TYPE_KEY, self._repository_type)
-        self._repository_properties.update(as_dict.pop(self._REPOSITORY_PROPERTIES_KEY, self._repository_properties))
+        if self._repository_properties is None:
+            self._repository_properties = as_dict.pop(
+                self._REPOSITORY_PROPERTIES_KEY, self._DEFAULT_REPOSITORY_PROPERTIES.copy()
+            )
+        else:
+            self._repository_properties.update(
+                as_dict.pop(self._REPOSITORY_PROPERTIES_KEY, self._repository_properties)
+            )
         self._read_entity_retry = as_dict.pop(self._READ_ENTITY_RETRY_KEY, self._read_entity_retry)
         self._mode = as_dict.pop(self._MODE_KEY, self.mode)
         self._version_number = as_dict.pop(self._VERSION_NUMBER_KEY, self.version_number)

--- a/tests/core/_orchestrator/test_orchestrator_factory.py
+++ b/tests/core/_orchestrator/test_orchestrator_factory.py
@@ -105,10 +105,7 @@ def test_rebuild_standalone_dispatcher_and_force_restart():
 
 
 def test_build_unknown_dispatcher():
-    with pytest.raises(ModeNotAvailable):
-        Config.configure_job_executions(mode="UNKNOWN")
-
-    Config.job_config.mode = "UNKNOWN"
+    Config.configure_job_executions(mode="UNKNOWN")
     _OrchestratorFactory._build_orchestrator()
     with pytest.raises(ModeNotAvailable):
         _OrchestratorFactory._build_dispatcher()

--- a/tests/core/config/checkers/test_core_section_checker.py
+++ b/tests/core/config/checkers/test_core_section_checker.py
@@ -34,6 +34,8 @@ class TestCoreSectionChecker:
         Config.check()
         assert len(Config._collector.warnings) == 0
 
+        Config.configure_core(repository_type="filesystem")
+
     def test_check_repository_type_value_wrong_str(self):
         Config.configure_core(repository_type="any")
         Config._collector = IssueCollector()

--- a/tests/core/config/checkers/test_job_config_checker.py
+++ b/tests/core/config/checkers/test_job_config_checker.py
@@ -40,6 +40,8 @@ class TestJobConfigChecker:
         expected_error_message = "Job execution mode must be either development, standalone."
         assert expected_error_message in caplog.text
 
+        Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
+
     def test_check_standalone_mode(self, caplog):
         Config._collector = IssueCollector()
         Config.check()

--- a/tests/core/config/checkers/test_job_config_checker.py
+++ b/tests/core/config/checkers/test_job_config_checker.py
@@ -17,6 +17,29 @@ from taipy.core.config.job_config import JobConfig
 
 
 class TestJobConfigChecker:
+    def test_check_mode(self, caplog):
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
+        Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
+        Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
+        Config.configure_job_executions(mode="foo", max_nb_of_workers=2)
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = "Job execution mode must be either development, standalone."
+        assert expected_error_message in caplog.text
+
     def test_check_standalone_mode(self, caplog):
         Config._collector = IssueCollector()
         Config.check()

--- a/tests/core/config/test_job_config.py
+++ b/tests/core/config/test_job_config.py
@@ -37,5 +37,4 @@ def test_clean_config():
     assert Config.job_config is job_config
 
     assert job_config.mode == "development"
-    assert job_config._config == {}
     assert job_config.properties == {}

--- a/tests/core/config/test_override_config.py
+++ b/tests/core/config/test_override_config.py
@@ -122,12 +122,15 @@ start_executor = "ENV[BAR]"
         assert Config.job_config.start_executor
 
     with mock.patch.dict(os.environ, {"FOO": "foo", "BAR": "true"}):
+        Config.override(tf.filename)
         with pytest.raises(InconsistentEnvVariableError):
-            Config.override(tf.filename)
+            _ = Config.job_config.max_nb_of_workers
 
     with mock.patch.dict(os.environ, {"FOO": "5"}):
+        Config.override(tf.filename)
+        assert Config.job_config.max_nb_of_workers == 5
         with pytest.raises(MissingEnvVariableError):
-            Config.override(tf.filename)
+            _ = Config.job_config.start_executor
 
 
 def test_code_configuration_do_not_override_file_configuration():


### PR DESCRIPTION
Resolves #497 

In this PR:
- Remove default value usages from CoreSection.__init__
- Refactor the JobConfig class: merge `JobConfig._config` with the `_properties`
- Check the job execution mode in the Config checker