### PR TITLE
scenario deletion

### DIFF
--- a/frontend/taipy/src/ScenarioViewer.tsx
+++ b/frontend/taipy/src/ScenarioViewer.tsx
@@ -89,7 +89,7 @@ interface ScenarioViewerProps {
     className?: string;
     dynamicClassName?: string;
     onSubmissionChange?: string;
-    updateScVar?: string;
+    updateScVars?: string;
 }
 
 interface SequencesRowProps {
@@ -345,7 +345,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
         showSubmit = true,
         showSubmitSequences = true,
         showTags = true,
-        updateScVar = "",
+        updateScVars = "",
     } = props;
 
     const dispatch = useDispatch();
@@ -358,7 +358,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
         let sc: ScenarioFull | undefined = undefined;
         if (Array.isArray(props.scenario)) {
             sc = getValidScenario(props.scenario);
-        } else if (props.defaultScenario) {
+        } else if (props.scenario !== null && props.defaultScenario) {
             try {
                 sc = getValidScenario(JSON.parse(props.defaultScenario));
             } catch {
@@ -397,9 +397,9 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
     const onDeleteScenario = useCallback(() => {
         setDeleteDialogOpen(false);
         if (valid) {
-            dispatch(createSendActionNameAction(id, module, props.onDelete, true, true, { id: scId }));
+            dispatch(createSendActionNameAction(id, module, { action: props.onDelete, error_id: getUpdateVar(updateScVars, "error_id") }, undefined, undefined, true, true, { id: scId }));
         }
-    }, [valid, props.onDelete, scId, id, dispatch, module]);
+    }, [valid, props.onDelete, scId, id, dispatch, module, updateScVars]);
 
     const [primaryDialog, setPrimaryDialog] = useState(false);
     const openPrimaryDialog = useCallback(() => setPrimaryDialog(true), []);
@@ -411,11 +411,11 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                 createSendActionNameAction(id, module, props.onEdit, {
                     id: scId,
                     primary: true,
-                    error_id: getUpdateVar(updateScVar, "error_id"),
+                    error_id: getUpdateVar(updateScVars, "error_id"),
                 })
             );
         }
-    }, [valid, props.onEdit, scId, id, dispatch, module, updateScVar]);
+    }, [valid, props.onEdit, scId, id, dispatch, module, updateScVars]);
 
     // userExpanded
     const [userExpanded, setUserExpanded] = useState(valid && expanded);
@@ -433,11 +433,11 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                         id: scId,
                         sequence: label,
                         on_submission_change: props.onSubmissionChange,
-                        error_id: getUpdateVar(updateScVar, "error_id"),
+                        error_id: getUpdateVar(updateScVars, "error_id"),
                     })
                 );
         },
-        [scId, props.onSubmit, props.onSubmissionChange, id, dispatch, module, updateScVar]
+        [scId, props.onSubmit, props.onSubmissionChange, id, dispatch, module, updateScVars]
     );
 
     const submitScenario = useCallback(
@@ -448,13 +448,13 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                     createSendActionNameAction(id, module, props.onSubmit, {
                         id: scId,
                         on_submission_change: props.onSubmissionChange,
-                        error_id: getUpdateVar(updateScVar, "error_id"),
+                        error_id: getUpdateVar(updateScVars, "error_id"),
                     })
                 );
                 setSubmissionStatus(Status.SUBMITTED);
             }
         },
-        [valid, props.onSubmit, props.onSubmissionChange, id, scId, dispatch, module, updateScVar]
+        [valid, props.onSubmit, props.onSubmissionChange, id, scId, dispatch, module, updateScVars]
     );
 
     // focus
@@ -474,13 +474,13 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                     createSendActionNameAction(id, module, props.onEdit, {
                         id: scId,
                         name: label,
-                        error_id: getUpdateVar(updateScVar, "error_id"),
+                        error_id: getUpdateVar(updateScVars, "error_id"),
                     })
                 );
                 setFocusName("");
             }
         },
