### PR TITLE
builder support lambda in callable typed properties

### DIFF
--- a/taipy/gui/builder/_api_generator.py
+++ b/taipy/gui/builder/_api_generator.py
@@ -19,7 +19,7 @@ import typing as t
 from taipy.logger._taipy_logger import _TaipyLogger
 
 from ..utils.singleton import _Singleton
-from ..utils.viselements import VisElements, resolve_inherits
+from ..utils.viselements import VisElementProperties, VisElements, resolve_inherits
 from ._element import _Block, _Control
 
 if t.TYPE_CHECKING:
@@ -31,11 +31,15 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
         self.__module: t.Optional[types.ModuleType] = None
 
     @staticmethod
-    def find_default_property(property_list: t.List[t.Dict[str, t.Any]]) -> str:
+    def find_default_property(property_list: t.List[VisElementProperties]) -> str:
         for property in property_list:
-            if "default_property" in property and property["default_property"] is True:
+            if property.get("default_property", False) is True:
                 return property["name"]
         return ""
+
+    @staticmethod
+    def get_properties_dict(property_list: t.List[VisElementProperties]) -> t.Dict[str, t.Any]:
+        return {prop["name"]: prop.get("type", "str") for prop in property_list}
 
     def add_default(self):
         current_frame = inspect.currentframe()
@@ -56,14 +60,24 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
                 setattr(
                     module,
                     blockElement[0],
-                    _ElementApiGenerator.create_block_api(blockElement[0], blockElement[0], default_property),
+                    _ElementApiGenerator.create_block_api(
+                        blockElement[0],
+                        blockElement[0],
+                        default_property,
+                        _ElementApiGenerator.get_properties_dict(blockElement[1]["properties"]),
+                    ),
                 )
             for controlElement in viselements["controls"]:
                 default_property = _ElementApiGenerator.find_default_property(controlElement[1]["properties"])
                 setattr(
                     module,
                     controlElement[0],
-                    _ElementApiGenerator.create_control_api(controlElement[0], controlElement[0], default_property),
+                    _ElementApiGenerator.create_control_api(
+                        controlElement[0],
+                        controlElement[0],
+                        default_property,
+                        _ElementApiGenerator.get_properties_dict(controlElement[1]["properties"]),
+                    ),
                 )
 
     def add_library(self, library: "ElementLibrary"):
@@ -82,7 +96,10 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
                 library_module,
                 element_name,
                 _ElementApiGenerator().create_control_api(
-                    element_name, f"{library_name}.{element_name}", element.default_attribute
+                    element_name,
+                    f"{library_name}.{element_name}",
+                    element.default_attribute,
+                    {name: str(prop.property_type) for name, prop in element.attributes.items()},
                 ),
             )
             # Allow element to be accessed from the root module
@@ -98,29 +115,29 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
         classname: str,
         element_name: str,
         default_property: str,
+        properties: t.Dict[str, str],
     ):
-        return _ElementApiGenerator.create_element_api(classname, element_name, default_property, _Block)
+        return _ElementApiGenerator.create_element_api(classname, element_name, default_property, properties, _Block)
 
     @staticmethod
     def create_control_api(
         classname: str,
         element_name: str,
         default_property: str,
+        properties: t.Dict[str, str],
     ):
-        return _ElementApiGenerator.create_element_api(classname, element_name, default_property, _Control)
+        return _ElementApiGenerator.create_element_api(classname, element_name, default_property, properties, _Control)
 
     @staticmethod
     def create_element_api(
         classname: str,
         element_name: str,
         default_property: str,
+        properties: t.Dict[str, str],
         ElementBaseClass: t.Union[t.Type[_Block], t.Type[_Control]],
     ):
         return type(
             classname,
             (ElementBaseClass,),
-            {
-                "_ELEMENT_NAME": element_name,
-                "_DEFAULT_PROPERTY": default_property,
-            },
+            {"_ELEMENT_NAME": element_name, "_DEFAULT_PROPERTY": default_property, "_TYPES": properties},
         )

