### PR TITLE
Fix - Reload the cache of _build_manager when needed

### DIFF
--- a/taipy/core/_version/_version_mixin.py
+++ b/taipy/core/_version/_version_mixin.py
@@ -15,8 +15,6 @@ from .._version._version_manager_factory import _VersionManagerFactory
 
 
 class _VersionMixin:
-    _version_manager = _VersionManagerFactory._build_manager()
-
     @classmethod
     def __fetch_version_number(cls, version_number):
         version_number = _VersionManagerFactory._build_manager()._replace_version_number(version_number)
@@ -35,4 +33,4 @@ class _VersionMixin:
 
     @classmethod
     def _get_latest_version(cls):
-        return cls._version_manager._get_latest_version()
+        return _VersionManagerFactory._build_manager()._get_latest_version()

--- a/taipy/core/config/core_section.py
+++ b/taipy/core/config/core_section.py
@@ -17,6 +17,14 @@ from taipy.config import Config, UniqueSection
 from taipy.config._config import _Config
 from taipy.config.common._config_blocker import _ConfigBlocker
 from taipy.config.common._template_handler import _TemplateHandler as _tpl
+from taipy.core._version._version_manager_factory import _VersionManagerFactory
+from taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
+from taipy.core.data._data_manager_factory import _DataManagerFactory
+from taipy.core.job._job_manager_factory import _JobManagerFactory
+from taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
+from taipy.core.sequence._sequence_manager_factory import _SequenceManagerFactory
+from taipy.core.submission._submission_manager_factory import _SubmissionManagerFactory
+from taipy.core.task._task_manager_factory import _TaskManagerFactory
 
 from .._init_version import _read_version
 from ..exceptions.exceptions import ConfigCoreVersionMismatched
@@ -159,6 +167,7 @@ class CoreSection(UniqueSection):
     @_ConfigBlocker._check()
     def repository_type(self, val):
         self._repository_type = val
+        CoreSection.__reload_repositories()
 
     @property
     def repository_properties(self):
@@ -389,4 +398,19 @@ class CoreSection(UniqueSection):
             **properties,
         )
         Config._register(section)
+
+        if repository_type:
+            CoreSection.__reload_repositories()
+
         return Config.unique_sections[CoreSection.name]
+
+    @staticmethod
+    def __reload_repositories():
+        _CycleManagerFactory._build_manager.cache_clear()
+        _SequenceManagerFactory._build_manager.cache_clear()
+        _ScenarioManagerFactory._build_manager.cache_clear()
+        _TaskManagerFactory._build_manager.cache_clear()
+        _JobManagerFactory._build_manager.cache_clear()
+        _DataManagerFactory._build_manager.cache_clear()
+        _SubmissionManagerFactory._build_manager.cache_clear()
+        _VersionManagerFactory._build_manager.cache_clear()

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -171,9 +171,9 @@ class DataNode(_Entity, _Labeled):
         self._editor_expiration_date: Optional[datetime] = editor_expiration_date
 
         # Track edits
-        self._edits = edits or []
+        self._edits: List[Edit] = edits or []
 
-        self._properties = _Properties(self, **kwargs)
+        self._properties: _Properties = _Properties(self, **kwargs)
 
     @staticmethod
     def _new_id(config_id: str) -> DataNodeId:


### PR DESCRIPTION
In this PR:
- Reload the cache of all `_build_manager()` method
- Fix an issue where we build the _VersionManager at class level, which build the cache from importing