### PR TITLE
Fix Md mode styling

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Field.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Field.tsx
@@ -14,6 +14,7 @@
 import React, { lazy, useMemo } from "react";
 import Typography from "@mui/material/Typography";
 import Tooltip from "@mui/material/Tooltip";
+import { Components } from "react-markdown";
 
 import { formatWSValue } from "../../utils";
 import { useClassNames, useDynamicProperty, useFormatConfig } from "../../utils/hooks";
@@ -39,6 +40,29 @@ const Field = (props: TaipyFieldProps) => {
     const formatConfig = useFormatConfig();
 
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
+    const markdownComponent: Components = {
+        h1(props) {
+            return <h1 className={`${className} ${getComponentClassName(props.children)}`} {...props} />
+        },
+        h2(props) {
+            return <h2 className={`${className} ${getComponentClassName(props.children)}`} {...props} />
+        },
+        h3(props) {
+            return <h3 className={`${className} ${getComponentClassName(props.children)}`} {...props} />
+        },
+        h4(props) {
+            return <h4 className={`${className} ${getComponentClassName(props.children)}`} {...props} />
+        },
+        h5(props) {
+            return <h5 className={`${className} ${getComponentClassName(props.children)}`}  {...props} />
+        },
+        h6(props) {
+            return <h6 className={`${className} ${getComponentClassName(props.children)}`} {...props} />
+        },
+        p(props) {
+            return <span className={`${className} ${getComponentClassName(props.children)}`} {...props}/>
+        }
+    }
     const hover = useDynamicProperty(props.hoverText, props.defaultHoverText, undefined);
 
     const mode = typeof props.mode === "string" ? props.mode.toLowerCase() : undefined;
@@ -72,7 +96,7 @@ const Field = (props: TaipyFieldProps) => {
                         {value}
                     </pre>
                 ) : mode == "markdown" || mode == "md" ? (
-                    <Markdown className={`${className} ${getComponentClassName(props.children)}`}>{value}</Markdown>
+                    <Markdown components={markdownComponent}>{value}</Markdown>
                 ) : raw || mode == "raw" ? (
                     <span className={className} id={id} style={style}>
                         {value}


### PR DESCRIPTION
## Related Issue
#1553

## Problem 
Md mode uses the react-markdown library to render markup language. 
It creates a different structure like
```
<div className=className>
    <p>value</p>
</div>
```
 This is why some styling doesn't work in non-md<div><span className></span></div> mode. It creates
```
<div>
  <span className=className>
  value
 </span>
</div>
``` 


## Solution
The library has mapping attribute. [source Appendix B: Components](https://github.com/remarkjs/react-markdown?tab=readme-ov-file#appendix-b-components:~:text=again%20contains%20markdown!-,Appendix%20B%3A%20Components,-You%20can%20also)
 
I used it to make the same structure for md-mode. 

##   Screenshot
![Screenshot from 2024-10-09 09-00-37](https://github.com/user-attachments/assets/c80418d0-37f7-440b-aa72-ea7ba6c7580a)

