### PR TITLE
fix cli collision between host and client_url (#2026)

### DIFF
--- a/taipy/gui/_gui_cli.py
+++ b/taipy/gui/_gui_cli.py
@@ -37,7 +37,7 @@ class _GuiCLI(_AbstractCLI):
             "const": "",
             "help": "Specify server host",
         },
-        ("--client-url", "-H"): {
+        ("--client-url",): {
             "dest": "taipy_client_url",
             "metavar": "CLIENT_URL",
             "nargs": "?",


### PR DESCRIPTION
Resolve https://github.com/Avaiga/taipy-enterprise/issues/498