### PR TITLE
display unsupported data in datanode with error message

### DIFF
--- a/frontend/taipy/src/ScenarioSelector.tsx
+++ b/frontend/taipy/src/ScenarioSelector.tsx
@@ -28,6 +28,7 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Dialog from "@mui/material/Dialog";
 import Select from "@mui/material/Select";
+import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { Close, DeleteOutline, Add, EditOutlined } from "@mui/icons-material";
@@ -107,7 +108,7 @@ const emptyScenario: ScenarioDict = {
     properties: [],
 };
 
-const ActionContentSx = { mr: 2, ml: 2 };
+const ActionContentSx = { mr: 2, ml: 2, width: "100%" };
 
 const DialogContentSx = {
     maxHeight: "calc(100vh - 256px)",
@@ -124,10 +125,6 @@ const SquareButtonSx = {
     p: 0,
     minWidth: 0,
     aspectRatio: "1",
-};
-
-const CancelBtnSx = {
-    mr: 2,
 };
 
 const IconButtonSx = {
@@ -370,36 +367,28 @@ const ScenarioEditDialog = ({ scenario, submit, open, actionEdit, configs, close
                     </DialogContent>
 
                     <DialogActions>
-                        <Grid container justifyContent="space-between" sx={ActionContentSx}>
+                        <Stack direction="row" justifyContent="space-between" sx={ActionContentSx}>
                             {actionEdit && (
-                                <Grid size={6}>
-                                    <Button
-                                        variant="outlined"
-                                        color="error"
-                                        onClick={onConfirmDialogOpen}
-                                        disabled={!scenario || !scenario[ScFProps.deletable]}
-                                    >
-                                        Delete
-                                    </Button>
-                                </Grid>
+                                <Button
+                                    variant="outlined"
+                                    color="error"
+                                    onClick={onConfirmDialogOpen}
+                                    disabled={!scenario || !scenario[ScFProps.deletable]}
+                                >
+                                    Delete
+                                </Button>
                             )}
-                            <Grid container size={actionEdit ? 6 : 12} justifyContent="flex-end">
-                                <Grid sx={CancelBtnSx}>
-                                    <Button variant="outlined" color="inherit" onClick={close}>
-                                        Cancel
-                                    </Button>
-                                </Grid>
-                                <Grid>
-                                    <Button
-                                        variant="contained"
-                                        type="submit"
-                                        disabled={!form.values.config || !form.values.name}
-                                    >
-                                        {actionEdit ? "Apply" : "Create"}
-                                    </Button>
-                                </Grid>
-                            </Grid>
-                        </Grid>
+                            <Button variant="outlined" color="inherit" onClick={close}>
+                                Cancel
+                            </Button>
+                            <Button
+                                variant="contained"
+                                type="submit"
+                                disabled={!form.values.config || !form.values.name}
+                            >
+                                {actionEdit ? "Apply" : "Create"}
+                            </Button>
+                        </Stack>
                     </DialogActions>
                 </form>
             </Dialog>
@@ -489,18 +478,18 @@ const ScenarioSelector = (props: ScenarioSelectorProps) => {
     const openEditDialog = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
             e.stopPropagation();
-            const { id: scenId } = e.currentTarget?.dataset || {};
+            const { id: scId } = e.currentTarget?.dataset || {};
             const varName = getUpdateVar(updateScVars, "sc_id");
-            scenId &&
+            scId &&
                 props.onScenarioSelect &&
-                dispatch(createSendActionNameAction(props.id, module, props.onScenarioSelect, varName, scenId));
+                dispatch(createSendActionNameAction(props.id, module, props.onScenarioSelect, varName, scId));
             setOpen(true);
             setActionEdit(true);
         },
         [props.onScenarioSelect, props.id, dispatch, module, updateScVars]
     );
 
-    const EditScenario = useCallback(
+    const editScenario = useCallback(
         (props: EditProps) => (
             <Tooltip title={props.active ? "Edit Scenario" : "Can't edit Scenario"}>
                 <span>
@@ -508,7 +497,7 @@ const ScenarioSelector = (props: ScenarioSelectorProps) => {
                         data-id={props.id}
                         onClick={openEditDialog}
                         sx={tinyEditIconButtonSx}
-                        disabled={props.active}
+                        disabled={!props.active}
                     >
                         <EditOutlined />
                     </IconButton>
@@ -526,7 +515,7 @@ const ScenarioSelector = (props: ScenarioSelectorProps) => {
                     entities={props.innerScenarios}
                     leafType={NodeType.SCENARIO}
                     lovPropertyName="innerScenarios"
-                    editComponent={EditScenario}
+                    editComponent={editScenario}
                     showPins={showPins}
                     multiple={multiple}
                     updateCoreVars={updateScVars}

--- a/taipy/gui_core/_adapters.py
+++ b/taipy/gui_core/_adapters.py
@@ -206,11 +206,17 @@ class _GuiCoreDatanodeAdapter(_TaipyBase):
                 )
                 if isinstance(value, float) and math.isnan(value):
                     value = None
+                error = None
+                if val_type not in ("date", "int", "float", "string"):
+                    try:
+                        json.dumps(value)
+                    except Exception as e:
+                        error = f"Unsupported data: {e}."
                 return (
                     value,
                     val_type,
                     None,
-                    None,
+                    error,
                 )
             except Exception as e:
                 return (None, None, None, f"read data_node: {e}")


### PR DESCRIPTION
resolves #1916

scenario_selector edit button is disabled
resolves #1948

```py
import taipy as tp
from taipy import Config

integer_cfg = Config.configure_data_node("integer", default_data=1)

model_cfg = Config.configure_data_node("model", default_data=Config)

scenario_cfg = Config.configure_scenario(
    id="my_scenario",
    additional_data_node_configs=[integer_cfg, model_cfg],
)

data_node = None

style = {"color": "green"}

if __name__ == "__main__":
    # Run of the Core
    tp.Orchestrator().run()

    # Creation of the scenario and execution
    scenario = tp.create_scenario(scenario_cfg, name="Submitted")

    scenario_md = """
<|try this >|button|>

<|scenario_selector|>

<|{data_node}|data_node_selector|style={style}|>

<|{data_node}|data_node|>
"""

    tp.Gui(scenario_md).run(title="1916 Datanodes with unsupported types are not selected")

```