### PR TITLE
Relax pyarrow dependency range to resolve conflict with databricks-sq…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
             "python-magic-bin>=0.4.14,<0.5;platform_system=='Windows'",
         ],
         "rdp": ["rdp>=0.8"],
-        "arrow": ["pyarrow>=17.0.0,<18.0"],
+        "arrow": ["pyarrow>=14.0.1,<18.0"],
         "mssql": ["pyodbc>=4"],
     },
     cmdclass={"build_py": NPMInstall},


### PR DESCRIPTION
### Detailed Description of the Changes for Issue [#1986](https://github.com/Avaiga/taipy/issues/1986)



#### Issue Summary

The issue titled "[Too much restriction on pyarrow dependency](https://github.com/Avaiga/taipy/issues/1986)" states a breaking change in dependencies from version 3.1.1 to 4.0 due to a restriction on `pyarrow`. This conflict prevents the installation of packages like `databricks-sql-connector==3.4.0`.



#### Changes Made

- **File Modified**: `setup.py` (branch: `develop`)

- **Dependency Updated**: The version range for `pyarrow` has been modified to accommodate both `Taipy` and `databricks-sql-connector` dependencies.

 - **Original Line**:

  ```python

  "arrow": ["pyarrow>=17.0.0,<18.0"],

  ```

 - **Updated Line**:

  ```python

  "arrow": ["pyarrow>=14.0.1,<18.0"],

  ```



#### Testing

- The changes were tested by attempting to install `Taipy` alongside `databricks-sql-connector==3.4.0` to ensure there are no dependency conflicts:

 ```sh

 pip install git+https://github.com/your-username/taipy.git databricks-sql-connector==3.4.0

 ```



#### Reference

This pull request addresses issue [#1986](https://github.com/Avaiga/taipy/issues/1986).