-        [valid, props.onEdit, scId, label, id, dispatch, module, updateScVar]
+        [valid, props.onEdit, scId, label, id, dispatch, module, updateScVars]
     );
     const cancelLabel = useCallback(
         (e?: MouseEvent<HTMLElement>) => {
@@ -518,13 +518,13 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                     createSendActionNameAction(id, module, props.onEdit, {
                         id: scId,
                         tags: tags,
-                        error_id: getUpdateVar(updateScVar, "error_id"),
+                        error_id: getUpdateVar(updateScVars, "error_id"),
                     })
                 );
                 setFocusName("");
             }
         },
-        [valid, props.onEdit, scId, tags, id, dispatch, module, updateScVar]
+        [valid, props.onEdit, scId, tags, id, dispatch, module, updateScVars]
     );
     const cancelTags = useCallback(
         (e?: MouseEvent<HTMLElement>) => {
@@ -559,7 +559,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                             name: label,
                             task_ids: taskIds,
                             del: !!del,
-                            error_id: getUpdateVar(updateScVar, "error_id"),
+                            error_id: getUpdateVar(updateScVars, "error_id"),
                         })
                     );
                 } else {
@@ -568,7 +568,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                 setFocusName("");
             }
         },
-        [valid, id, scId, props.onEdit, dispatch, module, updateScVar]
+        [valid, id, scId, props.onEdit, dispatch, module, updateScVars]
     );
     const isValidSequence = useCallback(
         (sLabel: string, label: string) => !!label && (sLabel == label || !sequences.find((seq) => seq[0] === label)),
@@ -841,7 +841,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                                 onFocus={onFocus}
                                 onEdit={props.onEdit}
                                 editable={scEditable}
-                                updatePropVars={updateScVar}
+                                updatePropVars={updateScVars}
                             />
                             {showSequences ? (
                                 <>

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -688,13 +688,14 @@ class Gui:
         elif rel_var and isinstance(current_value, _TaipyLovValue):  # pragma: no cover
             lov_holder = _getscopeattr_drill(self, self.__evaluator.get_hash_from_expr(rel_var))
             if isinstance(lov_holder, _TaipyLov):
-                val = value if isinstance(value, list) else [value]
-                elt_4_ids = self.__adapter._get_elt_per_ids(lov_holder.get_name(), lov_holder.get())
-                ret_val = [elt_4_ids.get(x, x) for x in val]
-                if isinstance(value, list):
-                    value = ret_val
-                elif ret_val:
-                    value = ret_val[0]
+                if value:
+                    val = value if isinstance(value, list) else [value]
+                    elt_4_ids = self.__adapter._get_elt_per_ids(lov_holder.get_name(), lov_holder.get())
+                    ret_val = [elt_4_ids.get(x, x) for x in val]
+                    if isinstance(value, list):
+                        value = ret_val
+                    elif ret_val:
+                        value = ret_val[0]
         elif isinstance(current_value, _TaipyBase):
             value = current_value.cast_value(value)
         self._update_var(
@@ -1033,7 +1034,7 @@ class Gui:
                     newvalue = self.__adapter.run(
                         newvalue.get_name(), newvalue.get(), id_only=isinstance(newvalue, _TaipyLovValue)
                     )
-                elif isinstance(newvalue, _TaipyToJson):
+                elif isinstance(newvalue, _TaipyBase):
                     newvalue = newvalue.get()
                 if isinstance(newvalue, (dict, _MapDict)):
                     # Skip in taipy-gui, available in custom frontend
@@ -1046,23 +1047,24 @@ class Gui:
                 if isinstance(newvalue, float) and math.isnan(newvalue):
                     # do not let NaN go through json, it is not handle well (dies silently through websocket)
                     newvalue = None
-                debug_warnings: t.List[warnings.WarningMessage] = []
-                with warnings.catch_warnings(record=True) as warns:
-                    warnings.resetwarnings()
-                    json.dumps(newvalue, cls=_TaipyJsonEncoder)
-                    if len(warns):
-                        keep_value = True
-                        for w in warns:
-                            if is_debugging():
-                                debug_warnings.append(w)
-                            if w.category is not DeprecationWarning and w.category is not PendingDeprecationWarning:
-                                keep_value = False
-                                break
-                        if not keep_value:
-                            # do not send data that is not serializable
-                            continue
-                for w in debug_warnings:
-                    warnings.warn(w.message, w.category)  # noqa: B028
+                if newvalue:
+                    debug_warnings: t.List[warnings.WarningMessage] = []
+                    with warnings.catch_warnings(record=True) as warns:
+                        warnings.resetwarnings()
+                        json.dumps(newvalue, cls=_TaipyJsonEncoder)
+                        if len(warns):
+                            keep_value = True
+                            for w in warns:
+                                if is_debugging():
+                                    debug_warnings.append(w)
+                                if w.category is not DeprecationWarning and w.category is not PendingDeprecationWarning:
+                                    keep_value = False
+                                    break
+                            if not keep_value:
+                                # do not send data that is not serializable
+                                continue
+                    for w in debug_warnings:
+                        warnings.warn(w.message, w.category)  # noqa: B028
             ws_dict[_var] = newvalue
         # TODO: What if value == newvalue?
         self.__send_ws_update_with_dict(ws_dict)

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -98,7 +98,6 @@ from .utils import (
     _TaipyData,
     _TaipyLov,
     _TaipyLovValue,
-    _TaipyToJson,
     _to_camel_case,
     _variable_decode,
     is_debugging,

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -142,7 +142,6 @@ class _GuiCoreContext(CoreEventConsumerBase):
         with self.lock:
             self.scenario_by_cycle = None
             self.data_nodes_by_owner = None
-            print(f"scenario_refresh(self, scenario_id: {scenario_id})")
         self.broadcast_core_changed({"scenario": scenario_id or True})
 
     def submission_status_callback(self, submission_id: t.Optional[str] = None, event: t.Optional[Event] = None):

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -105,7 +105,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
             with self.gui._get_autorization(system=True):
                 self.scenario_refresh(
                     event.entity_id
-                    if event.operation != EventOperation.DELETION and is_readable(t.cast(ScenarioId, event.entity_id))
+                    if event.operation == EventOperation.DELETION or is_readable(t.cast(ScenarioId, event.entity_id))
                     else None
                 )
         elif event.entity_type == EventEntityType.SEQUENCE and event.entity_id:
@@ -142,6 +142,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
         with self.lock:
             self.scenario_by_cycle = None
             self.data_nodes_by_owner = None
+            print(f"scenario_refresh(self, scenario_id: {scenario_id})")
         self.broadcast_core_changed({"scenario": scenario_id or True})
 
     def submission_status_callback(self, submission_id: t.Optional[str] = None, event: t.Optional[Event] = None):


### PR DESCRIPTION
resolves #1542

```
import datetime as dt

import taipy as tp
from taipy import Config, Frequency


# Function to run a Dataiku scenario
def run_something(input_1, input_2):
    datetime = dt.datetime.now()
    date = dt.date(2018, 1, 1)
    int_var = 10
    string_var = "String"
    return datetime, date, int_var, string_var


data = {"toto": list(range(10_000)),
        "titi": [2*i for i in range(10_000)],
        "tata": [4*i for i in range(10_000)]}



input_1_cfg = Config.configure_data_node(
    id="input_1_data_node",
    default_data=data,
)


input_2_cfg = Config.configure_data_node(
    id="input_2_data_node",
    default_data=data,
)

datetime_cfg = Config.configure_data_node(id="datetime_data_node")
date_cfg = Config.configure_data_node(id="date_data_node")
int_cfg = Config.configure_data_node(id="int_data_node")
string_cfg = Config.configure_data_node(id="string_data_node")


# Scenario and task configuration in Taipy
scenario_task_cfg = Config.configure_task(
    id="scenario_task",
    function=run_something,
    input=[input_1_cfg, input_2_cfg],
    output=[datetime_cfg, date_cfg, int_cfg, string_cfg]
)

scenario_cfg = Config.configure_scenario(
    id="scenario",
    task_configs=[scenario_task_cfg],
    frequency=Frequency.DAILY)


# GUI Markdown content
scenario_md = """
<|1 1|layout|
<|{scenario}|scenario_selector|>

<|{scenario}|scenario|>
|>
"""

# Main execution block with GUI setup
if __name__ == "__main__":
    tp.Core().run()
    scenario = tp.create_scenario(scenario_cfg)

    tp.Gui(scenario_md).run(title="1542 Bug replication")

```