### PR TITLE
fix: replace macos latest with macos-13 due to latest not supporting …

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - name: Setup LibMagic (MacOS)
-      if: inputs.os == 'macos-latest' && inputs.install-gui
+      if: inputs.os == 'macos-13' && inputs.install-gui
       run: brew install libmagic
       shell: bash
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
 
     defaults:

--- a/.github/workflows/overall-tests.yml
+++ b/.github/workflows/overall-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         pipfile-version: ['min', 'max']
     runs-on: ${{ matrix.os }}
     steps:
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         orchestrator: ['orchestrator_dispatcher', 'standalone']
         pipfile-version: ['min', 'max']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-versions: [ '3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, macos-latest] #, windows-latest]
+        os: [ubuntu-latest, macos-13] #, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/partial-tests.yml
+++ b/.github/workflows/partial-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
         run: pipenv install --dev --python=${{ matrix.python-version }}
 
       - name: Setup LibMagic (MacOS)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: brew install libmagic
 
       - uses: actions/setup-node@v4
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
         run: pipenv install --dev --python=${{ matrix.python-version }}
 
       - name: Setup LibMagic (MacOS)
-        if: matrix.os == 'macos-latest' && steps.changes.outputs.core == 'true'
+        if: matrix.os == 'macos-13' && steps.changes.outputs.core == 'true'
         run: brew install libmagic
 
       - name: Pytest Core orchestrator_dispatcher
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
         run: pipenv install --dev --python=${{ matrix.python-version }}
 
       - name: Setup LibMagic (MacOS)
-        if: matrix.os == 'macos-latest' && steps.changes.outputs.core == 'true'
+        if: matrix.os == 'macos-13' && steps.changes.outputs.core == 'true'
         run: brew install libmagic
 
       - name: Pytest Core standalone

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         python-versions: ['3.8','3.9','3.10', '3.11', '3.12']
-        os: [ubuntu-latest,windows-latest,macos-latest]
+        os: [ubuntu-latest,windows-latest,macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
`macos-latest` on GH actions now is run on the M1 architecture. Github actions on this architecture do not have Pythons 3.8 and 3.9 available, making some tests crash. Im replacing latest with the latest version that runs on the x86 architecure, `macos-13`, ultil latest support those earlier versions(if they ever do) or when we stop supporting those versions.

Macos on M1 does come with some significant performance improvements, so we would benefit of using it if available.