### PR TITLE
Improve core selector loading

### DIFF
--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -398,15 +398,15 @@ class _Builder:
         if isinstance(lov, list):
             if not isinstance(var_type, str):
                 elt = None
-                if len(lov) == 0:
+                if lov:
+                    elt = lov[0]
+                else:
                     value = self.__attributes.get("value")
                     if isinstance(value, list):
                         if len(value) > 0:
                             elt = value[0]
                     else:
                         elt = value
-                else:
-                    elt = lov[0]
                 var_type = self.__gui._get_unique_type_adapter(type(elt).__name__)
             if adapter is None:
                 adapter = self.__gui._get_adapter_for_type(var_type)
@@ -429,7 +429,7 @@ class _Builder:
             if adapter is not None:
                 self.__gui._add_adapter_for_type(var_type, adapter)  # type: ignore
 
-            if default_lov is not None and len(lov) > 0:
+            if default_lov is not None and lov:
                 for elt in lov:
                     ret = self.__gui._run_adapter(
                         t.cast(t.Callable, adapter), elt, adapter.__name__ if callable(adapter) else "adapter"

--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -377,7 +377,9 @@ class _Builder:
     def __set_react_attribute(self, name: str, value: t.Any):
         return self.set_attribute(name, "{!" + (str(value).lower() if isinstance(value, bool) else str(value)) + "!}")
 
-    def _get_lov_adapter(self, var_name: str, property_name: t.Optional[str] = None, multi_selection=True, with_default = True):  # noqa: C901
+    def _get_lov_adapter(  # noqa: C901
+        self, var_name: str, property_name: t.Optional[str] = None, multi_selection=True, with_default=True
+    ):
         property_name = var_name if property_name is None else property_name
         lov_name = self.__hashes.get(var_name)
         lov = self.__get_list_of_(var_name)
@@ -1032,8 +1034,16 @@ class _Builder:
                 self.__set_dynamic_date_attribute(attr[0], _get_tuple_val(attr, 2, None))
             elif var_type == PropertyType.data:
                 self.__set_dynamic_property_without_default(attr[0], var_type)
-            elif var_type == PropertyType.lov or var_type == PropertyType.single_lov or var_type == PropertyType.lov_no_default:
-                self._get_lov_adapter(attr[0], multi_selection=var_type != PropertyType.single_lov, with_default = var_type != PropertyType.lov_no_default)
+            elif (
+                var_type == PropertyType.lov
+                or var_type == PropertyType.single_lov
+                or var_type == PropertyType.lov_no_default
+            ):
+                self._get_lov_adapter(
+                    attr[0],
+                    multi_selection=var_type != PropertyType.single_lov,
+                    with_default=var_type != PropertyType.lov_no_default,
+                )
             elif var_type == PropertyType.lov_value:
                 self.__set_dynamic_property_without_default(
                     attr[0], var_type, _get_tuple_val(attr, 2, None) == "optional"

--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -377,11 +377,11 @@ class _Builder:
     def __set_react_attribute(self, name: str, value: t.Any):
         return self.set_attribute(name, "{!" + (str(value).lower() if isinstance(value, bool) else str(value)) + "!}")
 
-    def _get_lov_adapter(self, var_name: str, property_name: t.Optional[str] = None, multi_selection=True):  # noqa: C901
+    def _get_lov_adapter(self, var_name: str, property_name: t.Optional[str] = None, multi_selection=True, with_default = True):  # noqa: C901
         property_name = var_name if property_name is None else property_name
         lov_name = self.__hashes.get(var_name)
         lov = self.__get_list_of_(var_name)
-        default_lov = []
+        default_lov: t.Optional[t.List[t.Any]] = [] if with_default or not lov_name else None
 
         adapter = self.__attributes.get("adapter")
         if adapter and isinstance(adapter, str):
@@ -427,7 +427,7 @@ class _Builder:
             if adapter is not None:
                 self.__gui._add_adapter_for_type(var_type, adapter)  # type: ignore
 
-            if len(lov) > 0:
+            if default_lov is not None and len(lov) > 0:
                 for elt in lov:
                     ret = self.__gui._run_adapter(
                         t.cast(t.Callable, adapter), elt, adapter.__name__ if callable(adapter) else "adapter"
@@ -453,7 +453,8 @@ class _Builder:
                 self.__set_default_value("value", ret_val)
 
         # LoV default value
-        self.__set_json_attribute(_to_camel_case(f"default_{property_name}"), default_lov)
+        if default_lov is not None:
+            self.__set_json_attribute(_to_camel_case(f"default_{property_name}"), default_lov)
 
         # LoV expression binding
         if lov_name:
@@ -1031,8 +1032,8 @@ class _Builder:
                 self.__set_dynamic_date_attribute(attr[0], _get_tuple_val(attr, 2, None))
             elif var_type == PropertyType.data:
                 self.__set_dynamic_property_without_default(attr[0], var_type)
-            elif var_type == PropertyType.lov or var_type == PropertyType.single_lov:
-                self._get_lov_adapter(attr[0], multi_selection=var_type != PropertyType.single_lov)
+            elif var_type == PropertyType.lov or var_type == PropertyType.single_lov or var_type == PropertyType.lov_no_default:
+                self._get_lov_adapter(attr[0], multi_selection=var_type != PropertyType.single_lov, with_default = var_type != PropertyType.lov_no_default)
             elif var_type == PropertyType.lov_value:
                 self.__set_dynamic_property_without_default(
                     attr[0], var_type, _get_tuple_val(attr, 2, None) == "optional"

--- a/taipy/gui/types.py
+++ b/taipy/gui/types.py
@@ -118,6 +118,7 @@ class PropertyType(Enum):
     json = "json"
     single_lov = "singlelov"
     lov = _TaipyLov
+    lov_no_default = "lovnodefault"
     """
     The property holds a LoV (list of values).
     """

--- a/taipy/gui_core/_GuiCoreLib.py
+++ b/taipy/gui_core/_GuiCoreLib.py
@@ -87,7 +87,7 @@ class _GuiCore(ElementLibrary):
             },
             inner_properties={
                 "inner_scenarios": ElementProperty(
-                    PropertyType.lov,
+                    PropertyType.lov_no_default,
                     f"{{{__CTX_VAR_NAME}.get_scenarios(<tp:prop:{__SEL_SCENARIOS_PROP}>, "
                     + f"{__SCENARIO_SELECTOR_FILTER_VAR}<tp:uniq:sc>, "
                     + f"{__SCENARIO_SELECTOR_SORT_VAR}<tp:uniq:sc>)}}",
@@ -182,7 +182,7 @@ class _GuiCore(ElementLibrary):
             },
             inner_properties={
                 "inner_datanodes": ElementProperty(
-                    PropertyType.lov,
+                    PropertyType.lov_no_default,
                     f"{{{__CTX_VAR_NAME}.get_datanodes_tree(<tp:prop:{__DATANODE_SEL_SCENARIO_PROP}>, "
                     + f"<tp:prop:{__SEL_DATANODES_PROP}>, "
                     + f"{__DATANODE_SELECTOR_FILTER_VAR}<tp:uniq:dns>, "


### PR DESCRIPTION
resolves #1543 ?

```
import taipy as tp
from taipy import Config, Frequency

import datetime as dt


# Function to run a Dataiku scenario
def run_something(**kwargs):
    datetime = dt.datetime.now()
    date = dt.date(2018, 1, 1)
    int_var = 10
    string_var = "String"
    return kwargs


data = {"toto": [i for i in range(10_000)],
        "titi": [2*i for i in range(10_000)],
        "tata": [4*i for i in range(10_000)]}


def create_dn(id):
    return Config.configure_data_node(id=id, default_data=data)


# Scenario and task configuration in Taipy
scenario_task_cfg = Config.configure_task(
    id="scenario_task",
    function=run_something,
    input=[create_dn(f"input_datanode_{i}") for i in range(10)],
    output=[create_dn(f"output_datanode_{i}") for i in range(10)]
)

scenario_cfg = Config.configure_scenario(
    id="scenario",
    task_configs=[scenario_task_cfg],
    frequency=Frequency.MONTHLY)


scenario_1 = None
scenario_2 = None

data_node = None

# GUI Markdown content
scenario_md = """
# Compare scenarios
<|1 1|layout|
<|{scenario_1}|scenario_selector|>

<|{scenario_2}|scenario_selector|>

<|{scenario_1}|scenario|>

<|{scenario_2}|scenario|>
|>

# Data Nodes

<|1 1|layout|
<|{data_node}|data_node_selector|>

<|{data_node}|data_node|>
|>

"""

pages = {
    "/": "<|navbar|>",
         "home":"Nothing here",
         "vizelements":scenario_md}

# Main execution block with GUI setup
if __name__ == "__main__":
    tp.Core().run()
    [tp.create_scenario(scenario_cfg,
                        name=f"scenario_{i}",
                        creation_date=dt.datetime(2024, i, 7))
                    for i in range(1, 11)]

    tp.Gui(pages=pages).run(title="1543 Slow core")

```