### PR TITLE
Fix - Filter scenarios with creation_time should exclude the created_end_time

### DIFF
--- a/taipy/core/scenario/_scenario_manager.py
+++ b/taipy/core/scenario/_scenario_manager.py
@@ -312,11 +312,10 @@ class _ScenarioManager(_Manager[Scenario], _VersionMixin):
     ) -> List[Scenario]:
         """
         Filter a list of scenarios by a given creation time period.
-        The time period is inclusive.
 
         Parameters:
-            created_start_time (Optional[datetime]): Start time of the period.
-            created_end_time (Optional[datetime]): End time of the period.
+            created_start_time (Optional[datetime]): Start time of the period. The start time is inclusive.
+            created_end_time (Optional[datetime]): End time of the period. The end time is exclusive.
 
         Returns:
             List[Scenario]: List of scenarios created in the given time period.
@@ -325,12 +324,12 @@ class _ScenarioManager(_Manager[Scenario], _VersionMixin):
             return scenarios
 
         if not created_start_time:
-            return [scenario for scenario in scenarios if scenario.creation_date <= created_end_time]
+            return [scenario for scenario in scenarios if scenario.creation_date < created_end_time]
 
         if not created_end_time:
             return [scenario for scenario in scenarios if created_start_time <= scenario.creation_date]
 
-        return [scenario for scenario in scenarios if created_start_time <= scenario.creation_date <= created_end_time]
+        return [scenario for scenario in scenarios if created_start_time <= scenario.creation_date < created_end_time]
 
     @classmethod
     def _is_promotable_to_primary(cls, scenario: Union[Scenario, ScenarioId]) -> bool:

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -528,7 +528,7 @@ def get_scenarios(
         descending (bool): If True, sort the output list of scenarios in descending order.
             The default value is False.
         created_start_time (Optional[datetime]): The optional inclusive start date to filter scenarios by creation date.
-        created_end_time (Optional[datetime]): The optional inclusive end date to filter scenarios by creation date.
+        created_end_time (Optional[datetime]): The optional exclusive end date to filter scenarios by creation date.
         sort_key (Literal["name", "id", "creation_date", "tags"]): The optional sort_key to
             decide upon what key scenarios are sorted. The sorting is in increasing order for
             dates, in alphabetical order for name and id, and in lexicographical order for tags.
@@ -586,7 +586,7 @@ def get_primary_scenarios(
         descending (bool): If True, sort the output list of scenarios in descending order.
             The default value is False.
         created_start_time (Optional[datetime]): The optional inclusive start date to filter scenarios by creation date.
-        created_end_time (Optional[datetime]): The optional inclusive end date to filter scenarios by creation date.
+        created_end_time (Optional[datetime]): The optional exclusive end date to filter scenarios by creation date.
         sort_key (Literal["name", "id", "creation_date", "tags"]): The optional sort_key to
             decide upon what key scenarios are sorted. The sorting is in increasing order for
             dates, in alphabetical order for name and id, and in lexicographical order for tags.

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -1508,11 +1508,20 @@ def test_filter_scenarios_by_creation_datetime():
     assert len(filtered_scenarios) == 1
     assert [s_1_1] == filtered_scenarios
 
-    # The time period is inclusive
+    # The start time is inclusive
     filtered_scenarios = _ScenarioManager._filter_by_creation_time(
         scenarios=all_scenarios,
         created_start_time=datetime(2024, 1, 1),
         created_end_time=datetime(2024, 1, 3),
+    )
+    assert len(filtered_scenarios) == 1
+    assert [s_1_1] == filtered_scenarios
+
+    # The end time is exclusive
+    filtered_scenarios = _ScenarioManager._filter_by_creation_time(
+        scenarios=all_scenarios,
+        created_start_time=datetime(2024, 1, 1),
+        created_end_time=datetime(2024, 1, 4),
     )
     assert len(filtered_scenarios) == 2
     assert sorted([s_1_1.id, s_1_2.id]) == sorted([scenario.id for scenario in filtered_scenarios])

--- a/tests/core/scenario/test_scenario_manager_with_sql_repo.py
+++ b/tests/core/scenario/test_scenario_manager_with_sql_repo.py
@@ -458,11 +458,20 @@ def test_filter_scenarios_by_creation_datetime(init_sql_repo):
     assert len(filtered_scenarios) == 1
     assert [s_1_1] == filtered_scenarios
 
-    # The time period is inclusive
+    # The start time is inclusive
     filtered_scenarios = _ScenarioManager._filter_by_creation_time(
         scenarios=all_scenarios,
         created_start_time=datetime(2024, 1, 1),
         created_end_time=datetime(2024, 1, 3),
+    )
+    assert len(filtered_scenarios) == 1
+    assert [s_1_1] == filtered_scenarios
+
+    # The end time is exclusive
+    filtered_scenarios = _ScenarioManager._filter_by_creation_time(
+        scenarios=all_scenarios,
+        created_start_time=datetime(2024, 1, 1),
+        created_end_time=datetime(2024, 1, 4),
     )
     assert len(filtered_scenarios) == 2
     assert sorted([s_1_1.id, s_1_2.id]) == sorted([scenario.id for scenario in filtered_scenarios])


### PR DESCRIPTION
Change according to the discussion in https://github.com/Avaiga/taipy-doc/pull/1044