### PR TITLE
refresh when the list of messages is emptied

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -35,7 +35,7 @@ import { TaipyActiveProps, disableColor, getSuffixedClassNames } from "./utils";
 import { useClassNames, useDispatch, useDynamicProperty, useElementVisible, useModule } from "../../utils/hooks";
 import { LoVElt, useLovListMemo } from "./lovUtils";
 import { IconAvatar, avatarSx } from "../../utils/icon";
-import { getInitials } from "../../utils";
+import { emptyArray, getInitials } from "../../utils";
 import { RowType, TableValueType } from "./tableUtils";
 
 interface ChatProps extends TaipyActiveProps {
@@ -290,20 +290,24 @@ const Chat = (props: ChatProps) => {
     useEffect(() => {
         if (!refresh && props.messages && page.current.key && props.messages[page.current.key] !== undefined) {
             const newValue = props.messages[page.current.key];
-            const nr = newValue.data as RowType[];
-            if (Array.isArray(nr) && nr.length > newValue.start && nr[newValue.start]) {
-                setRows((old) => {
-                    old.length && nr.length > old.length && setShowMessage(true);
-                    if (nr.length < old.length) {
-                        return nr.concat(old.slice(nr.length))
-                    }
-                    if (old.length > newValue.start) {
-                        return old.slice(0, newValue.start).concat(nr.slice(newValue.start));
-                    }
-                    return nr;
-                });
-                const cols = Object.keys(nr[newValue.start]);
-                setColumns(cols.length > 2 ? cols : cols.length == 2 ? [...cols, ""] : ["", ...cols, "", ""]);
+            if (newValue.rowcount == 0) {
+                setRows(emptyArray)
+            } else {
+                const nr = newValue.data as RowType[];
+                if (Array.isArray(nr) && nr.length > newValue.start && nr[newValue.start]) {
+                    setRows((old) => {
+                        old.length && nr.length > old.length && setShowMessage(true);
+                        if (nr.length < old.length) {
+                            return nr.concat(old.slice(nr.length))
+                        }
+                        if (old.length > newValue.start) {
+                            return old.slice(0, newValue.start).concat(nr.slice(newValue.start));
+                        }
+                        return nr;
+                    });
+                    const cols = Object.keys(nr[newValue.start]);
+                    setColumns(cols.length > 2 ? cols : cols.length == 2 ? [...cols, ""] : ["", ...cols, "", ""]);
+                }
             }
             page.current.key = getChatKey(0, pageSize);
         }


### PR DESCRIPTION
resolves #1618

```
from taipy.gui import Gui

users = ["user1", "user2"]
messages = [
    ("0", "message 0", "user1"), ("1", "message 1", "user2"),
    ("2", "message 2", "user1"), ("3", "message 3", "user2"),
]

input_index = 0

def add_message(state):
    global input_index
    state.messages.append((f"{len(messages)}", f"message {len(messages)}", users[input_index]))
    input_index = 1-input_index
    state.assign("messages", messages)


def clear_messages(state):
    state.messages.clear()
    state.assign("messages", messages)


page = """
<|{messages}|chat|users={users}|sender_id={users[0]}|with_input=False|>

<|Add message|button|on_action=add_message|>
<|Clear messages|button|on_action=clear_messages|>
"""

Gui(page).run(title="1618 chat empty messages")

```