### PR TITLE
Support None as a value for progress

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Progress.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Progress.tsx
@@ -49,7 +49,7 @@ const Progress = (props: ProgressBarProps) => {
     const { linear = false, showValue = false } = props;
 
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
-    const value = useDynamicProperty(props.value, props.defaultValue, undefined, "number");
+    const value = useDynamicProperty(props.value, props.defaultValue, undefined, "number", true);
     const render = useDynamicProperty(props.render, props.defaultRender, true);
 
     if (!render) {

--- a/frontend/taipy-gui/src/utils/hooks.ts
+++ b/frontend/taipy-gui/src/utils/hooks.ts
@@ -29,16 +29,22 @@ import { TIMEZONE_CLIENT } from "../utils";
  * @param defaultStatic - The default static value.
  * @returns The latest updated value.
  */
-export const useDynamicProperty = <T>(value: T, defaultValue: T, defaultStatic: T, checkType?: string, allowNull?: boolean): T => {
+export const useDynamicProperty = <T>(value: T, defaultValue: T, defaultStatic: T, checkType?: string, nullToDefault?: boolean): T => {
     return useMemo(() => {
-        if (value !== undefined && ((allowNull && value === null) || !checkType || typeof value === checkType)) {
+        if (nullToDefault && value === null) {
+            return defaultStatic;
+        }
+        if (value !== undefined && (!checkType || typeof value === checkType)) {
             return value;
         }
-        if (defaultValue !== undefined && ((allowNull && value === null) || !checkType || typeof defaultValue === checkType)) {
+        if (nullToDefault && defaultValue === null) {
+            return defaultStatic;
+        }
+        if (defaultValue !== undefined && (!checkType || typeof defaultValue === checkType)) {
             return defaultValue;
         }
         return defaultStatic;
-    }, [value, defaultValue, defaultStatic, checkType, allowNull]);
+    }, [value, defaultValue, defaultStatic, checkType, nullToDefault]);
 };
 
 /**

--- a/frontend/taipy-gui/src/utils/hooks.ts
+++ b/frontend/taipy-gui/src/utils/hooks.ts
@@ -29,16 +29,16 @@ import { TIMEZONE_CLIENT } from "../utils";
  * @param defaultStatic - The default static value.
  * @returns The latest updated value.
  */
-export const useDynamicProperty = <T>(value: T, defaultValue: T, defaultStatic: T, check_type?: string): T => {
+export const useDynamicProperty = <T>(value: T, defaultValue: T, defaultStatic: T, checkType?: string, allowNull?: boolean): T => {
     return useMemo(() => {
-        if (value !== undefined && (!check_type || typeof value === check_type)) {
+        if (value !== undefined && ((allowNull && value === null) || !checkType || typeof value === checkType)) {
             return value;
         }
-        if (defaultValue !== undefined && (!check_type || typeof value === check_type)) {
+        if (defaultValue !== undefined && ((allowNull && value === null) || !checkType || typeof defaultValue === checkType)) {
             return defaultValue;
         }
         return defaultStatic;
-    }, [value, defaultValue, defaultStatic, check_type]);
+    }, [value, defaultValue, defaultStatic, checkType, allowNull]);
 };
 
 /**

--- a/taipy/gui/utils/types.py
+++ b/taipy/gui/utils/types.py
@@ -86,6 +86,8 @@ class _TaipyBool(_TaipyBase):
 
 class _TaipyNumber(_TaipyBase):
     def get(self):
+        if super().get() is None:
+            return None
         try:
             return float(super().get())
         except Exception as e:


### PR DESCRIPTION
Fix a bug on default value
resolves #1627

```
import taipy.gui.builder as tgb
from taipy.gui import Gui

progress_value = 10

def set_value_to_none(state):
    state.progress_value = None

with tgb.Page() as page:
    tgb.progress(value="{progress_value}")
    tgb.button("Set value to None!", on_action=set_value_to_none)

Gui(page=page).run(title="1627 progress value to None")

```