### PR TITLE
Fix - Strip unnecessary path separator from migration backup path

### DIFF
--- a/taipy/core/_entity/_migrate/_migrate_fs.py
+++ b/taipy/core/_entity/_migrate/_migrate_fs.py
@@ -98,7 +98,7 @@ def _migrate_fs_entities(path: str, backup: bool = True) -> bool:
         return False
 
     if backup:
-        backup_path = f"{path}_backup"
+        backup_path = path.rstrip("\\/") + "_backup"
         try:
             shutil.copytree(path, backup_path)
         except FileExistsError:


### PR DESCRIPTION
There is an unexpected bug when we create the backup folder, there is unnecessary path separator. That would cause the backup path to be `.taipy/_backup` instead of `.taipy_backup`.

This sometimes causes the actual migration data to be written on the backup path instead of actual path on Windows.