### PR TITLE
Feature/#949 - Refactor Taipy CLI

### DIFF
--- a/taipy/_cli/_base_cli/_abstract_cli.py
+++ b/taipy/_cli/_base_cli/_abstract_cli.py
@@ -1,0 +1,64 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import sys
+from abc import abstractmethod
+from difflib import SequenceMatcher
+from typing import List, Optional
+
+from taipy.logger._taipy_logger import _TaipyLogger
+
+from ._taipy_parser import _TaipyParser
+
+
+class _AbstractCLI:
+    _logger = _TaipyLogger._get_logger()
+
+    _COMMAND_NAME: Optional[str] = None
+    _ARGUMENTS: List[str] = []
+    SIMILARITY_THRESHOLD = 0.8
+
+    @classmethod
+    @abstractmethod
+    def create_parser(cls):
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def handle_command(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def _parse_arguments(cls):
+        args, unknown_args = _TaipyParser._parser.parse_known_args()
+
+        if getattr(args, "which", None) != cls._COMMAND_NAME:
+            return
+
+        if unknown_args:
+            _TaipyParser._sub_taipyparsers.get(cls._COMMAND_NAME).print_help()
+            for unknown_arg in unknown_args:
+                if not unknown_arg.startswith("-"):
+                    continue
+
+                error_message = f"Unknown arguments: {unknown_arg}."
+                similar_args = [
+                    arg
+                    for arg in cls._ARGUMENTS
+                    if SequenceMatcher(None, unknown_arg, arg).ratio() > cls.SIMILARITY_THRESHOLD
+                ]
+                if similar_args:
+                    error_message += f" Did you mean: {' or '.join(similar_args)}?"
+                cls._logger.error(error_message)
+            cls._logger.error("Please refer to the help message above for more information.")
+            sys.exit(1)
+
+        return args

--- a/taipy/_cli/_base_cli/_taipy_parser.py
+++ b/taipy/_cli/_base_cli/_taipy_parser.py
@@ -13,7 +13,7 @@ import argparse
 from typing import Dict
 
 
-class _CLI:
+class _TaipyParser:
     """Argument parser for Taipy application."""
 
     # The conflict_handler is set to "resolve" to override conflict arguments
@@ -50,12 +50,6 @@ class _CLI:
         groupparser = cls._parser.add_argument_group(title=title, description=description)
         cls._arg_groups[title] = groupparser
         return groupparser
-
-    @classmethod
-    def _parse(cls):
-        """Parse and return only known arguments."""
-        args, _ = cls._parser.parse_known_args()
-        return args
 
     @classmethod
     def _remove_argument(cls, arg: str):

--- a/taipy/_cli/_help_cli.py
+++ b/taipy/_cli/_help_cli.py
@@ -11,31 +11,36 @@
 
 import sys
 
-from taipy._cli._base_cli import _CLI
-from taipy.logger._taipy_logger import _TaipyLogger
+from ._base_cli._abstract_cli import _AbstractCLI
+from ._base_cli._taipy_parser import _TaipyParser
 
 
-class _HelpCLI:
-    __logger = _TaipyLogger._get_logger()
+class _HelpCLI(_AbstractCLI):
+    _COMMAND_NAME = "help"
 
     @classmethod
     def create_parser(cls):
-        create_parser = _CLI._add_subparser("help", help="Show the Taipy help message.", add_help=False)
+        create_parser = _TaipyParser._add_subparser(
+            cls._COMMAND_NAME,
+            help="Show the Taipy help message.",
+            add_help=False,
+        )
         create_parser.add_argument(
             "command", nargs="?", type=str, const="", default="", help="Show the help message of the command."
         )
 
     @classmethod
-    def parse_arguments(cls):
-        args = _CLI._parse()
+    def handle_command(cls):
+        args = cls._parse_arguments()
+        if not args:
+            return
 
-        if getattr(args, "which", None) == "help":
-            if args.command:
-                if args.command in _CLI._sub_taipyparsers.keys():
-                    _CLI._sub_taipyparsers.get(args.command).print_help()
-                else:
-                    cls.__logger.error(f"{args.command} is not a valid command.")
+        if args.command:
+            if args.command in _TaipyParser._sub_taipyparsers.keys():
+                _TaipyParser._sub_taipyparsers.get(args.command).print_help()
             else:
-                _CLI._parser.print_help()
+                cls._logger.error(f"{args.command} is not a valid command.")
+        else:
+            _TaipyParser._parser.print_help()
 
-            sys.exit(0)
+        sys.exit(0)

--- a/taipy/_entrypoint.py
+++ b/taipy/_entrypoint.py
@@ -13,7 +13,7 @@ import os
 import sys
 from importlib.util import find_spec
 
-from taipy._cli._base_cli import _CLI
+from taipy._cli._base_cli._taipy_parser import _TaipyParser
 from taipy.core._core_cli import _CoreCLI
 from taipy.core._entity._migrate_cli import _MigrateCLI
 from taipy.core._version._cli._version_cli import _VersionCLI
@@ -29,7 +29,12 @@ def _entrypoint():
     # Add the current working directory to path to execute version command on FS repo
     sys.path.append(os.path.normpath(os.getcwd()))
 
-    _CLI._parser.add_argument("-v", "--version", action="store_true", help="Print the current Taipy version and exit.")
+    _TaipyParser._parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        help="Print the current Taipy version and exit.",
+    )
 
     _RunCLI.create_parser()
     _GuiCLI.create_run_parser()
