### PR TITLE
Fix - load_workbook with read_only option when do reading

### DIFF
--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -175,7 +175,7 @@ class ExcelDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
     def _read_as(self, path: str):
         try:
             properties = self.properties
-            excel_file = load_workbook(path)
+            excel_file = load_workbook(path, read_only=True)
             exposed_type = properties[self._EXPOSED_TYPE_PROPERTY]
             work_books = {}
             sheet_names = excel_file.sheetnames


### PR DESCRIPTION
This PR fixes the failing test on taipy-integration-testing.
The test results can be found in https://github.com/Avaiga/taipy-integration-testing/pull/67.

The reason is that the `openpyxl.load_workbook()` can only be closed when the loaded file is read/write only.
On MacOS and Linux, it's fine. However, on Windows, the file is not cleaned automatically, which makes the next test to fail.