### PR TITLE
bug: lov within table rebuild

### DIFF
--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -70,6 +70,7 @@ class _Builder:
         "style",
         "tooltip",
         "lov",
+        "on_edit",
     ]
 
     def __init__(
@@ -480,7 +481,7 @@ class _Builder:
     def __build_rebuild_fn(self, fn_name: str, attribute_names: t.Iterable[str]):
         rebuild = self.__attributes.get("rebuild", False)
         rebuild_hash = self.__hashes.get("rebuild")
-        if rebuild_hash or rebuild:
+        if rebuild_hash or _is_boolean_true(rebuild):
             attributes, hashes = self.__filter_attributes_hashes(self.__filter_attribute_names(attribute_names))
             rebuild_name = f"bool({self.__gui._get_real_var_name(rebuild_hash)[0]})" if rebuild_hash else "None"
             try:


### PR DESCRIPTION
resolves #1201

```
from taipy.gui import Gui, Markdown

vehicle_type_options = ["car", "motorcycle"]
vehicle_list = ['Toyota Camry', 'Honda Civic', 'Ford Mustang', 'Honda CG1600X', 'Yamaha YBR135', 'Suzuki GSX-R1000']
vehicle_type = ['car', 'car', 'car', 'motorcycle', 'motorcycle', 'motorcycle']
vehicle_dict = {'vehicle_name': vehicle_list, 'vehicle_type': vehicle_type}

md = Markdown(
"""
<|{vehicle_dict}|table|rebuild|editable|editable[vehicle_name]=False|lov[vehicle_type]={vehicle_type_options}|on_edit=edit_vehicle_type|width=fit-content|>
""")

def edit_vehicle_type(state, var_name, payload):
    state.vehicle_dict[payload["col"]][payload["index"]] = payload["value"]
    state.refresh(var_name)

Gui(md).run()

```