### PR TITLE
manage multi trace selection when on selected variable is binded

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chart.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chart.tsx
@@ -238,7 +238,7 @@ const TaipyPlotlyButtons: ModeBarButtonAny[] = [
 
 const updateArrays = (sel: number[][], val: number[], idx: number) => {
     if (idx >= sel.length || val.length !== sel[idx].length || val.some((v, i) => sel[idx][i] != v)) {
-        sel = sel.concat();
+        sel = sel.concat(); // shallow copy
         sel[idx] = val;
     }
     return sel;


### PR DESCRIPTION
if there are several traces and only one bound variable for selected property, the value is an array of the different selections


resolves #1061



```
import numpy as np
import pandas as pd

from taipy.gui import Gui

mean_values = []
selected_indices = []

data = pd.DataFrame(
    {
        "Time": np.arange(0, 10, 0.1),
        "A": np.arange(0, 10, 0.1) + np.random.randn(100) + 10,
        "B": np.arange(0, 10, 0.1) + np.random.randn(100),
    }
)

layout = {
    # Force the Box select tool
    "dragmode": "select",
}


def on_change(state, var: str, val):
    if var.startswith("selected_indices"):
        if val and isinstance(val[0], list):
            means = []
            for i, sel in enumerate(val):
                arr = [data["A" if i == 0 else "B"][idx] for idx in sel]
                means.append(
                    f"Trace {i} Mean of {len(arr)} selected points:"
                    + "{:10.4f}".format(np.mean(arr) if len(sel) else 0)
                )
            state.mean_values = means
        else:
            state.mean_values = [
                f"Trace 0 ({var}): Mean of {len(val)} selected points:"
                + "{:10.4f}".format(np.mean([data["A"][idx] for idx in val]) if len(val) else 0)
            ]


page = """
## Select points to see the mean
<|selector|lov={mean_values}|not active|>

<|{data}|chart|selected={selected_indices}|x=Time|y[1]=A|y[2]=B|layout={layout}|>
"""

Gui(page).run()
```