--- a/taipy/gui/utils/viselements.py
+++ b/taipy/gui/utils/viselements.py
@@ -13,16 +13,16 @@ import typing as t
 from copy import deepcopy
 
 
-class VisElementProperties(t.TypedDict, total=False):
+class VisElementProperties(t.TypedDict):
     name: str
     type: str
     doc: str
-    default_value: t.Any
+    default_value: t.NotRequired[t.Any]
     default_property: t.Any
 
 
-class VisElementDetail(t.TypedDict, total=False):
-    inherits: t.List[str]
+class VisElementDetail(t.TypedDict):
+    inherits: t.NotRequired[t.List[str]]
     properties: t.List[VisElementProperties]
 
 

--- a/taipy/gui/utils/viselements.py
+++ b/taipy/gui/utils/viselements.py
@@ -17,12 +17,12 @@ class VisElementProperties(t.TypedDict):
     name: str
     type: str
     doc: str
-    default_value: t.NotRequired[t.Any]
+    default_value: t.Any
     default_property: t.Any
 
 
 class VisElementDetail(t.TypedDict):
-    inherits: t.NotRequired[t.List[str]]
+    inherits: t.List[str]
     properties: t.List[VisElementProperties]
 
 

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -783,7 +783,7 @@
                     },
                     {
                         "name": "style",
-                        "type": "str",
+                        "type": "Union[str, Callable]",
                         "doc": "Allows the styling of table lines.<br/>See <a href=\"#dynamic-styling\">below</a> for details."
                     },
                     {
@@ -851,7 +851,7 @@
                     },
                     {
                         "name": "on_edit",
-                        "type": "Callable",
+                        "type": "Union[Callable, bool]",
                         "doc": "TODO: Default implementation and False value. The name of a function that is triggered when a cell edition is validated.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>\nThis dictionary has the following keys:\n<ul>\n<li>index (int): the row index.</li>\n<li>col (str): the column name.</li>\n<li>value (Any): the new cell value cast to the type of the column.</li>\n<li>user_value (str): the new cell value, as it was provided by the user.</li>\n<li>tz (str): the timezone if the column type is date.</li>\n</ul>\n</li>\n</ul><br/>If this property is not set, the user cannot edit cells.",
                         "signature": [
                             [
@@ -870,7 +870,7 @@
                     },
                     {
                         "name": "on_delete",
-                        "type": "Callable",
+                        "type": "Union[Callable, bool]",
                         "doc": "TODO: Default implementation and False value. The name of a function that is triggered when a row is deleted.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>\nThis dictionary has the following keys:\n<ul>\n<li>index (int): the row index.</li>\n</ul>\n</li>\n</ul><br/>If this property is not set, the user cannot delete rows.",
                         "signature": [
                             [
@@ -889,7 +889,7 @@
                     },
                     {
                         "name": "on_add",
-                        "type": "Callable",
+                        "type": "Union[Callable, bool]",
                         "doc": "TODO: Default implementation and False value. The name of a function that is triggered when the user requests a row to be added.<br/>All parameters of that function are optional:\n<ul>\n<li>state (<code>State^</code>): the state instance.</li>\n<li>var_name (str): the name of the tabular data variable.</li>\n<li>payload (dict): the details on this callback's invocation.<br/>This dictionary has the following keys:\n<ul>\n<li>index (int): the row index.</li>\n</ul>\n</li>\n</ul><br/>If this property is not set, the user cannot add rows.",
                         "signature": [
                             [


### PR DESCRIPTION
resolves #1816 

fix lambda in builder on property that takes a callable but don't start with on_
```
import taipy.gui.builder as tgb
from taipy.gui import Gui

x_range = range(-10, 11, 4)
data = {"x": x_range, "y": [x * x for x in x_range]}

with tgb.Page(
    style={
        ".blue-row>td": {"color": "white", "background-color": "blue"},
        ".red-row>td": {"color": "yellow", "background-color": "red"},
    }
) as page:
    tgb.table("{data}", style=lambda s, row: 'blue-row' if row % 2 else 'red-row', show_all=True)

Gui(page=page).run(stylekit=False)

```