@@ -45,16 +50,16 @@ def _entrypoint():
 
         _enterprise_entrypoint()
 
-    args = _CLI._parse()
+    args, _ = _TaipyParser._parser.parse_known_args()
     if args.version:
         print(f"Taipy {_get_version()}")  # noqa: T201
         sys.exit(0)
 
-    _RunCLI.parse_arguments()
-    _HelpCLI.parse_arguments()
-    _VersionCLI.parse_arguments()
-    _MigrateCLI.parse_arguments()
-    _ScaffoldCLI.parse_arguments()
+    _RunCLI.handle_command()
+    _HelpCLI.handle_command()
+    _VersionCLI.handle_command()
+    _MigrateCLI.handle_command()
+    _ScaffoldCLI.handle_command()
 
-    _CLI._remove_argument("help")
-    _CLI._parser.print_help()
+    _TaipyParser._remove_argument("help")
+    _TaipyParser._parser.print_help()

--- a/taipy/core/_core.py
+++ b/taipy/core/_core.py
@@ -103,7 +103,7 @@ class Core:
     def __update_core_section(cls):
         cls.__logger.info("Updating configuration with command-line arguments...")
         _CoreCLI.create_parser()
-        Config._applied_config._unique_sections[CoreSection.name]._update(_CoreCLI.parse_arguments())
+        Config._applied_config._unique_sections[CoreSection.name]._update(_CoreCLI.handle_command())
 
     @classmethod
     def __manage_version(cls):

--- a/taipy/core/_core_cli.py
+++ b/taipy/core/_core_cli.py
@@ -11,12 +11,13 @@
 
 from typing import Dict
 
-from taipy._cli._base_cli import _CLI
+from taipy._cli._base_cli._abstract_cli import _AbstractCLI
+from taipy._cli._base_cli._taipy_parser import _TaipyParser
 
 from .config import CoreSection
 
 
