### PR TITLE
Feature/#453 add width to input control element

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Input.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.spec.tsx
@@ -39,6 +39,24 @@ describe("Input Component", () => {
         );
         getByDisplayValue("titi");
     });
+    it("displays with width=70%", async () => {
+        const { getByDisplayValue, getByTestId } = render(
+            <Input value="toto" type="text" defaultValue="titi" width="70%"/>
+        );
+        const parent = getByTestId('textfield-box');
+        const element = getByDisplayValue("toto");
+        expect(element).toHaveStyle('width: 100%');
+        expect(parent).toHaveStyle('width: 70%');
+    });
+    it("displays with width=500", async () => {
+        const { getByDisplayValue, getByTestId } = render(
+            <Input value="toto" type="text" defaultValue="titi" width={500}/>
+        );
+        const parent = getByTestId('textfield-box');
+        const element = getByDisplayValue("toto");
+        expect(element).toHaveStyle('width: 100%');
+        expect(parent).toHaveStyle('width: 500px');
+    });
     it("is disabled", async () => {
         const { getByDisplayValue } = render(<Input value="val" type="text" active={false} />);
         const elt = getByDisplayValue("val");

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -18,6 +18,7 @@ import Tooltip from "@mui/material/Tooltip";
 import { createSendActionNameAction, createSendUpdateAction } from "../../context/taipyReducers";
 import { TaipyInputProps } from "./utils";
 import { useClassNames, useDispatch, useDynamicProperty, useModule } from "../../utils/hooks";
+import { Box } from "@mui/material";
 
 const AUTHORIZED_KEYS = ["Enter", "Escape", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12"];
 
@@ -37,6 +38,7 @@ const Input = (props: TaipyInputProps) => {
     const {
         type,
         id,
+        width,
         updateVarName,
         propagate = true,
         defaultValue = "",
@@ -103,20 +105,23 @@ const Input = (props: TaipyInputProps) => {
 
     return (
         <Tooltip title={hover || ""}>
-            <TextField
-                margin="dense"
-                hiddenLabel
-                value={value ?? ""}
-                className={className}
-                type={type}
-                id={id}
-                label={props.label}
-                onChange={handleInput}
-                disabled={!active}
-                onKeyDown={handleAction}
-                multiline={multiline}
-                minRows={linesShown}
-            />
+            <Box width={width} data-testid="textfield-box">
+                <TextField
+                    margin="dense"
+                    hiddenLabel
+                    value={value ?? ""}
+                    className={className}
+                    type={type}
+                    id={id}
+                    label={props.label}
+                    onChange={handleInput}
+                    disabled={!active}
+                    onKeyDown={handleAction}
+                    multiline={multiline}
+                    minRows={linesShown}
+                    fullWidth
+                />
+            </Box>
         </Tooltip>
     );
 };

--- a/frontend/taipy-gui/src/components/Taipy/utils.ts
+++ b/frontend/taipy-gui/src/components/Taipy/utils.ts
@@ -47,6 +47,7 @@ export interface TaipyChangeProps {
 export interface TaipyInputProps extends TaipyActiveProps, TaipyChangeProps, TaipyLabelProps {
     type: string;
     value: string;
+    width?: string | number;
     defaultValue?: string;
     changeDelay?: number;
     onAction?: string;

--- a/frontend/taipy-gui/src/themes/stylekit.ts
+++ b/frontend/taipy-gui/src/themes/stylekit.ts
@@ -59,7 +59,6 @@ export const stylekitTheme = {
         root: {
           marginTop: 4,
           width: "100%",
-          maxWidth: "15rem",
           verticalAlign: "middle",
         },
       },

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -278,6 +278,7 @@ class _Factory:
         .set_attributes(
             [
                 ("id",),
+                ("width", PropertyType.string_or_number, "15rem"),
                 ("active", PropertyType.dynamic_boolean, True),
                 ("hover_text", PropertyType.dynamic_string),
                 ("on_change", PropertyType.function),

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -74,6 +74,13 @@
             "doc": "The value represented by this control."
           },
           {
+            "name": "width",
+            "default_property": false,
+            "type": "int|str",
+            "default_value": "15rem",
+            "doc": "The width of the control element."
+          },
+          {
             "name": "password",
             "type": "bool",
             "default_value": "False",

--- a/tests/gui/control/test_input.py
+++ b/tests/gui/control/test_input.py
@@ -23,6 +23,21 @@ def test_input_md(gui: Gui, helpers):
         'updateVarName="tpec_TpExPr_x_TPMDL_0"',
         'defaultValue="Hello World!"',
         'type="text"',
+        'width="15rem"',
+        "value={tpec_TpExPr_x_TPMDL_0}",
+    ]
+    helpers.test_control_md(gui, md_string, expected_list)
+
+def test_input_md_width(gui: Gui, helpers):
+    x = "Hello World!"  # noqa: F841
+    gui._set_frame(inspect.currentframe())
+    md_string = "<|{x}|input|width=70%|>"
+    expected_list = [
+        "<Input",
+        'updateVarName="tpec_TpExPr_x_TPMDL_0"',
+        'defaultValue="Hello World!"',
+        'type="text"',
+        'width="70%"',
         "value={tpec_TpExPr_x_TPMDL_0}",
     ]
     helpers.test_control_md(gui, md_string, expected_list)
@@ -37,6 +52,7 @@ def test_password_md(gui: Gui, helpers):
         'updateVarName="tpec_TpExPr_x_TPMDL_0"',
         'defaultValue="Hello World!"',
         'type="password"',
+        'width="15rem"',
         "value={tpec_TpExPr_x_TPMDL_0}",
     ]
     helpers.test_control_md(gui, md_string, expected_list)
@@ -51,6 +67,7 @@ def test_input_html_1(gui: Gui, helpers):
         'updateVarName="tpec_TpExPr_x_TPMDL_0"',
         'defaultValue="Hello World!"',
         'type="text"',
+        'width="15rem"',
         "value={tpec_TpExPr_x_TPMDL_0}",
     ]
     helpers.test_control_html(gui, html_string, expected_list)
@@ -59,12 +76,13 @@ def test_input_html_1(gui: Gui, helpers):
 def test_password_html(gui: Gui, helpers):
     x = "Hello World!"  # noqa: F841
     gui._set_frame(inspect.currentframe())
-    html_string = '<taipy:input value="{x}" password="True" />'
+    html_string = '<taipy:input value="{x}" password="True" width="{100}"/>'
     expected_list = [
         "<Input",
         'updateVarName="tpec_TpExPr_x_TPMDL_0"',
         'defaultValue="Hello World!"',
         'type="password"',
+        'width={100}',
         "value={tpec_TpExPr_x_TPMDL_0}",
     ]
     helpers.test_control_html(gui, html_string, expected_list)
@@ -79,6 +97,7 @@ def test_input_html_2(gui: Gui, helpers):
         'updateVarName="tpec_TpExPr_x_TPMDL_0"',
         'defaultValue="Hello World!"',
         'type="text"',
+        'width="15rem"',
         "value={tpec_TpExPr_x_TPMDL_0}",
     ]
     helpers.test_control_html(gui, html_string, expected_list)


### PR DESCRIPTION
Issue #453 
```
from taipy.gui import Gui, State

bval = True
user_prompt_1 = "Enter your name"
user_prompt_2 = "Enter your message"

md = """

<|{user_prompt_1}|input|width={500}|>
<|{user_prompt_2}|input|width=70%|>

"""

Gui(md).run()
```