### PR TITLE
Fixed File Upload Notification 

### DIFF
--- a/frontend/taipy-gui/src/workers/fileupload.worker.ts
+++ b/frontend/taipy-gui/src/workers/fileupload.worker.ts
@@ -82,8 +82,8 @@ const process = (files: FileList, uploadUrl: string, varName: string, id: string
 
                 start = end;
                 end = start + BYTES_PER_CHUNK;
-                uploadedFiles.push(blob.name);
             }
+            uploadedFiles.push(blob.name);
         }
         self.postMessage({
             progress: 100,


### PR DESCRIPTION
## Related Issue 
closes #1060  
## Update 
Moved uploadedFiles.push(blob.name) outside of while loop
## Result 
Tested locally 
![notification-demo](https://github.com/Avaiga/taipy/assets/73622805/1c3c7bb4-9c54-4f6a-8c47-0d6fc03f5aba)
