### PR TITLE
take into account ReasonCollection

### DIFF
--- a/frontend/taipy/src/DataNodeTable.tsx
+++ b/frontend/taipy/src/DataNodeTable.tsx
@@ -58,14 +58,14 @@ interface DataNodeTableProps {
     onLock?: string;
     editInProgress?: boolean;
     editLock: MutableRefObject<boolean>;
-    editable: boolean;
+    notEditableReason: string;
     updateDnVars?: string;
 }
 
 const pushRightSx = { ml: "auto" };
 
 const DataNodeTable = (props: DataNodeTableProps) => {
-    const { uniqid, configId, nodeId, columns = "", onViewTypeChange, editable, updateDnVars = "" } = props;
+    const { uniqid, configId, nodeId, columns = "", onViewTypeChange, notEditableReason, updateDnVars = "" } = props;
 
     const dispatch = useDispatch();
     const module = useModule();
@@ -202,7 +202,7 @@ const DataNodeTable = (props: DataNodeTableProps) => {
                 ) : null}
                 <Grid item sx={tableEdit ? undefined : pushRightSx}>
                     <FormControlLabel
-                        disabled={!props.active || !editable || !!props.editInProgress}
+                        disabled={!props.active || !!notEditableReason || !!props.editInProgress}
                         control={<Switch color="primary" checked={tableEdit} onChange={toggleTableEdit} />}
                         label="Edit data"
                         labelPlacement="start"

--- a/frontend/taipy/src/DataNodeViewer.tsx
+++ b/frontend/taipy/src/DataNodeViewer.tsx
@@ -114,8 +114,8 @@ type DataNodeFull = [
     DatanodeData, // data
     boolean, // editInProgress
     string, // editorId
-    boolean, // readable
-    boolean // editable
+    string, // notReadableReason
+    string // notEditableReason
 ];
 
 enum DataNodeFullProps {
@@ -131,8 +131,8 @@ enum DataNodeFullProps {
     data,
     editInProgress,
     editorId,
-    readable,
-    editable,
+    notReadableReason,
+    notEditableReason,
 }
 const DataNodeFullLength = Object.keys(DataNodeFullProps).length / 2;
 
@@ -206,8 +206,8 @@ const invalidDatanode: DataNodeFull = [
     [null, null, null, null],
     false,
     "",
-    false,
-    false,
+    "invalid",
+    "invalid",
 ];
 
 enum TabValues {
@@ -253,8 +253,8 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
         dnData,
         dnEditInProgress,
         dnEditorId,
-        dnReadable,
-        dnEditable,
+        dnNotReadableReason,
+        dnNotEditableReason,
     ] = datanode;
     const dtType = dnData[DatanodeDataProps.type];
     const dtValue = dnData[DatanodeDataProps.value] ?? (dtType == "float" ? null : undefined);
@@ -454,7 +454,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
         [dnId, id, dispatch, module, props.onLock, updateDnVars]
     );
 
-    const active = useDynamicProperty(props.active, props.defaultActive, true) && dnReadable;
+    const active = useDynamicProperty(props.active, props.defaultActive, true) && !dnNotReadableReason;
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
 
     // history & data
@@ -715,7 +715,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
                                         onClick={onFocus}
                                         sx={hoverSx}
                                     >