-class _CoreCLI:
+class _CoreCLI(_AbstractCLI):
     """Command-line interface for Taipy Core application."""
 
     __MODE_ARGS: Dict[str, Dict] = {
@@ -69,7 +70,7 @@ class _CoreCLI:
 
     @classmethod
     def create_parser(cls):
-        core_parser = _CLI._add_groupparser("Taipy Core", "Optional arguments for Taipy Core service")
+        core_parser = _TaipyParser._add_groupparser("Taipy Core", "Optional arguments for Taipy Core service")
 
         mode_group = core_parser.add_mutually_exclusive_group()
         for mode_arg, mode_arg_dict in cls.__MODE_ARGS.items():
@@ -81,7 +82,7 @@ class _CoreCLI:
 
     @classmethod
     def create_run_parser(cls):
-        run_parser = _CLI._add_subparser("run", help="Run a Taipy application.")
+        run_parser = _TaipyParser._add_subparser("run", help="Run a Taipy application.")
         mode_group = run_parser.add_mutually_exclusive_group()
         for mode_arg, mode_arg_dict in cls.__MODE_ARGS.items():
             mode_group.add_argument(mode_arg, **mode_arg_dict)
@@ -91,8 +92,9 @@ class _CoreCLI:
             force_group.add_argument(force_arg, **force_arg_dict)
 
     @classmethod
-    def parse_arguments(cls):
-        args = _CLI._parse()
+    def handle_command(cls):
+        args, _ = _TaipyParser._parser.parse_known_args()
+
         as_dict = {}
         if args.taipy_development:
             as_dict[CoreSection._MODE_KEY] = CoreSection._DEVELOPMENT_MODE

--- a/taipy/gui/_gui_cli.py
+++ b/taipy/gui/_gui_cli.py
@@ -11,10 +11,11 @@
 
 from typing import Dict, Tuple
 
-from taipy._cli._base_cli import _CLI
+from taipy._cli._base_cli._abstract_cli import _AbstractCLI
+from taipy._cli._base_cli._taipy_parser import _TaipyParser
 
 
-class _GuiCLI:
+class _GuiCLI(_AbstractCLI):
     """Command-line interface of GUI."""
 
     __GUI_ARGS: Dict[Tuple, Dict] = {
@@ -72,7 +73,7 @@ class _GuiCLI:
 
     @classmethod
     def create_parser(cls):
-        gui_parser = _CLI._add_groupparser("Taipy GUI", "Optional arguments for Taipy GUI service")
+        gui_parser = _TaipyParser._add_groupparser("Taipy GUI", "Optional arguments for Taipy GUI service")
 
         for args, arg_dict in cls.__GUI_ARGS.items():
             taipy_arg = (args[0], cls.__add_taipy_prefix(args[0]), *args[1:])
@@ -88,7 +89,7 @@ class _GuiCLI:
 
     @classmethod
     def create_run_parser(cls):
-        run_parser = _CLI._add_subparser("run", help="Run a Taipy application.")
+        run_parser = _TaipyParser._add_subparser("run", help="Run a Taipy application.")
         for args, arg_dict in cls.__GUI_ARGS.items():
             run_parser.add_argument(*args, **arg_dict)
 
@@ -101,8 +102,9 @@ class _GuiCLI:
             reloader_group.add_argument(reloader_arg, **reloader_arg_dict)
 
     @classmethod
-    def parse_arguments(cls):
-        return _CLI._parse()
+    def handle_command(cls):
+        args, _ = _TaipyParser._parser.parse_known_args()
+        return args
 
     @classmethod
     def __add_taipy_prefix(cls, key: str):

--- a/taipy/gui/config.py
+++ b/taipy/gui/config.py
@@ -185,7 +185,7 @@ class _Config(object):
 
     def _handle_argparse(self):
         _GuiCLI.create_parser()
-        args = _GuiCLI.parse_arguments()
+        args = _GuiCLI.handle_command()
 
         config = self.config
         if args.taipy_port:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -8,3 +8,14 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_repository(clean_argparser):
+    clean_argparser()
+
+    yield
+
+    clean_argparser()

--- a/tests/cli/test_help_cli.py
+++ b/tests/cli/test_help_cli.py
@@ -9,13 +9,11 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-import argparse
 import re
 from unittest.mock import patch
 
 import pytest
 
-from taipy._cli._base_cli import _CLI
 from taipy._entrypoint import _entrypoint
 
 
@@ -24,40 +22,13 @@ def preprocess_stdout(stdout):
     return re.sub(" +", " ", stdout)
 
 
-def remove_subparser(name: str):
-    """Remove a subparser from the _CLI class."""
-    _CLI._sub_taipyparsers.pop(name, None)
-
-    if _CLI._subparser_action:
-        _CLI._subparser_action._name_parser_map.pop(name, None)
-
-        for action in _CLI._subparser_action._choices_actions:
-            if action.dest == name:
-                _CLI._subparser_action._choices_actions.remove(action)
-
-
-@pytest.fixture(autouse=True, scope="function")
-def clean_argparser():
-    _CLI._parser = argparse.ArgumentParser(conflict_handler="resolve")
-    _CLI._subparser_action = None
-    _CLI._arg_groups = {}
-    subcommands = list(_CLI._sub_taipyparsers.keys())
-    for subcommand in subcommands:
-        remove_subparser(subcommand)
-
-    yield
-
-    _CLI._subparser_action = None
-    _CLI._sub_taipyparsers = {}
-
-
 expected_help = """{run,manage-versions,create,migrate,help} ...
 
 positional arguments:
   {run,manage-versions,create,migrate,help}
     run                 Run a Taipy application.
     manage-versions     Taipy version control system.
-    create              Create a new Taipy application.
+    create              Create a new Taipy application using pre-defined templates.
     migrate             Migrate entities created from old taipy versions to be compatible with the current taipy
     version. The entity migration should be performed only after updating taipy code to the current version.
     help                Show the Taipy help message.

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -315,7 +315,8 @@ def tmp_sqlite(tmpdir_factory):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_repository(init_config, init_managers, init_orchestrator, init_notifier):
+def clean_repository(init_config, init_managers, init_orchestrator, init_notifier, clean_argparser):
+    clean_argparser()
     close_all_sessions()
     init_config()
     init_orchestrator()
@@ -326,6 +327,7 @@ def clean_repository(init_config, init_managers, init_orchestrator, init_notifie
     with patch("sys.argv", ["prog"]):
         yield
 
+    clean_argparser()
     close_all_sessions()
     init_orchestrator()
     init_managers()

--- a/tests/core/version/test_version_cli.py
+++ b/tests/core/version/test_version_cli.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+from taipy._entrypoint import _entrypoint
 from taipy.config.common.frequency import Frequency
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
@@ -25,6 +26,13 @@ from taipy.core.job._job_manager import _JobManager
 from taipy.core.scenario._scenario_manager import _ScenarioManager
 from taipy.core.sequence._sequence_manager import _SequenceManager
 from taipy.core.task._task_manager import _TaskManager
+
+
+def test_version_cli_with_wrong_arguments(caplog):
+    with patch("sys.argv", ["prog", "manage-versions", "--lits"]):
+        with pytest.raises(SystemExit):
+            _entrypoint()
+        assert "Unknown arguments: --lits. Did you mean: --list?" in caplog.text
 
 
 def test_delete_version(caplog):
@@ -87,7 +95,7 @@ def test_delete_version(caplog):
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--delete", "1.0"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     assert "Successfully delete version 1.0." in caplog.text
     all_versions = [version.id for version in _VersionManager._get_all()]
@@ -97,13 +105,13 @@ def test_delete_version(caplog):
     # Test delete a non-existed version
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--delete", "non_exist_version"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     # Test delete production version will change the version from production to experiment
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--delete-production", "1.1"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     assert "Successfully delete version 1.1 from the production version list." in caplog.text
     all_versions = [version.id for version in _VersionManager._get_all()]
@@ -114,7 +122,7 @@ def test_delete_version(caplog):
     # Test delete a non-existed production version
     with pytest.raises(SystemExit) as e:
         with patch("sys.argv", ["prog", "manage-versions", "--delete-production", "non_exist_version"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     assert str(e.value) == "Version 'non_exist_version' is not a production version."
 
@@ -158,7 +166,7 @@ def test_list_versions(capsys):
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--list"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     out, _ = capsys.readouterr()
     version_list = str(out).strip().split("\n")
@@ -194,20 +202,20 @@ def test_rename_version(caplog):
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "non_exist_version", "1.1"]):
             # This should raise an exception since version "non_exist_version" does not exist
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "1.0", "2.0"]):
             # This should raise an exception since 2.0 already exists
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version name '2.0' is already used." in caplog.text
 
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "1.0", "1.1"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert _VersionManager._get("1.0") is None
     assert [version.id for version in _VersionManager._get_all()].sort() == [dev_ver, "1.1", "2.0"].sort()
     # All entities are assigned to the new version
@@ -220,7 +228,7 @@ def test_rename_version(caplog):
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "2.0", "2.1"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert _VersionManager._get("2.0") is None
     assert [version.id for version in _VersionManager._get_all()].sort() == [dev_ver, "1.1", "2.1"].sort()
     assert _VersionManager._get_production_versions() == ["2.1"]
@@ -258,23 +266,23 @@ def test_compare_version_config(caplog, init_config):
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "non_exist_version", "2.0"]):
             # This should raise an exception since version "non_exist_version" does not exist
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "1.0", "non_exist_version"]):
             # This should raise an exception since 2.0 already exists
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "1.0", "1.0"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "There is no difference between version 1.0 Configuration and version 1.0 Configuration." in caplog.text
 
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "1.0", "2.0"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     expected_message = """Differences between version 1.0 Configuration and version 2.0 Configuration:
 \tDATA_NODE "d2" has attribute "default_path" modified: foo.csv -> bar.csv"""
     assert expected_message in caplog.text

--- a/tests/core/version/test_version_cli_with_sql_repo.py
+++ b/tests/core/version/test_version_cli_with_sql_repo.py
@@ -90,7 +90,7 @@ def test_delete_version(caplog, init_sql_repo):
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--delete", "1.0"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     assert "Successfully delete version 1.0." in caplog.text
     all_versions = [version.id for version in _VersionManager._get_all()]
@@ -100,13 +100,13 @@ def test_delete_version(caplog, init_sql_repo):
     # Test delete a non-existed version
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--delete", "non_exist_version"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     # Test delete production version will change the version from production to experiment
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--delete-production", "1.1"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     assert "Successfully delete version 1.1 from the production version list." in caplog.text
     all_versions = [version.id for version in _VersionManager._get_all()]
@@ -117,7 +117,7 @@ def test_delete_version(caplog, init_sql_repo):
     # Test delete a non-existed production version
     with pytest.raises(SystemExit) as e:
         with patch("sys.argv", ["prog", "manage-versions", "--delete-production", "non_exist_version"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     assert str(e.value) == "Version 'non_exist_version' is not a production version."
 
@@ -163,7 +163,7 @@ def test_list_versions(capsys, init_sql_repo):
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--list"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
 
     out, _ = capsys.readouterr()
     version_list = str(out).strip().split("\n")
@@ -201,20 +201,20 @@ def test_rename_version(caplog, init_sql_repo):
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "non_exist_version", "1.1"]):
             # This should raise an exception since version "non_exist_version" does not exist
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "1.0", "2.0"]):
             # This should raise an exception since 2.0 already exists
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version name '2.0' is already used." in caplog.text
 
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "1.0", "1.1"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert _VersionManager._get("1.0") is None
     assert [version.id for version in _VersionManager._get_all()].sort() == [dev_ver, "1.1", "2.0"].sort()
     # All entities are assigned to the new version
@@ -227,7 +227,7 @@ def test_rename_version(caplog, init_sql_repo):
     _VersionCLI.create_parser()
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--rename", "2.0", "2.1"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert _VersionManager._get("2.0") is None
     assert [version.id for version in _VersionManager._get_all()].sort() == [dev_ver, "1.1", "2.1"].sort()
     assert _VersionManager._get_production_versions() == ["2.1"]
@@ -269,23 +269,23 @@ def test_compare_version_config(caplog, init_sql_repo, init_config):
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "non_exist_version", "2.0"]):
             # This should raise an exception since version "non_exist_version" does not exist
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "1.0", "non_exist_version"]):
             # This should raise an exception since 2.0 already exists
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "Version 'non_exist_version' does not exist." in caplog.text
 
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "1.0", "1.0"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     assert "There is no difference between version 1.0 Configuration and version 1.0 Configuration." in caplog.text
 
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "manage-versions", "--compare-config", "1.0", "2.0"]):
-            _VersionCLI.parse_arguments()
+            _VersionCLI.handle_command()
     expected_message = """Differences between version 1.0 Configuration and version 2.0 Configuration:
 \tDATA_NODE "d2" has attribute "default_path" modified: foo.csv -> bar.csv"""
     assert expected_message in caplog.text

--- a/tests/templates/test_template_cli.py
+++ b/tests/templates/test_template_cli.py
@@ -21,3 +21,11 @@ def test_create_cli_with_wrong_arguments(caplog):
         with pytest.raises(SystemExit):
             _entrypoint()
         assert "Unknown arguments: --teamplaet. Did you mean: --template?" in caplog.text
+
+
+def test_create_cli_with_unsupported_template(capsys):
+    with patch("sys.argv", ["prog", "create", "--template", "not-a-template"]):
+        with pytest.raises(SystemExit):
+            _entrypoint()
+        _, err = capsys.readouterr()
+        assert "invalid choice: 'not-a-template'" in err

--- a/tests/templates/test_template_cli.py
+++ b/tests/templates/test_template_cli.py
@@ -8,3 +8,16 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from taipy._entrypoint import _entrypoint
+
+
+def test_create_cli_with_wrong_arguments(caplog):
+    with patch("sys.argv", ["prog", "create", "--teamplaet", "default"]):
+        with pytest.raises(SystemExit):
+            _entrypoint()
+        assert "Unknown arguments: --teamplaet. Did you mean: --template?" in caplog.text


### PR DESCRIPTION
Resolves https://github.com/Avaiga/taipy/issues/949

In this PR:
- Refactoring Taipy CLI. Now all _CLI classes inherits from `_AbstractCLI`.
- Except from `_GuiCLI` and `_CoreCLI`, all other CLI with specific arguments will raise an error if the argument is not supported. If their is a typo that similar enough to an argument, there will be a suggestion. Something like:
```
$ taipy migrate --repository-type filesystem --slip-backup 
usage: taipy migrate [-h] [--repository-type REPOSITORY_TYPE [REPOSITORY_TYPE ...]] [--skip-backup] [--restore] [--remove-backup]

options:
  -h, --help            show this help message and exit
  --repository-type REPOSITORY_TYPE [REPOSITORY_TYPE ...]
                        The type of repository to migrate. If filesystem or sql, a path to the database folder/.sqlite file should be
                        informed. In case of mongo host, port, user and password must be informed, if left empty it is assumed
                        default values
  --skip-backup         Skip the backup of entities before migration.
  --restore             Restore the migration of entities from backup folder.
  --remove-backup       Remove the backup of entities. Only use this option if the migration was successful.
[2024-03-27 19:46:48.675][Taipy][ERROR] Unknown arguments: --slip-backup. Did you mean: --skip-backup?
[2024-03-27 19:46:48.675][Taipy][ERROR]  Please refer to the help message above for more information.
```
Here, we also print the help message for the user to modify the command.