### PR TITLE
chart selection when figure

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chart.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chart.tsx
@@ -656,10 +656,16 @@ const Chart = (props: ChartProp) => {
                     tr[pt.curveNumber].push(getRealIndex(getPlotIndex(pt)));
                     return tr;
                 }, [] as number[][]);
+                if (config.traces.length === 0) { // figure
+                    const theVar = getUpdateVar(updateVars, "selected");
+                    theVar && dispatch(createSendUpdateAction(theVar, traces, module, props.onChange, propagate));
+                    return;
+                }
                 if (traces.length) {
                     const upvars = traces.map((_, idx) => getUpdateVar(updateVars, `selected${idx}`));
-                    if (traces.length > 1 && new Set(upvars).size === 1) {
-                        dispatch(createSendUpdateAction(upvars[0], traces, module, props.onChange, propagate));
+                    const setVars = new Set(upvars.filter((v) => v));
+                    if (traces.length > 1 && setVars.size === 1) {
+                        dispatch(createSendUpdateAction(setVars.values().next().value, traces, module, props.onChange, propagate));
                         return;
                     }
                     traces.forEach((tr, idx) => {

--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -79,7 +79,7 @@ class _Builder:
         element_name: str,
         attributes: t.Optional[t.Dict[str, t.Any]],
         hash_names: t.Optional[t.Dict[str, str]] = None,
-        default_value="<Empty>",
+        default_value: t.Optional[t.Any] = "<Empty>",
         lib_name: str = "taipy",
     ):
         from ..gui import Gui
@@ -599,7 +599,7 @@ class _Builder:
         config = _build_chart_config(self.__gui, self.__attributes, col_types)
 
         self.__set_json_attribute("defaultConfig", config)
-        self._set_chart_selected(max=len(config.get("traces", "")))
+        self._set_chart_selected(max=len(config.get("traces", [])))
         self.__set_refresh_on_update()
         return self
 
@@ -641,6 +641,16 @@ class _Builder:
         default_sel = self.__attributes.get(name)
         if not isinstance(default_sel, list) and name in self.__attributes:
             default_sel = []
+        if max == 0:
+            self.__update_vars.extend(
+                self.__set_list_attribute(
+                    name,
+                    self.__hashes.get(name),
+                    default_sel,
+                    int,
+                )
+            )
+            return
         idx = 1
         name_idx = f"{name}[{idx}]"
         sel = self.__attributes.get(name_idx)

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -278,7 +278,7 @@ class _Factory:
                 ("max", PropertyType.number),
                 ("value", PropertyType.dynamic_number),
                 ("format",),
-                ("orientation"),
+                ("orientation",),
                 ("width",),
                 ("height",),
             ]

--- a/taipy/gui/utils/chart_config_builder.py
+++ b/taipy/gui/utils/chart_config_builder.py
@@ -113,11 +113,11 @@ def __get_col_from_indexed(col_name: str, idx: int) -> t.Optional[str]:
 
 
 def _build_chart_config(gui: "Gui", attributes: t.Dict[str, t.Any], col_types: t.Dict[str, str]):  # noqa: C901
+    if "data" not in attributes and "figure" in attributes:
+        return {"traces": []}
     default_type = attributes.get("_default_type", "scatter")
     default_mode = attributes.get("_default_mode", "lines+markers")
     trace = __get_multiple_indexed_attributes(attributes, _CHART_NAMES)
-    if len([t for t in trace if t]) == 0:
-        return {"traces": []}
     if not trace[_Chart_iprops.mode.value]:
         trace[_Chart_iprops.mode.value] = default_mode
     # type

--- a/taipy/gui/utils/chart_config_builder.py
+++ b/taipy/gui/utils/chart_config_builder.py
@@ -116,6 +116,8 @@ def _build_chart_config(gui: "Gui", attributes: t.Dict[str, t.Any], col_types: t
     default_type = attributes.get("_default_type", "scatter")
     default_mode = attributes.get("_default_mode", "lines+markers")
     trace = __get_multiple_indexed_attributes(attributes, _CHART_NAMES)
+    if len([t for t in trace if t]) == 0:
+        return {"traces": []}
     if not trace[_Chart_iprops.mode.value]:
         trace[_Chart_iprops.mode.value] = default_mode
     # type


### PR DESCRIPTION
resolves #1786

```
import plotly.express as px

from taipy.gui import Gui
from taipy.gui import builder as tgb

df = px.data.carshare()
df["peak_hour"] = df["peak_hour"].astype(str)  # toggle off to get int column
fig = px.scatter_map(
    df,
    lat="centroid_lat",
    lon="centroid_lon",
    color="peak_hour",
    size="car_hours",
    color_continuous_scale=px.colors.cyclical.IceFire,
    size_max=15,
    zoom=10,
)
selected_indices = []


def on_init(state):
    state.selected_indices = []


def on_plot_clicked(state, var, val):
    print(f"On plot clicked : {var}")
    if var == "selected_indices":
        print(f"point selected = {val}")


with tgb.Page() as page:
    tgb.chart(
        figure="{fig}",
        on_change=on_plot_clicked,
        selected="{selected_indices}",
    )
    tgb.text("Point Selected = {selected_indices}")
Gui(
    page,
).run(title="1786 chart figure selection")

```