### PR TITLE
[DOCS] - Standardize/Consistent Terminology in Function and Method Docstrings

### DIFF
--- a/taipy/core/notification/event.py
+++ b/taipy/core/notification/event.py
@@ -132,7 +132,7 @@ def _make_event(
     """Helper function to make an event for this entity with the given `EventOperation^` type.
     In case of `EventOperation.UPDATE^` events, an attribute name and value must be given.
 
-    Parameters:
+    Arguments:
         entity (Any): The entity object to generate an event for.
         operation (EventOperation^): The operation of the event. The possible values are:
             <ul>


### PR DESCRIPTION
### Issue Description
Function and method parameters are documented using either `Parameters`, `Arguments`, or `Args` keywords. We should only use `Arguments` everywhere.

### Code of Conduct
- [x] I have checked the [existing issues](https://github.com/Avaiga/taipy/issues?q=is%3Aissue+).
- [ ] I am willing to work on this issue (optional)