### PR TITLE
Feature Improvement: Status controls could have a way to have icons instead of the default letters #1157

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Status.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Status.spec.tsx
@@ -15,12 +15,29 @@ import React from "react";
 import {render} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
+import { CheckCircle, Error, Warning, Info } from '@mui/icons-material';
 
 import { PlusOneOutlined } from "@mui/icons-material";
 
 import Status, { StatusType } from './Status';
 
 const status: StatusType = {status: "status", message: "message"};
+
+const getStatusIcon = (status: string) => {
+  switch (status) {
+    case 'S':
+      return <CheckCircle data-testid="CheckCircleIcon" />;
+    case 'E':
+      return <Error data-testid="ErrorIcon" />;
+    case 'W':
+      return <Warning data-testid="WarningIcon" />;
+    case 'I':
+      return <Info data-testid="InfoIcon" />;
+    default:
+      return '❓';
+  }
+};
+
 
 describe("Status Component", () => {
     it("renders", async () => {
@@ -46,4 +63,31 @@ describe("Status Component", () => {
         const {getByTestId} = render(<Status value={status} icon={<PlusOneOutlined/>} onClose={jest.fn()} />);
         getByTestId("PlusOneOutlinedIcon");
     })
+});
+
+describe("StatusAvatar Icon Rendering", () => {
+    it("renders the correct icon for 'S' status", () => {
+        const { getByTestId } = render(getStatusIcon('S'));
+        getByTestId("CheckCircleIcon");
+    });
+
+    it("renders the correct icon for 'E' status", () => {
+        const { getByTestId } = render(getStatusIcon('E'));
+        getByTestId("ErrorIcon");
+    });
+
+    it("renders the correct icon for 'W' status", () => {
+        const { getByTestId } = render(getStatusIcon('W'));
+        getByTestId("WarningIcon");
+    });
+
+    it("renders the correct icon for 'I' status", () => {
+        const { getByTestId } = render(getStatusIcon('I'));
+        getByTestId("InfoIcon");
+    });
+
+    it("renders the default emoji for unknown status", () => {
+        const { getByText } = render(getStatusIcon('unknown'));
+        getByText("❓");
+    });
 });

--- a/frontend/taipy-gui/src/components/Taipy/Status.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Status.spec.tsx
@@ -19,24 +19,9 @@ import { CheckCircle, Error, Warning, Info } from '@mui/icons-material';
 
 import { PlusOneOutlined } from "@mui/icons-material";
 
-import Status, { StatusType } from './Status';
+import Status, { StatusType, getStatusIcon } from './Status';
 
 const status: StatusType = {status: "status", message: "message"};
-
-const getStatusIcon = (status: string) => {
-  switch (status) {
-    case 'S':
-      return <CheckCircle data-testid="CheckCircleIcon" />;
-    case 'E':
-      return <Error data-testid="ErrorIcon" />;
-    case 'W':
-      return <Warning data-testid="WarningIcon" />;
-    case 'I':
-      return <Info data-testid="InfoIcon" />;
-    default:
-      return '❓';
-  }
-};
 
 
 describe("Status Component", () => {

--- a/frontend/taipy-gui/src/components/Taipy/Status.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Status.spec.tsx
@@ -43,9 +43,7 @@ describe("Status Component", () => {
     it("renders", async () => {
         const {getByText} = render(<Status value={status} />);
         const elt = getByText("message");
-        const av = getByText("S");
         expect(elt.tagName).toBe("SPAN");
-        expect(av.tagName).toBe("DIV");
     })
     it("uses the class", async () => {
         const {getByText} = render(<Status value={status} className="taipy-status" />);

--- a/frontend/taipy-gui/src/components/Taipy/Status.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Status.tsx
@@ -14,6 +14,10 @@
 import React, { MouseEvent, ReactNode, useMemo } from "react";
 import Chip from "@mui/material/Chip";
 import Avatar from "@mui/material/Avatar";
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import WarningIcon from '@mui/icons-material/Warning';
+import InfoIcon from '@mui/icons-material/Info';
 
 import { getInitials } from "../../utils";
 import { TaipyBaseProps } from "./utils";
@@ -44,6 +48,22 @@ const status2Color = (status: string): "error" | "info" | "success" | "warning" 
     return "info";
 };
 
+const getStatusIcon = (status:string) => {
+  switch (status) {
+    case 'S':
+      return <CheckCircleIcon />;
+    case 'E':
+      return <ErrorIcon />;
+    case 'W':
+      return <WarningIcon />;
+    case 'I':
+      return <InfoIcon />;
+    default:
+      return '❓';
+  }
+}
+
+
 const chipSx = { alignSelf: "flex-start" };
 
 const Status = (props: StatusProps) => {
@@ -54,7 +74,7 @@ const Status = (props: StatusProps) => {
     const chipProps = useMemo(() => {
         const cp: Record<string, unknown> = {};
         cp.color = status2Color(value.status);
-        cp.avatar = <Avatar sx={{ bgcolor: `${cp.color}.main` }}>{getInitials(value.status)}</Avatar>;
+        cp.avatar = <Avatar sx={{ bgcolor: `${cp.color}.main` }}>{getStatusIcon(getInitials(value.status))}</Avatar>;
         if (props.onClose) {
             cp.onDelete = props.onClose;
         }

--- a/frontend/taipy-gui/src/components/Taipy/Status.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Status.tsx
@@ -48,7 +48,7 @@ const status2Color = (status: string): "error" | "info" | "success" | "warning" 
     return "info";
 };
 
-const getStatusIcon = (status:string) => {
+export const getStatusIcon = (status:string) => {
   switch (status) {
     case 'S':
       return <CheckCircleIcon />;


### PR DESCRIPTION
Here is the PR for Issue number #1157. The icons should be rendering correctly. Consider the icons as just placeholders now. However getting this error.

`
 FAIL  src/components/Taipy/Status.spec.tsx (363.203 s)
  Status Component
    × renders (321 ms)
    √ uses the class (27 ms)
    √ can be closed (290 ms)
    √ displays the icon (17 ms)
  StatusAvatar Icon Rendering
    √ renders the correct icon for 'S' status (7 ms)
    √ renders the correct icon for 'E' status (4 ms)
    √ renders the correct icon for 'W' status (4 ms)
    √ renders the correct icon for 'I' status (5 ms)
    √ renders the default emoji for unknown status (4 ms)

  ● Status Component › renders

    TestingLibraryElementError: Unable to find an element with the text: S. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
    Ignored nodes: comments, script, style
    <body>
      <div>
        <div
          class="MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorSuccess MuiChip-outlinedSuccess css-3a6itu-MuiChip-root"
        >
          <div
            class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiChip-avatar MuiChip-avatarMedium MuiChip-avatarColorSuccess css-b3y4oa-MuiAvatar-root"
          >
            <svg
              aria-hidden="true"
              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
              data-testid="CheckCircleIcon"
              focusable="false"
              viewBox="0 0 24 24"
            >
              <path
                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
              />
            </svg>
          </div>
          <span
            class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
          >
            message
          </span>
        </div>
      </div>
    </body>

      46 |         const {getByText} = render(<Status value={status} />);
      47 |         const elt = getByText("message");
    > 48 |         const av = getByText("S");
         |                    ^
      49 |         expect(elt.tagName).toBe("SPAN");
      50 |         expect(av.tagName).toBe("DIV");
      51 |     })

      at Object.getElementError (node_modules/@testing-library/dom/dist/config.js:37:19)
      at node_modules/@testing-library/dom/dist/query-helpers.js:76:38
      at node_modules/@testing-library/dom/dist/query-helpers.js:52:17
      at node_modules/@testing-library/dom/dist/query-helpers.js:95:19
      at src/components/Taipy/Status.spec.tsx:48:20
      at src/components/Taipy/Status.spec.tsx:8:71
      at Object.<anonymous>.__awaiter (src/components/Taipy/Status.spec.tsx:4:12)
      at Object.<anonymous> (src/components/Taipy/Status.spec.tsx:45:30)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 8 passed, 9 total
Snapshots:   0 total
Time:        365.167 s
Ran all test suites matching /Status.spec.tsx/i.`

