### PR TITLE
Shutdown taipy gracefully without long traceback

### DIFF
--- a/taipy/_cli/_run_cli.py
+++ b/taipy/_cli/_run_cli.py
@@ -53,11 +53,14 @@ class _RunCLI(_AbstractCLI):
             all_args = all_args[:external_args_index]
 
         taipy_args = [f"--taipy-{arg[2:]}" if arg.startswith("--") else arg for arg in all_args]
-
-        subprocess.run(
-            [sys.executable, args.application_main_file, *(external_args + taipy_args)],
-            stdout=sys.stdout,
-            stderr=sys.stdout,
-        )
-
+        
+        try:
+            subprocess.run(
+                [sys.executable, args.application_main_file, *(external_args + taipy_args)],
+                stdout=sys.stdout,
+                stderr=sys.stdout,
+            )
+        except KeyboardInterrupt:
+            pass
+        
         sys.exit(0)

--- a/taipy/_cli/_run_cli.py
+++ b/taipy/_cli/_run_cli.py
@@ -53,7 +53,7 @@ class _RunCLI(_AbstractCLI):
             all_args = all_args[:external_args_index]
 
         taipy_args = [f"--taipy-{arg[2:]}" if arg.startswith("--") else arg for arg in all_args]
-        
+
         try:
             subprocess.run(
                 [sys.executable, args.application_main_file, *(external_args + taipy_args)],
@@ -62,5 +62,5 @@ class _RunCLI(_AbstractCLI):
             )
         except KeyboardInterrupt:
             pass
-        
+
         sys.exit(0)

--- a/taipy/gui/server.py
+++ b/taipy/gui/server.py
@@ -256,7 +256,8 @@ class _Server:
 
     def _apply_patch(self):
         if self._get_async_mode() == "gevent" and util.find_spec("gevent"):
-            from gevent import monkey, get_hub
+            from gevent import get_hub, monkey
+
             get_hub().NOT_ERROR += (KeyboardInterrupt, )
             if not monkey.is_module_patched("time"):
                 monkey.patch_time()


### PR DESCRIPTION
Fixes #1334 

On pressing ctrl + c, keyboard interrupt error is not shown now.
![image](https://github.com/user-attachments/assets/a65387a8-caad-4c06-932c-1ffcf4250ba8)
