### PR TITLE
Better column width management

### DIFF
--- a/frontend/taipy-gui/.eslintrc.js
+++ b/frontend/taipy-gui/.eslintrc.js
@@ -11,36 +11,33 @@
  * specific language governing permissions and limitations under the License.
  */
 
-module.exports =  {
-    parser:  '@typescript-eslint/parser',  // Specifies the ESLint parser
-    extends:  [
-      'plugin:react/recommended',  // Uses the recommended rules from @eslint-plugin-react
-      'plugin:@typescript-eslint/recommended',  // Uses the recommended rules from @typescript-eslint/eslint-plugin
+module.exports = {
+    parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+    extends: [
+        "plugin:react/recommended", // Uses the recommended rules from @eslint-plugin-react
+        "plugin:@typescript-eslint/recommended", // Uses the recommended rules from @typescript-eslint/eslint-plugin
+//        "plugin:react/jsx-runtime", //using the new JSX transform from React 17
     ],
-    plugins: [
-      "@typescript-eslint",
-      "react-hooks",
-      "eslint-plugin-tsdoc"
-    ],
-    parserOptions:  {
-      ecmaVersion:  2018,  // Allows for the parsing of modern ECMAScript features
-      sourceType:  'module',  // Allows for the use of imports
-      ecmaFeatures:  {
-        jsx:  true,  // Allows for the parsing of JSX
-      },
+    plugins: ["@typescript-eslint", "react-hooks", "eslint-plugin-tsdoc"],
+    parserOptions: {
+        ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+        sourceType: "module", // Allows for the use of imports
+        ecmaFeatures: {
+            jsx: true, // Allows for the parsing of JSX
+        },
     },
-    rules:  {
-      // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-      "@typescript-eslint/explicit-function-return-type": "off",
-      "@typescript-eslint/explicit-module-boundary-types": "off",
-      "@typescript-eslint/no-unused-expressions": "off", // allows a && b()
-      "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
-      "react-hooks/exhaustive-deps": "error", // Checks effect dependencies
-      "tsdoc/syntax": "off", // "warn" to check tsdoc syntax
+    rules: {
+        // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/no-unused-expressions": "off", // allows a && b()
+        "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
+        "react-hooks/exhaustive-deps": "error", // Checks effect dependencies
+        "tsdoc/syntax": "off", // "warn" to check tsdoc syntax
     },
-    settings:  {
-      react:  {
-        version:  'detect',  // Tells eslint-plugin-react to automatically detect the version of React to use
-      },
+    settings: {
+        react: {
+            version: "detect", // Tells eslint-plugin-react to automatically detect the version of React to use
+        },
     },
-  };
+};

--- a/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
@@ -604,7 +604,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
                                         <TableCell
                                             key={`head${columns[col].dfid}`}
                                             sortDirection={orderBy === columns[col].dfid && order}
-                                            sx={columns[col].width ? { width: columns[col].width } : {}}
+                                            sx={columns[col].width ? { width: columns[col].width } : undefined}
                                         >
                                             {columns[col].dfid === EDIT_COL ? (
                                                 [


### PR DESCRIPTION
resolves #2082

must manage the editable mode as well

```py
import taipy.gui.builder as tgb
from taipy.gui import Gui

data = {
    "a_long_title": [1],
    "b_long_title": [2],
    "c_long_title": [3],
    "d_long_title": [4],
    "e_long_title": [5],
    "f_long_title": [6],
    "g_long_title": [7],
    "h_long_title": [8],
    "i_long_title": [9],
    "j_long_title": [10],
    "k_long_title": [11],
    "l_long_title": [12],
    "m_long_title": [13],
    "n_long_title": [14],
    "o_long_title": [15],
    "p_long_title": [16],
    "q_long_title": [17],
    "r_long_title": [18],
    "s_long_title": [19],
    "t_long_title": [20],
    "u_long_title": [21],
    "v_long_title": [22],
    "w_long_title": [23],
}
editable = False

with tgb.Page() as page:
    tgb.toggle("{editable}", label="Editable")
    tgb.table("{data}", editable="{editable}")

Gui(page).run(title="2082 [🐛 BUG] Column headers of Taipy table are truncated")

```