### PR TITLE
Warn user on style property name change

### DIFF
--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -571,6 +571,8 @@ class _Builder:
             self.set_boolean_attribute("compare", True)
             self.__set_string_attribute("on_compare")
 
+        if self.__attributes.get("style"):
+            _warn("Table: property 'style' has been renamed to 'row_class_name'.")
         if row_class_name := self.__attributes.get("row_class_name"):
             if isfunction(row_class_name):
                 value = self.__hashes.get("row_class_name")

--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as etree
 from datetime import date, datetime, time
 from enum import Enum
 from inspect import isclass, isfunction
+from types import NoneType
 from urllib.parse import quote
 
 from .._warnings import _warn
@@ -571,7 +572,7 @@ class _Builder:
             self.set_boolean_attribute("compare", True)
             self.__set_string_attribute("on_compare")
 
-        if self.__attributes.get("style"):
+        if not isinstance(self.__attributes.get("style"), (NoneType, dict, _MapDict)):
             _warn("Table: property 'style' has been renamed to 'row_class_name'.")
         if row_class_name := self.__attributes.get("row_class_name"):
             if isfunction(row_class_name):

--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -18,7 +18,6 @@ import xml.etree.ElementTree as etree
 from datetime import date, datetime, time
 from enum import Enum
 from inspect import isclass, isfunction
-from types import NoneType
 from urllib.parse import quote
 
 from .._warnings import _warn
@@ -572,7 +571,7 @@ class _Builder:
             self.set_boolean_attribute("compare", True)
             self.__set_string_attribute("on_compare")
 
-        if not isinstance(self.__attributes.get("style"), (NoneType, dict, _MapDict)):
+        if not isinstance(self.__attributes.get("style"), (type(None), dict, _MapDict)):
             _warn("Table: property 'style' has been renamed to 'row_class_name'.")
         if row_class_name := self.__attributes.get("row_class_name"):
             if isfunction(row_class_name):

--- a/taipy/gui/utils/table_col_builder.py
+++ b/taipy/gui/utils/table_col_builder.py
@@ -82,6 +82,8 @@ def _enhance_columns(  # noqa: C901
                 col_desc["apply"] = value
         else:
             _warn(f"{elt_name}: '{k}' is not a displayed column in apply[].")
+    if _get_name_indexed_property(attributes, "style"):
+        _warn("Table: property 'style[]' has been renamed to 'cell_class_name[]'.")
     cell_class_names = _get_name_indexed_property(attributes, "cell_class_name")
     for k, v in cell_class_names.items():  # pragma: no cover
         if col_desc := _get_column_desc(columns, k):


### PR DESCRIPTION
resolves #1832

```
from taipy.gui import Gui, Markdown

x_range = range(-10, 11, 4)

data = {"x": x_range, "y": [x * x for x in x_range]}


def even_odd_class(_, row):
    if row % 2:
        # Odd rows are blue
        return "blue-row"
    else:
        # Even rows are red
        return "red-row"


# Lambda version, getting rid of even_odd_class():
# Replace the table control definition with
#    <|{data}|table|row_class_name={lambda _, row: 'blue-row' if row % 2 else 'red-row'}|show_all|>
page = Markdown(
    "<|{data}|table|row_class_name=even_odd_class|show_all|style=toto|style[a]=tata|>",
    style={
        ".blue-row>td": {"color": "white", "background-color": "blue"},
        ".red-row>td": {"color": "yellow", "background-color": "red"},
    },
)


if __name__ == "__main__":
    Gui(page).run(title="Table - Styling rows")
```
results in: 

```
--- 2 warning(s) were found for page '/'  ---
 - Warning 1: Table: property 'style[]' has been renamed to 'cell_class_name[]'.
 - Warning 2: Table: property 'style' has been renamed to 'row_class_name'.
----------------------------------------------
```