### PR TITLE
Fix/#1687 - First cli option is skipped if it's before the positional arg

### DIFF
--- a/taipy/_cli/_run_cli.py
+++ b/taipy/_cli/_run_cli.py
@@ -41,7 +41,9 @@ class _RunCLI(_AbstractCLI):
         if getattr(args, "which", None) != "run":
             return
 
-        all_args = sys.argv[3:]  # First 3 args are always (1) Python executable, (2) run, (3) Python file
+        # First 2 args are always (1) Python executable, (2) run
+        # Unknown args are passed when running the application but will be ignored
+        all_args = sys.argv[2:]
 
         external_args = []
         try:


### PR DESCRIPTION
Resolves #1687 

The problem is that when we run the `taipy run` command, we ignored the 3rd parameters, which is assumed as the file name.
But it's not always the file name, so we need to consider it now.