### PR TITLE
Fix/#1359 - Inconsistently not be able to access sequences

### DIFF
--- a/taipy/core/exceptions/exceptions.py
+++ b/taipy/core/exceptions/exceptions.py
@@ -369,6 +369,10 @@ class FileCannotBeRead(Exception):
     """Raised when a file cannot be read."""
 
 
+class FileEmpty(Exception):
+    """Raised when a file is empty."""
+
+
 class ExportPathAlreadyExists(Exception):
     """Raised when the export folder already exists."""
 

--- a/tests/core/repository/test_repositories.py
+++ b/tests/core/repository/test_repositories.py
@@ -16,10 +16,28 @@ import shutil
 
 import pytest
 
+from taipy.core.exceptions.exceptions import ModelNotFound
+
 from .mocks import MockConverter, MockFSRepository, MockModel, MockObj, MockSQLRepository
 
 
 class TestRepositoriesStorage:
+    def test_load_from_non_existent_file_on_fs_repo(self):
+        r = MockFSRepository(model_type=MockModel, dir_name="mock_model", converter=MockConverter)
+
+        # The file does not exist should raise ModelNotFound exception
+        with pytest.raises(ModelNotFound):
+            r._load("non_existent_file")
+
+        # The file exists but is empty should also raise ModelNotFound exception
+        os.makedirs(r.dir_path)
+        with open(r.dir_path / "empty_file.json", "w") as f:
+            f.write("")
+
+        assert r._exists("empty_file")
+        with pytest.raises(ModelNotFound):
+            r._load("empty_file")
+
     @pytest.mark.parametrize(
         "mock_repo,params",
         [


### PR DESCRIPTION
Resolves #1359 

In `Scenario` class, we are using both `__getattr__()` and `@property`. The `__getattr__()` is called when:
- the property doesn't exist (which is not true with the "sequences" property) or
- the property method raise AttributeError

The failure happens when the following steps happen:
1. The `_get_sequences()` method is called by the "sequences" property
2. The @_self_reload mechanism try to read the scenario
3. The scenario file is created but not been written yet, so the file is empty
4. The `_FileSystemRepository._load()` method return None but did not raise an exception, so the retry_read_entity mechanism is not called.
5. The @_self_reload raise AttributeError because None object has no attribute that needs to be called when reloading the entity.
6. The `__getattr__()` is called because the "sequences" property failed to return.
7. The AttributeError is raised.

In this PR, when trying to load an entity file, if the file is empty, a new `FileEmpty` exception will be raise, which triggered the read_entity_retry to run.
This will make sure that when we read entity, the file is written properly.

