### PR TITLE
Fix/#1418 - DataNode not found error appearing when creating data nodes with default_data

### DIFF
--- a/taipy/core/data/csv.py
+++ b/taipy/core/data/csv.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from taipy.config.common.scope import Scope
 
+from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..job.job_id import JobId
 from ._file_datanode_mixin import _FileDataNodeMixin
@@ -116,7 +117,8 @@ class CSVDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             **properties,
         )
 
-        self._write_default_data(default_value)
+        with _Reloader():
+            self._write_default_data(default_value)
 
         self._TAIPY_PROPERTIES.update(
             {

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -18,6 +18,7 @@ from openpyxl import load_workbook
 
 from taipy.config.common.scope import Scope
 
+from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import ExposedTypeLengthMismatch, NonExistingExcelSheet, SheetNameLengthMismatch
 from ..job.job_id import JobId
@@ -118,7 +119,8 @@ class ExcelDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             **properties,
         )
 
-        self._write_default_data(default_value)
+        with _Reloader():
+            self._write_default_data(default_value)
 
         self._TAIPY_PROPERTIES.update(
             {

--- a/taipy/core/data/json.py
+++ b/taipy/core/data/json.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from taipy.config.common.scope import Scope
 
-from .._entity._reload import _self_reload
+from .._entity._reload import _Reloader, _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
 from ._file_datanode_mixin import _FileDataNodeMixin
 from .data_node import DataNode
@@ -112,7 +112,8 @@ class JSONDataNode(DataNode, _FileDataNodeMixin):
         self._decoder = self._properties.get(self._DECODER_KEY, _DefaultJSONDecoder)
         self._encoder = self._properties.get(self._ENCODER_KEY, _DefaultJSONEncoder)
 
-        self._write_default_data(default_value)
+        with _Reloader():
+            self._write_default_data(default_value)
 
         self._TAIPY_PROPERTIES.update(
             {

--- a/taipy/core/data/parquet.py
+++ b/taipy/core/data/parquet.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from taipy.config.common.scope import Scope
 
+from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import UnknownCompressionAlgorithm, UnknownParquetEngine
 from ..job.job_id import JobId
@@ -153,7 +154,8 @@ class ParquetDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             **properties,
         )
 
-        self._write_default_data(default_value)
+        with _Reloader():
+            self._write_default_data(default_value)
 
         if not self._last_edit_date and (isfile(self._path) or isdir(self._path)):
             self._last_edit_date = datetime.now()

--- a/taipy/core/data/pickle.py
+++ b/taipy/core/data/pickle.py
@@ -15,6 +15,7 @@ from typing import List, Optional, Set
 
 from taipy.config.common.scope import Scope
 
+from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
 from ._file_datanode_mixin import _FileDataNodeMixin
 from .data_node import DataNode
@@ -98,7 +99,8 @@ class PickleDataNode(DataNode, _FileDataNodeMixin):
             **properties,
         )
 
-        self._write_default_data(default_value)
+        with _Reloader():
+            self._write_default_data(default_value)
 
         self._TAIPY_PROPERTIES.update(
             {


### PR DESCRIPTION
Resolves https://github.com/Avaiga/taipy/issues/1418

This PR puts the _write_default_data() inside the _Reloader context to make sure that we don't reload the entities when it's not save to the repository yet