### PR TITLE
datanode properties load and refresh

### DIFF
--- a/frontend/taipy/src/DataNodeViewer.tsx
+++ b/frontend/taipy/src/DataNodeViewer.tsx
@@ -413,7 +413,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
             setPropertiesRequested((req) => {
                 if ((req || !showData) && tabValue == TabValues.Properties) {
                     const idVar = getUpdateVar(updateDnVars, "properties_id");
-                    const vars = getUpdateVarNames(updateVars, "properties");
+                    const vars = getUpdateVarNames(updateVars, "dnProperties");
                     Promise.resolve().then(() =>
                         dispatch(
                             createRequestUpdateAction(id, module, vars, true, idVar ? { [idVar]: newDnId } : undefined)
@@ -631,7 +631,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
     );
 
     // file action
-    const onfileHandler = useCallback(
+    const onFileHandler = useCallback(
         (e: MouseEvent<HTMLElement>) => {
             e.stopPropagation();
             const { action = "import" } = e.currentTarget.dataset || {};
@@ -733,7 +733,7 @@ const DataNodeViewer = (props: DataNodeViewerProps) => {
                                                 <span>
                                                     <Button
                                                         data-action="export"
-                                                        onClick={onfileHandler}
+                                                        onClick={onFileHandler}
                                                         sx={buttonSx}
                                                         disabled={!!dnNotDownloadableReason}
                                                     >

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -1123,13 +1123,11 @@ class _GuiCoreContext(CoreEventConsumerBase):
         self.__lazy_start()
         if id and is_readable(t.cast(DataNodeId, id)) and (dn := core_get(id)) and isinstance(dn, DataNode):
             try:
-                return (
-                    (
+                return [
                         (k, f"{v}")
                         for k, v in dn._get_user_properties().items()
                         if k != _GuiCoreContext.__PROP_ENTITY_NAME
-                    ),
-                )
+                    ]
             except Exception:
                 return None
         return None

--- a/tests/gui_core/test_context_dn_properties.py
+++ b/tests/gui_core/test_context_dn_properties.py
@@ -1,0 +1,53 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import typing as t
+from unittest.mock import Mock, patch
+
+from taipy.common.config.common.scope import Scope
+from taipy.core.data.pickle import PickleDataNode
+from taipy.gui_core._context import _GuiCoreContext
+
+a_datanode = PickleDataNode("data_node_config_id", Scope.SCENARIO)
+
+
+def mock_core_get(entity_id):
+    if entity_id == a_datanode.id:
+        return a_datanode
+    return None
+
+def mock_is_readable_false(entity_id):
+    return False
+
+
+def mock_is_true(entity_id):
+    return True
+
+
+class MockState:
+    def __init__(self, **kwargs) -> None:
+        self.assign = kwargs.get("assign")
+
+
+class TestGuiCoreContext_data_node_properties:
+    def test_get_data_node_properties(self):
+        with (
+            patch("taipy.gui_core._context.core_get", side_effect=mock_core_get),
+            patch("taipy.gui_core._context.is_readable", side_effect=mock_is_true),
+        ):
+            gui_core_context = _GuiCoreContext(Mock())
+            assert gui_core_context.get_data_node_properties("") is None
+            assert gui_core_context.get_data_node_properties("not a datanode") is None
+            with patch("taipy.gui_core._context.is_readable", side_effect=mock_is_readable_false):
+                assert gui_core_context.get_data_node_properties(a_datanode.id) is None
+            assert gui_core_context.get_data_node_properties(a_datanode.id) is not None
+            assert isinstance(gui_core_context.get_data_node_properties(a_datanode.id), list)
+            assert len(t.cast(list, gui_core_context.get_data_node_properties(a_datanode.id))) == 0


### PR DESCRIPTION
resolves #2088

```py
import taipy as tp
import taipy.gui.builder as tgb
from taipy import Config, Orchestrator, Scope
from taipy.gui import Gui

bug_node = Config.configure_data_node(
    id="bug_node",
    default_data="bug",
    scope=Scope.GLOBAL,
)

with tgb.Page() as data_node_viewer:
    tgb.text("## Discovering Data Node viewers", mode="md")

    tgb.data_node(
        data_node="{bug_data_node}",
    )
bug_gui = Gui(page=data_node_viewer)

if __name__ == "__main__":
    orchestrator = Orchestrator()
    orchestrator.run()
    bug_data_node = tp.create_global_data_node(bug_node)
    bug_gui.run(title="2088 [🐛 BUG] Cannot add properties to Data Node with Data Node viewer")

```