### PR TITLE
lambda in exported page

### DIFF
--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -159,20 +159,17 @@ class _Builder:
             hash_name = hash_names.get(k)
             if hash_name is None:
                 if isinstance(v, str):
-                    looks_like_a_lambda = v.startswith("{lambda ") and v.endswith("}")
                     # need to unescape the double quotes that were escaped during preprocessing
                     (val, hash_name) = _Builder.__parse_attribute_value(gui, v.replace('\\"', '"'))
                 else:
-                    looks_like_a_lambda = False
                     val = v
-                if isroutine(val):
+                if isroutine(val) and not hash_name:
                     # if it's not a callable (and not a string), forget it
                     if val.__name__ == "<lambda>":
                         # if it is a lambda and it has already a hash_name, we're fine
-                        if looks_like_a_lambda or not hash_name:
-                            hash_name = _get_lambda_id(t.cast(LambdaType, val))
-                            gui._bind_var_val(hash_name, val)  # type: ignore[arg-type]
-                    elif not hash_name:
+                        hash_name = _get_lambda_id(t.cast(LambdaType, val))
+                        gui._bind_var_val(hash_name, val)  # type: ignore[arg-type]
+                    else:
                         hash_name = _get_expr_var_name(val.__name__)
 
                 if val is not None or hash_name:

--- a/tests/gui/lambdas/__init__.py
+++ b/tests/gui/lambdas/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.

--- a/tests/gui/lambdas/another_module.py
+++ b/tests/gui/lambdas/another_module.py
@@ -1,0 +1,1 @@
+exported_page ="<|Hello|button|on_action={lambda s,i,p: None}|>"

--- a/tests/gui/lambdas/test_lambda.py
+++ b/tests/gui/lambdas/test_lambda.py
@@ -1,0 +1,24 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+from taipy.gui import Gui
+
+from .another_module import exported_page
+
+
+def test_lambda_1(gui: Gui, test_client, helpers):
+    md_string = "<|Hello|button|on_action={lambda s,i,p: None}|>"
+    expected_list = ['onAction="__lambda_', "_TPMDL_1"]
+    helpers.test_control_md(gui, md_string, expected_list)
+
+def test_lambda_2(gui: Gui, test_client, helpers):
+    expected_list = ['onAction="__lambda_', "_TPMDL_1"]
+    gui.add_page("test", exported_page)
+    helpers._test_control(gui, expected_list)


### PR DESCRIPTION
resolves #1920

```py
from demo_1920_lambda_in_imported_page import page_1
from taipy.gui import Gui

values = {"Historical": [1, 4, 6], "Forecast": [2, 3, 6]}

if __name__ == "__main__":
    Gui(page=page_1).run(title="1920 Lambda functions not working when page is imported")
```

```py title="demo_1920_lambda_in_imported_page.py"
from taipy.gui import Markdown


def get_forecast_css(s, v, i, r):
  return 'red_row' if r['Historical']!=r['Forecast'] else 'blue_row'

def on_push(state, id, pl):
  print(f"on_push(state, {id}, {pl})")

page_1 = Markdown(
    "<|{values}|table|width=fit-content"
    "|cell_class_name[Historical]={lambda s,v,i,r: 'blue_row' if r['Historical']!=r['Forecast'] else 'red_row'}"
    "|cell_class_name[Forecast]=get_forecast_css|"
    "class_name=ml-auto mr-auto|>"
    "<|Push me|button|on_action=on_push|>",
    style={
        ".blue_row": {"color": "white", "background-color": "blue"},
        ".red_row": {"color": "yellow", "background-color": "red"},
    },
)

```