### PR TITLE
Fix/#680 - S3ObjectDtaNode.read should return the binary form of the data

### DIFF
--- a/taipy/core/data/aws_s3.py
+++ b/taipy/core/data/aws_s3.py
@@ -152,7 +152,7 @@ class S3ObjectDataNode(DataNode):
             Bucket=properties[self.__AWS_STORAGE_BUCKET_NAME],
             Key=properties[self.__AWS_S3_OBJECT_KEY],
         )
-        return aws_s3_object["Body"].read().decode("utf-8")
+        return aws_s3_object["Body"].read()
 
     def _write(self, data: Any):
         properties = self.properties


### PR DESCRIPTION
Resolves #680

The `S3ObjectDtaNode.read()` method now returns the binary form of the data.

The developer will need to handle the decoding of the file them self.