### PR TITLE
Fix - Update permission of manage stale issues action

### DIFF
--- a/.github/workflows/manage-stale-issue-pr.yml
+++ b/.github/workflows/manage-stale-issue-pr.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run once every day at 9 AM UTC
     - cron: 00 9 * * *
+  workflow_dispatch:
 
 jobs:
   stale-issues-and-prs:

--- a/.github/workflows/manage-stale-issue-pr.yml
+++ b/.github/workflows/manage-stale-issue-pr.yml
@@ -9,6 +9,9 @@ jobs:
   stale-issues-and-prs:
     name: Comment on possible stable issues and PRs, and close stale PRs
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:
@@ -30,6 +33,8 @@ jobs:
   unassign-issues-labeled-waiting-for-contributor-after-14-days-of-inactivity:
     name: Unassign issues labeled \"🥶Waiting for contributor\" after 14 days of inactivity.
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@v1
         with:


### PR DESCRIPTION
Fix the error where the GITHUB_TOKEN doesn't have the permission to comment on issues or PRs.