### PR TITLE
limit d-flex children width

### DIFF
--- a/frontend/taipy-gui/public/stylekit/utilities/misc.css
+++ b/frontend/taipy-gui/public/stylekit/utilities/misc.css
@@ -30,6 +30,8 @@
 
 .d-flex > .taipy-part:not(.MuiDrawer-docked) {
     width: -webkit-fill-available;
+    width: -moz-available;
+    /* width: fill-available; */
 }
 
 .d-block {

--- a/frontend/taipy-gui/public/stylekit/utilities/misc.css
+++ b/frontend/taipy-gui/public/stylekit/utilities/misc.css
@@ -25,6 +25,11 @@
 
 .d-flex {
     display: flex !important;
+
+}
+
+.d-flex > .taipy-part:not(.MuiDrawer-docked) {
+    width: -webkit-fill-available;
 }
 
 .d-block {


### PR DESCRIPTION
resolves #1683

```
with tgb.Page() as page:
    with tgb.part(class_name="container d-flex"):
        with tgb.part():
            tgb.text("Sales Insights", class_name="h1 text-center")
...
        with tgb.pane(
            open="{show_city_info_pane}",
            width="300px",
            persistent=True,
            anchor="right",
        ):
            tgb.part(partial="{city_info_partial}")

```