### PR TITLE
Remove hover_text from Indicator

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -15,3 +15,4 @@ bobbyshermi
 Forchapeatl
 yarikoptic
 Luke-0162
+Satoshi-Sh

--- a/frontend/taipy-gui/src/components/Taipy/Indicator.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Indicator.tsx
@@ -13,13 +13,12 @@
 
 import React, { useCallback, useMemo } from "react";
 import Slider from "@mui/material/Slider";
-import Tooltip from "@mui/material/Tooltip";
 import { sprintf } from "sprintf-js";
 
-import { TaipyBaseProps, TaipyHoverProps } from "./utils";
-import { useClassNames, useDynamicProperty } from "../../utils/hooks";
+import { TaipyBaseProps } from "./utils";
+import { useClassNames } from "../../utils/hooks";
 
-interface IndicatorProps extends TaipyBaseProps, TaipyHoverProps {
+interface IndicatorProps extends TaipyBaseProps {
     min?: number;
     max?: number;
     value?: number;
@@ -43,7 +42,6 @@ const Indicator = (props: IndicatorProps) => {
 
     const horizontalOrientation = props.orientation ? props.orientation.charAt(0).toLowerCase() !== "v" : true;
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
-    const hover = useDynamicProperty(props.hoverText, props.defaultHoverText, undefined);
 
     const getLabel = useCallback(() => {
         const dsp = display === undefined ? (defaultDisplay === undefined ? "" : defaultDisplay) : display;
@@ -95,7 +93,6 @@ const Indicator = (props: IndicatorProps) => {
     );
 
     return (
-        <Tooltip title={hover || ""}>
             <Slider
                 id={props.id}
                 className={className}
@@ -109,7 +106,6 @@ const Indicator = (props: IndicatorProps) => {
                 orientation={horizontalOrientation ? undefined : "vertical"}
                 sx={sliderSx}
             ></Slider>
-        </Tooltip>
     );
 };
 

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -57,7 +57,7 @@ class _Factory:
         "text": "value",
         "toggle": "value",
         "tree": "value",
-        "metric": "value"
+        "metric": "value",
     }
 
     _TEXT_ATTRIBUTES = ["format", "id", "hover_text", "raw"]
@@ -280,7 +280,6 @@ class _Factory:
                 ("value", PropertyType.dynamic_number),
                 ("format",),
                 ("orientation"),
-                ("hover_text", PropertyType.dynamic_string),
                 ("width",),
                 ("height",),
             ]

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -833,6 +833,10 @@
                         "type": "str",
                         "default_value": "None",
                         "doc": "The height, in CSS units, of the indicator (used when orientation is vertical)."
+                    },
+                    {
+                        "name": "hover_text",
+                        "doc": "TODO not implemented"
                     }
                 ]
             }

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -836,7 +836,8 @@
                     },
                     {
                         "name": "hover_text",
-                        "doc": "TODO not implemented"
+                        "doc": "TODO not implemented",
+                        "hide": true
                     }
                 ]
             }


### PR DESCRIPTION
## Related Issue 
Fixed #1147
Resolves #1147 

## Updates 
- Added `div` to the Indicator component to capture mouseOver events. 

## Screenshot 

![tooltip-demo](https://github.com/Avaiga/taipy/assets/73622805/f7efe499-2733-459a-987e-9a3a852bdbfd)

## Reference 
I referred to [this link](https://stackoverflow.com/questions/57527896/material-ui-tooltip-doesnt-display-on-custom-component-despite-spreading-props#:~:text=Your%20Tooltip%20is%20not%20working%20properly%20because%20the%20child%20of%20a%20Material%2DUI%20Tooltip%20must%20be%20able%20to%20hold%20a%20ref.)