### PR TITLE
Handle multiple consecutive chart refresh

### DIFF
--- a/frontend/taipy-gui/base/src/wsAdapter.ts
+++ b/frontend/taipy-gui/base/src/wsAdapter.ts
@@ -34,7 +34,7 @@ export class TaipyWsAdapter extends WsAdapter {
                 for (const muPayload of message.payload as [MultipleUpdatePayload]) {
                     const encodedName = muPayload.name;
                     const { value } = muPayload.payload;
-                    if (value && typeof (value as any).__taipy_refresh === "boolean") {
+                    if (value && (value as any).__taipy_refresh !== undefined) {
                         // refresh all requested data for this encodedName var
                         const requestDataOptions = taipyApp.variableData?._requested_data[encodedName];
                         for (const dataKey in requestDataOptions) {

--- a/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
@@ -225,7 +225,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
     const hover = useDynamicProperty(props.hoverText, props.defaultHoverText, undefined);
     const baseColumns = useDynamicJsonProperty(props.columns, props.defaultColumns, defaultColumns);
 
-    const refresh = props.data && typeof props.data.__taipy_refresh === "boolean";
+    const refresh = props.data?.__taipy_refresh !== undefined;
 
     useEffect(() => {
         if (!refresh && props.data && page.current.key && props.data[page.current.key] !== undefined) {

--- a/frontend/taipy-gui/src/components/Taipy/Chart.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chart.tsx
@@ -11,7 +11,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import React, { CSSProperties, useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
+import React, { CSSProperties, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useTheme } from "@mui/material";
+import Box from "@mui/material/Box";
+import Skeleton from "@mui/material/Skeleton";
+import Tooltip from "@mui/material/Tooltip";
+import { nanoid } from "nanoid";
 import {
     Config,
     Data,
@@ -23,18 +29,15 @@ import {
     PlotSelectionEvent,
     ScatterLine,
 } from "plotly.js";
-import Skeleton from "@mui/material/Skeleton";
-import Box from "@mui/material/Box";
-import Tooltip from "@mui/material/Tooltip";
-import { useTheme } from "@mui/material";
+import { Figure } from "react-plotly.js";
 
-import { getArrayValue, getUpdateVar, TaipyActiveProps, TaipyChangeProps } from "./utils";
 import {
     createRequestChartUpdateAction,
     createSendActionNameAction,
     createSendUpdateAction,
 } from "../../context/taipyReducers";
-import { ColumnDesc } from "./tableUtils";
+import { lightenPayload } from "../../context/wsUtils";
+import { darkThemeTemplate } from "../../themes/darkThemeTemplate";
 import {
     useClassNames,
     useDispatch,
@@ -43,11 +46,9 @@ import {
     useDynamicProperty,
     useModule,
 } from "../../utils/hooks";
-import { darkThemeTemplate } from "../../themes/darkThemeTemplate";
-import { Figure } from "react-plotly.js";
-import { lightenPayload } from "../../context/wsUtils";
+import { ColumnDesc } from "./tableUtils";
 import { getComponentClassName } from "./TaipyStyle";
-import { nanoid } from "nanoid";
+import { getArrayValue, getUpdateVar, TaipyActiveProps, TaipyChangeProps } from "./utils";
 
 const Plot = lazy(() => import("react-plotly.js"));
 

--- a/frontend/taipy-gui/src/components/Taipy/Chart.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chart.tsx
@@ -47,6 +47,7 @@ import { darkThemeTemplate } from "../../themes/darkThemeTemplate";
 import { Figure } from "react-plotly.js";
 import { lightenPayload } from "../../context/wsUtils";
 import { getComponentClassName } from "./TaipyStyle";
+import { nanoid } from "nanoid";
 
 const Plot = lazy(() => import("react-plotly.js"));
 
@@ -298,7 +299,7 @@ const Chart = (props: ChartProp) => {
     const theme = useTheme();
     const module = useModule();
 
-    const refresh = typeof data?.__taipy_refresh === "number" ? data.__taipy_refresh : 0;
+    const refresh = useMemo(() => data?.__taipy_refresh !== undefined ? nanoid() : false, [data]);
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
     const active = useDynamicProperty(props.active, props.defaultActive, true);
     const render = useDynamicProperty(props.render, props.defaultRender, true);
@@ -348,10 +349,8 @@ const Chart = (props: ChartProp) => {
         if (updateVarName && (refresh || !data[dataKey])) {
             const backCols = Object.values(config.columns).map((col) => col.dfid);
             const dtKey = backCols.join("-") + (config.decimators ? `--${config.decimators.join("")}` : "");
-            console.log("dataKey", dtKey, "useEffect");
             setDataKey(dtKey);
             if (refresh || !data[dtKey]) {
-                console.log("Requesting new data", refresh, dtKey, data[dtKey]);
                 dispatch(
                     createRequestChartUpdateAction(
                         updateVarName,
@@ -443,7 +442,6 @@ const Chart = (props: ChartProp) => {
     const skelStyle = useMemo(() => ({ ...style, minHeight: "7em" }), [style]);
 
     const dataPl = useMemo(() => {
-        console.log("receive data", data, dataKey, lastDataPl.current);
         if (props.figure) {
             return lastDataPl.current;
         }
@@ -570,7 +568,6 @@ const Chart = (props: ChartProp) => {
                     (config.decimators ? `--${config.decimators.join("")}` : "") +
                     "--" +
                     eventDataKey;
-                console.log("dataKey", dtKey, "onRelayout");
                 setDataKey(dtKey);
                 dispatch(
                     createRequestChartUpdateAction(

--- a/frontend/taipy-gui/src/components/Taipy/Chart.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chart.tsx
@@ -298,7 +298,7 @@ const Chart = (props: ChartProp) => {
     const theme = useTheme();
     const module = useModule();
 
-    const refresh = typeof data.__taipy_refresh === "boolean";
+    const refresh = typeof data?.__taipy_refresh === "number" ? data.__taipy_refresh : 0;
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
     const active = useDynamicProperty(props.active, props.defaultActive, true);
     const render = useDynamicProperty(props.render, props.defaultRender, true);
@@ -348,8 +348,10 @@ const Chart = (props: ChartProp) => {
         if (updateVarName && (refresh || !data[dataKey])) {
             const backCols = Object.values(config.columns).map((col) => col.dfid);
             const dtKey = backCols.join("-") + (config.decimators ? `--${config.decimators.join("")}` : "");
+            console.log("dataKey", dtKey, "useEffect");
             setDataKey(dtKey);
             if (refresh || !data[dtKey]) {
+                console.log("Requesting new data", refresh, dtKey, data[dtKey]);
                 dispatch(
                     createRequestChartUpdateAction(
                         updateVarName,
@@ -441,10 +443,11 @@ const Chart = (props: ChartProp) => {
     const skelStyle = useMemo(() => ({ ...style, minHeight: "7em" }), [style]);
 
     const dataPl = useMemo(() => {
+        console.log("receive data", data, dataKey, lastDataPl.current);
         if (props.figure) {
             return lastDataPl.current;
         }
-        if (typeof data === "number" && lastDataPl.current) {
+        if (data.__taipy_refresh !== undefined && lastDataPl.current) {
             return lastDataPl.current;
         }
         const datum = data[dataKey];
@@ -567,6 +570,7 @@ const Chart = (props: ChartProp) => {
                     (config.decimators ? `--${config.decimators.join("")}` : "") +
                     "--" +
                     eventDataKey;
+                console.log("dataKey", dtKey, "onRelayout");
                 setDataKey(dtKey);
                 dispatch(
                     createRequestChartUpdateAction(

--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -346,8 +346,7 @@ const Chat = (props: ChatProps) => {
         setShowMessage(false);
     }, []);
 
-    // const refresh = typeof props.messages === "number";
-    const refresh = props.messages && typeof props.messages.__taipy_refresh === "boolean";
+    const refresh = props.messages?.__taipy_refresh !== undefined;
 
     useEffect(() => {
         if (!refresh && props.messages && page.current.key && props.messages[page.current.key] !== undefined) {

--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
@@ -129,7 +129,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
     const formatConfig = useFormatConfig();
     const module = useModule();
 
-    const refresh = props.data && typeof props.data.__taipy_refresh === "boolean";
+    const refresh = props.data?.__taipy_refresh !== undefined;
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
     const active = useDynamicProperty(props.active, props.defaultActive, true);
     const editable = useDynamicProperty(props.editable, props.defaultEditable, false);

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1042,8 +1042,6 @@ class Gui:
                         setattr(self._bindings(), var_name, newvalue)
         return ("", 200)
 
-    _data_request_counter = 1
-
     def __send_var_list_update(  # noqa C901
         self,
         modified_vars: t.List[str],
@@ -1064,8 +1062,7 @@ class Gui:
             resource_handler = get_current_resource_handler()
             custom_page_filtered_types = resource_handler.data_layer_supported_types if resource_handler else ()
             if isinstance(newvalue, (_TaipyData)) or isinstance(newvalue, custom_page_filtered_types):
-                Gui._data_request_counter = (Gui._data_request_counter % 0xFFFFFFF0) + 1
-                newvalue = {"__taipy_refresh": Gui._data_request_counter}
+                newvalue = {"__taipy_refresh": True}
             else:
                 if isinstance(newvalue, (_TaipyContent, _TaipyContentImage)):
                     ret_value = self.__get_content_accessor().get_info(

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1042,6 +1042,8 @@ class Gui:
                         setattr(self._bindings(), var_name, newvalue)
         return ("", 200)
 
+    _data_request_counter = 1
+
     def __send_var_list_update(  # noqa C901
         self,
         modified_vars: t.List[str],
@@ -1062,7 +1064,8 @@ class Gui:
             resource_handler = get_current_resource_handler()
             custom_page_filtered_types = resource_handler.data_layer_supported_types if resource_handler else ()
             if isinstance(newvalue, (_TaipyData)) or isinstance(newvalue, custom_page_filtered_types):
-                newvalue = {"__taipy_refresh": True}
+                Gui._data_request_counter = (Gui._data_request_counter % 0xFFFFFFF0) + 1
+                newvalue = {"__taipy_refresh": Gui._data_request_counter}
             else:
                 if isinstance(newvalue, (_TaipyContent, _TaipyContentImage)):
                     ret_value = self.__get_content_accessor().get_info(


### PR DESCRIPTION
resolves #1992

```py
from math import cos, exp

from taipy.gui import Gui

value = 10


def compute_data(decay: int) -> list:
    return [cos(i / 6) * exp(-i * decay / 600) for i in range(100)]


if __name__ == "__main__":
    page = """
<|{value}|slider|>

<|{compute_data(value)}|chart|>
"""

    Gui(page).run(title="[🐛 BUG] 1992 Blank chart after too much changes")

```