-                                        {active && dnEditable && focusName === "label" ? (
+                                        {active && !dnNotEditableReason && focusName === "label" ? (
                                             <TextField
                                                 label="Label"
                                                 variant="outlined"
@@ -859,7 +859,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
                                     setFocusName={setFocusName}
                                     onFocus={onFocus}
                                     onEdit={props.onEdit}
-                                    editable={dnEditable}
+                                    notEditableReason={dnNotEditableReason}
                                     updatePropVars={updateDnVars}
                                 />
                             </Grid>
@@ -929,7 +929,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
                                         sx={hoverSx}
                                     >
                                         {active &&
-                                        dnEditable &&
+                                        !dnNotEditableReason &&
                                         dnEditInProgress &&
                                         dnEditorId === editorId &&
                                         focusName === dataValueFocus ? (
@@ -1088,7 +1088,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
                                                 onLock={props.onLock}
                                                 editInProgress={dnEditInProgress && dnEditorId !== editorId}
                                                 editLock={editLock}
-                                                editable={dnEditable}
+                                                notEditableReason={dnNotEditableReason}
                                                 updateDnVars={updateDnVars}
                                             />
                                         ) : (

--- a/frontend/taipy/src/PropertiesEditor.tsx
+++ b/frontend/taipy/src/PropertiesEditor.tsx
@@ -50,7 +50,7 @@ interface PropertiesEditorProps {
     setFocusName: (name: string) => void;
     isDefined: boolean;
     onEdit?: string;
-    editable: boolean;
+    notEditableReason: string;
     updatePropVars?: string;
 }
 
@@ -65,7 +65,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
         focusName,
         setFocusName,
         entProperties,
-        editable,
+        notEditableReason,
         updatePropVars = "",
     } = props;
 
@@ -195,7 +195,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                                   onClick={onFocus}
                                   sx={hoverSx}
                               >
-                                  {active && editable && focusName === propName ? (
+                                  {active && !notEditableReason && focusName === propName ? (
                                       <>
                                           <Grid item xs={4}>
                                               <TextField
@@ -284,7 +284,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                                           </Grid>
                                           <Grid item xs={5}>
                                               <Typography variant="subtitle2">{property.value}</Typography>
-                                          </Grid>{" "}
+                                          </Grid>
                                           <Grid item xs={3} />
                                       </>
                                   )}

--- a/frontend/taipy/src/ScenarioViewer.tsx
+++ b/frontend/taipy/src/ScenarioViewer.tsx
@@ -106,7 +106,7 @@ interface SequencesRowProps {
     focusName: string;
     setFocusName: (name: string) => void;
     notSubmittableReason: string;
-    editable: boolean;
+    notEditableReason: string;
     isValid: (sLabel: string, label: string) => boolean;
 }
 
@@ -119,12 +119,12 @@ const tagsAutocompleteSx = {
     maxWidth: "none",
 };
 
-type SequenceFull = [string, string[], string, boolean];
+type SequenceFull = [string, string[], string, string];
 // enum SeFProps {
 //     label,
 //     tasks,
-//     submittable,
-//     editable,
+//     notSubmittableReason,
+//     notEditablereason,
 // }
 
 const SequenceRow = ({
@@ -141,7 +141,7 @@ const SequenceRow = ({
     focusName,
     setFocusName,
     notSubmittableReason,
-    editable,
+    notEditableReason,
     isValid,
 }: SequencesRowProps) => {
     const [label, setLabel] = useState("");
@@ -202,7 +202,7 @@ const SequenceRow = ({
 
     return (
         <Grid item xs={12} container justifyContent="space-between" data-focus={name} onClick={onFocus} sx={hoverSx}>
-            {active && editable && focusName === name ? (
+            {active && !notEditableReason && focusName === name ? (
                 <>
                     <Grid item xs={4}>
                         <TextField
@@ -324,11 +324,11 @@ const invalidScenario: ScenarioFull = [
     [],
     {},
     [],
-    false,
-    false,
     "invalid",
-    false,
-    false,
+    "invalid",
+    "invalid",
+    "invalid",
+    "invalid",
 ];
 
 const ScenarioViewer = (props: ScenarioViewerProps) => {
@@ -390,11 +390,11 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
         scDeletable,
         scPromotable,
         scNotSubmittableReason,
-        scReadable,
-        scEditable,
+        scNotReadableReason,
+        scNotEditableReason,
     ] = scenario || invalidScenario;
 
-    const active = useDynamicProperty(props.active, props.defaultActive, true) && scReadable;
+    const active = useDynamicProperty(props.active, props.defaultActive, true) && !scNotReadableReason;
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
 
     const [deleteDialog, setDeleteDialogOpen] = useState(false);
@@ -595,7 +595,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
         [sequences]
     );
 
-    const addSequenceHandler = useCallback(() => setSequences((seq) => [...seq, ["", [], "", true]]), []);
+    const addSequenceHandler = useCallback(() => setSequences((seq) => [...seq, ["", [], "", ""]]), []);
 
     // on scenario change
     useEffect(() => {
@@ -714,7 +714,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                                     onClick={onFocus}
                                     sx={hoverSx}
                                 >
-                                    {active && scEditable && focusName === "label" ? (
+                                    {active && !scNotEditableReason && focusName === "label" ? (
                                         <TextField
                                             label="Label"
                                             variant="outlined"
@@ -770,7 +770,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                                         onClick={onFocus}
                                         sx={hoverSx}
                                     >
-                                        {active && scEditable && focusName === "tags" ? (
+                                        {active && !scNotEditableReason && focusName === "tags" ? (
                                             <Autocomplete
                                                 multiple
                                                 options={scAuthorizedTags}
@@ -857,7 +857,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                                 setFocusName={setFocusName}
                                 onFocus={onFocus}
                                 onEdit={props.onEdit}
-                                editable={scEditable}
+                                notEditableReason={scNotEditableReason}
                                 updatePropVars={updateScVars}
                             />
                             {showSequences ? (
@@ -874,7 +874,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                                     </Grid>
 
                                     {sequences.map((item, index) => {
-                                        const [label, taskIds, notSubmittableReason, editable] = item;
+                                        const [label, taskIds, notSubmittableReason, notEditableReason] = item;
                                         return (
                                             <SequenceRow
                                                 active={active}
@@ -891,7 +891,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                                                 focusName={focusName}
                                                 setFocusName={setFocusName}
                                                 notSubmittableReason={notSubmittableReason}
-                                                editable={editable}
+                                                notEditableReason={notEditableReason}
                                                 isValid={isValidSequence}
                                             />
                                         );

--- a/frontend/taipy/src/utils.ts
+++ b/frontend/taipy/src/utils.ts
@@ -24,14 +24,14 @@ export type ScenarioFull = [
     string,     // label
     string[],   // tags
     Array<[string, string]>,    // properties
-    Array<[string, string[], string, boolean]>,   // sequences (label, task ids, notSubmittableReason, editable)
+    Array<[string, string[], string, string]>,   // sequences (label, task ids, notSubmittableReason, notEditableReason)
     Record<string, string>, // tasks (id: label)
     string[],   // authorized_tags
-    boolean,    // deletable
-    boolean,    // promotable
+    string,    // notDeletableReason
+    string,    // notPromotableReason
     string,     // notSubmittableReason
-    boolean,    // readable
-    boolean     // editable
+    string,     // notReadableReason
+    string      // notEditableReason
 ];
 
 export enum ScFProps {

--- a/taipy/gui_core/_adapters.py
+++ b/taipy/gui_core/_adapters.py
@@ -37,6 +37,7 @@ from taipy.core import (
 from taipy.core import get as core_get
 from taipy.core.config import Config
 from taipy.core.data._tabular_datanode_mixin import _TabularDataNodeMixin
+from taipy.core.reason import ReasonCollection
 from taipy.gui._warnings import _warn
 from taipy.gui.gui import _DoNotUpdate
 from taipy.gui.utils import _is_boolean, _is_true, _TaipyBase
@@ -54,6 +55,9 @@ class _EntityType(Enum):
     SEQUENCE = 2
     DATANODE = 3
 
+
+def _get_reason(rc: ReasonCollection, message: str):
+    return "" if rc else f"{message}: {rc.reasons}"
 
 class _GuiCoreScenarioAdapter(_TaipyBase):
     __INNER_PROPS = ["name"]
@@ -84,8 +88,8 @@ class _GuiCoreScenarioAdapter(_TaipyBase):
                             (
                                 s.get_simple_label(),
                                 [t.id for t in s.tasks.values()] if hasattr(s, "tasks") else [],
-                                "" if (reason := is_submittable(s)) else f"Sequence not submittable: {reason.reasons}",
-                                is_editable(s),
+                                _get_reason(is_submittable(s), "Sequence not submittable"),
+                                _get_reason(is_editable(s), "Sequence not editable"),
                             )
                             for s in scenario.sequences.values()
                         ]
@@ -95,11 +99,11 @@ class _GuiCoreScenarioAdapter(_TaipyBase):
                         if hasattr(scenario, "tasks")
                         else {},
                         list(scenario.properties.get("authorized_tags", [])) if scenario.properties else [],
-                        is_deletable(scenario),
-                        is_promotable(scenario),
-                        "" if (reason := is_submittable(scenario)) else f"Scenario not submittable: {reason.reasons}",
-                        is_readable(scenario),
-                        is_editable(scenario),
+                        _get_reason(is_deletable(scenario), "Scenario not deletable"),
+                        _get_reason(is_promotable(scenario), "Scenario not promotable"),
+                        _get_reason(is_submittable(scenario), "Scenario not submittable"),
+                        _get_reason(is_readable(scenario), "Scenario not readable"),
+                        _get_reason(is_editable(scenario), "Scenario not editable"),
                     ]
             except Exception as e:
                 _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
@@ -221,8 +225,8 @@ class _GuiCoreDatanodeAdapter(_TaipyBase):
                         self.__get_data(datanode),
                         datanode._edit_in_progress,
                         datanode._editor_id,
-                        is_readable(datanode),
-                        is_editable(datanode),
+                        _get_reason(is_readable(datanode), "Datanode not readable"),
+                        _get_reason(is_editable(datanode), "Datanode not editable"),
                     ]
             except Exception as e:
                 _warn(f"Access to datanode ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)


### PR DESCRIPTION
handle return from  is_promotable, is_readable, is_editable ...

resolves #1608

```
import datetime as dt

import taipy as tp
from taipy import Config, Frequency

Config.configure_job_executions(mode="standalone", max_nb_of_workers=2)

# Function to run a Dataiku scenario
def run_something(input_1, input_2):
    datetime = dt.datetime.now()
    date = dt.date(2018, 1, 1)
    int_var = 10
    string_var = "String"
    return datetime, date, int_var, string_var


data = {"toto": list(range(10_000)),
        "titi": [2*i for i in range(10_000)],
        "tata": [4*i for i in range(10_000)]}



input_1_cfg = Config.configure_data_node(
    id="input_1_data_node",
    default_data=1,
)


input_2_cfg = Config.configure_data_node(
    id="input_2_data_node",
    default_data=data,
)

datetime_cfg = Config.configure_data_node(id="datetime_data_node")
date_cfg = Config.configure_data_node(id="date_data_node")
int_cfg = Config.configure_data_node(id="int_data_node")
string_cfg = Config.configure_data_node(id="string_data_node")


# Scenario and task configuration in Taipy
scenario_task_cfg = Config.configure_task(
    id="scenario_task",
    function=run_something,
    input=[input_1_cfg, input_2_cfg],
    output=[datetime_cfg, date_cfg, int_cfg, string_cfg]
)

scenario_cfg = Config.configure_scenario(
    id="scenario",
    task_configs=[scenario_task_cfg],
    frequency=Frequency.DAILY)

data_node = None
# GUI Markdown content
scenario_md = """
<|{scenario}|scenario_selector|>

<|{data_node}|data_node|>

<|{scenario}|scenario|>
"""


def on_change(state, var_name, var_value):
    if var_name == "scenario" and isinstance(var_value, tp.Scenario):
        state.data_node = state.scenario.input_1_data_node
# Main execution block with GUI setup
if __name__ == "__main__":
    tp.Core().run()
    scenario = tp.create_scenario(scenario_cfg)

    tp.Gui(scenario_md).run(title="1608 Inactive submit after datanode edit")

```