### PR TITLE
Metric: Add support for None

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
@@ -286,8 +286,28 @@ describe("Metric Component", () => {
         });
     });
 
-    it("processes type prop correctly when type is none", async () => {
-        const { container } = render(<Metric type="none"  />);
+    it("processes type prop correctly when type is none (string)", async () => {
+        const { container } = render(<Metric type="none" />);
+        await waitFor(() => {
+            const angularElm = container.querySelector(".angular");
+            const angularAxis = container.querySelector(".angularaxis");
+            expect(angularElm).not.toBeInTheDocument();
+            expect(angularAxis).not.toBeInTheDocument();
+        });
+    });
+    
+    it("processes type prop correctly when type is null", async () => {
+        const { container } = render(<Metric type={null} />);
+        await waitFor(() => {
+            const angularElm = container.querySelector(".angular");
+            const angularAxis = container.querySelector(".angularaxis");
+            expect(angularElm).not.toBeInTheDocument();
+            expect(angularAxis).not.toBeInTheDocument();
+        });
+    });
+    
+    it("processes type prop correctly when type is NONE (all uppercase)", async () => {
+        const { container } = render(<Metric type="NONE" />);
         await waitFor(() => {
             const angularElm = container.querySelector(".angular");
             const angularAxis = container.querySelector(".angularaxis");

--- a/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
@@ -296,8 +296,8 @@ describe("Metric Component", () => {
         });
     });
     
-    it("processes type prop correctly when type is NONE (all uppercase)", async () => {
-        const { container } = render(<Metric type="NONE" />);
+    it("processes type prop correctly when type is None", async () => {
+        const { container } = render(<Metric type="None" />);
         await waitFor(() => {
             const angularElm = container.querySelector(".angular");
             const angularAxis = container.querySelector(".angularaxis");

--- a/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
@@ -296,16 +296,6 @@ describe("Metric Component", () => {
         });
     });
     
-    it("processes type prop correctly when type is null", async () => {
-        const { container } = render(<Metric type={null} />);
-        await waitFor(() => {
-            const angularElm = container.querySelector(".angular");
-            const angularAxis = container.querySelector(".angularaxis");
-            expect(angularElm).not.toBeInTheDocument();
-            expect(angularAxis).not.toBeInTheDocument();
-        });
-    });
-    
     it("processes type prop correctly when type is NONE (all uppercase)", async () => {
         const { container } = render(<Metric type="NONE" />);
         await waitFor(() => {

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -87,7 +87,7 @@ const Metric = (props: MetricProps) => {
     }, [props.colorMap, props.max]);
 
     const data = useMemo(() => {
-        const mode = props.type == null || props.type.toLowerCase() === "none" ? [] : ["gauge"];
+        const mode = props.type == null || (typeof props.type === "string" && props.type.toLowerCase() === "none") ? [] : ["gauge"];
         showValue && mode.push("number");
         delta !== undefined && mode.push("delta");
         const deltaIncreasing = props.deltaColor

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -87,7 +87,7 @@ const Metric = (props: MetricProps) => {
     }, [props.colorMap, props.max]);
 
     const data = useMemo(() => {
-        const mode = props.type === "none" ? [] : ["gauge"];
+        const mode = props.type === null [] : ["gauge"];
         showValue && mode.push("number");
         delta !== undefined && mode.push("delta");
         const deltaIncreasing = props.deltaColor

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -87,7 +87,7 @@ const Metric = (props: MetricProps) => {
     }, [props.colorMap, props.max]);
 
     const data = useMemo(() => {
-        const mode = props.type === "none" || props.type == null ? [] : ["gauge"];
+        const mode = props.type == null || props.type.toLowerCase() === "none" ? [] : ["gauge"];
         showValue && mode.push("number");
         delta !== undefined && mode.push("delta");
         const deltaIncreasing = props.deltaColor

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -87,7 +87,7 @@ const Metric = (props: MetricProps) => {
     }, [props.colorMap, props.max]);
 
     const data = useMemo(() => {
-        const mode = props.type === null [] : ["gauge"];
+        const mode = props.type === "none" || props.type == null ? [] : ["gauge"];
         showValue && mode.push("number");
         delta !== undefined && mode.push("delta");
         const deltaIncreasing = props.deltaColor

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -30,7 +30,7 @@ interface MetricProps extends TaipyBaseProps, TaipyHoverProps {
     defaultValue?: number;
     delta?: number;
     defaultDelta?: number;
-    type?: string;
+    type?: string | null;
     min?: number;
     max?: number;
     deltaColor?: string;

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -87,7 +87,7 @@ const Metric = (props: MetricProps) => {
     }, [props.colorMap, props.max]);
 
     const data = useMemo(() => {
-        const mode = props.type == null || (typeof props.type === "string" && props.type.toLowerCase() === "none") ? [] : ["gauge"];
+        const mode = props.type === null || (typeof props.type === "string" && props.type.toLowerCase() === "none") ? [] : ["gauge"];
         showValue && mode.push("number");
         delta !== undefined && mode.push("delta");
         const deltaIncreasing = props.deltaColor

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -30,7 +30,7 @@ interface MetricProps extends TaipyBaseProps, TaipyHoverProps {
     defaultValue?: number;
     delta?: number;
     defaultDelta?: number;
-    type?: string | null;
+    type?: string;
     min?: number;
     max?: number;
     deltaColor?: string;
@@ -87,7 +87,7 @@ const Metric = (props: MetricProps) => {
     }, [props.colorMap, props.max]);
 
     const data = useMemo(() => {
-        const mode = props.type === null || (typeof props.type === "string" && props.type.toLowerCase() === "none") ? [] : ["gauge"];
+        const mode = typeof props.type === "string" && props.type.toLowerCase() === "none" ? [] : ["gauge"];
         showValue && mode.push("number");
         delta !== undefined && mode.push("delta");
         const deltaIncreasing = props.deltaColor

--- a/tests/gui/builder/control/test_metric.py
+++ b/tests/gui/builder/control/test_metric.py
@@ -1,0 +1,37 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import taipy.gui.builder as tgb
+from taipy.gui import Gui
+
+def test_metric_builder_none(gui: Gui, helpers):
+    with tgb.Page(frame=None) as page:
+        tgb.metric(type=None, value=42)  # type: ignore[attr-defined]
+    expected_list = ["<Metric", 'type="None"', 'value="42"']
+    helpers.test_control_builder(gui, page, expected_list)
+
+def test_metric_builder_none_lowercase(gui: Gui, helpers):
+    with tgb.Page(frame=None) as page:
+        tgb.metric(type="none", value=42)  # type: ignore[attr-defined]
+    expected_list = ["<Metric", 'type="none"', 'value="42"']
+    helpers.test_control_builder(gui, page, expected_list)
+
+def test_metric_builder_circular(gui: Gui, helpers):
+    with tgb.Page(frame=None) as page:
+        tgb.metric(type="circular", value=42)  # type: ignore[attr-defined]
+    expected_list = ["<Metric", 'type="circular"', 'value="42"']
+    helpers.test_control_builder(gui, page, expected_list)
+
+def test_metric_builder_linear(gui: Gui, helpers):
+    with tgb.Page(frame=None) as page:
+        tgb.metric(type="linear", value=42)  # type: ignore[attr-defined]
+    expected_list = ["<Metric", 'type="linear"', 'value="42"']
+    helpers.test_control_builder(gui, page, expected_list)

--- a/tests/gui/builder/control/test_metric.py
+++ b/tests/gui/builder/control/test_metric.py
@@ -12,26 +12,27 @@
 import taipy.gui.builder as tgb
 from taipy.gui import Gui
 
+
 def test_metric_builder_none(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
-        tgb.metric(type=None, value=42)  # type: ignore[attr-defined]
+        tgb.metric(type=None, value=42)
     expected_list = ["<Metric", 'type="None"', 'value="42"']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_none_lowercase(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
-        tgb.metric(type="none", value=42)  # type: ignore[attr-defined]
+        tgb.metric(type="none", value=42)
     expected_list = ["<Metric", 'type="none"', 'value="42"']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_circular(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
-        tgb.metric(type="circular", value=42)  # type: ignore[attr-defined]
+        tgb.metric(type="circular", value=42)
     expected_list = ["<Metric", 'type="circular"', 'value="42"']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_linear(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
-        tgb.metric(type="linear", value=42)  # type: ignore[attr-defined]
+        tgb.metric(type="linear", value=42)
     expected_list = ["<Metric", 'type="linear"', 'value="42"']
     helpers.test_control_builder(gui, page, expected_list)

--- a/tests/gui/builder/control/test_metric.py
+++ b/tests/gui/builder/control/test_metric.py
@@ -16,23 +16,23 @@ from taipy.gui import Gui
 def test_metric_builder_none(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type=None, value=42)
-    expected_list = ["<Metric", 'type="None"', 'value=42']
+    expected_list = ["<Metric", 'type="None"', 'value={42.0}']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_none_lowercase(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type="none", value=42)
-    expected_list = ["<Metric", 'type="none"', 'value=42']
+    expected_list = ["<Metric", 'type="none"', 'value={42.0}']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_circular(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type="circular", value=42)
-    expected_list = ["<Metric", 'type="circular"', 'value=42']
+    expected_list = ["<Metric", 'type="circular"', 'value={42.0}']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_linear(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type="linear", value=42)
-    expected_list = ["<Metric", 'type="linear"', 'value=42']
+    expected_list = ["<Metric", 'type="linear"', 'value={42.0}']
     helpers.test_control_builder(gui, page, expected_list)

--- a/tests/gui/builder/control/test_metric.py
+++ b/tests/gui/builder/control/test_metric.py
@@ -16,23 +16,23 @@ from taipy.gui import Gui
 def test_metric_builder_none(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type=None, value=42)
-    expected_list = ["<Metric", 'type="None"', 'value="42"']
+    expected_list = ["<Metric", 'type="None"', 'value=42']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_none_lowercase(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type="none", value=42)
-    expected_list = ["<Metric", 'type="none"', 'value="42"']
+    expected_list = ["<Metric", 'type="none"', 'value=42']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_circular(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type="circular", value=42)
-    expected_list = ["<Metric", 'type="circular"', 'value="42"']
+    expected_list = ["<Metric", 'type="circular"', 'value=42']
     helpers.test_control_builder(gui, page, expected_list)
 
 def test_metric_builder_linear(gui: Gui, helpers):
     with tgb.Page(frame=None) as page:
         tgb.metric(type="linear", value=42)
-    expected_list = ["<Metric", 'type="linear"', 'value="42"']
+    expected_list = ["<Metric", 'type="linear"', 'value=42']
     helpers.test_control_builder(gui, page, expected_list)

--- a/tests/gui/control/test_metric.py
+++ b/tests/gui/control/test_metric.py
@@ -11,6 +11,7 @@
 
 from taipy.gui import Gui
 
+
 def test_metric_md_none(gui: Gui, helpers):
     md_string = "<|metric|type=None|value=42|>"
     expected_list = ["<Metric", 'type="None"', 'value="42"']

--- a/tests/gui/control/test_metric.py
+++ b/tests/gui/control/test_metric.py
@@ -1,0 +1,52 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from taipy.gui import Gui
+
+def test_metric_md_none(gui: Gui, helpers):
+    md_string = "<|metric|type=None|value=42|>"
+    expected_list = ["<Metric", 'type="None"', 'value="42"']
+    helpers.test_control_md(gui, md_string, expected_list)
+
+def test_metric_md_none_lowercase(gui: Gui, helpers):
+    md_string = "<|metric|type=none|value=42|>"
+    expected_list = ["<Metric", 'type="none"', 'value="42"']
+    helpers.test_control_md(gui, md_string, expected_list)
+
+def test_metric_md_circular(gui: Gui, helpers):
+    md_string = "<|metric|type=circular|value=42|>"
+    expected_list = ["<Metric", 'type="circular"', 'value="42"']
+    helpers.test_control_md(gui, md_string, expected_list)
+
+def test_metric_md_linear(gui: Gui, helpers):
+    md_string = "<|metric|type=linear|value=42|>"
+    expected_list = ["<Metric", 'type="linear"', 'value="42"']
+    helpers.test_control_md(gui, md_string, expected_list)
+
+def test_metric_html_none(gui: Gui, helpers):
+    html_string = '<taipy:metric type="None" value="42" />'
+    expected_list = ["<Metric", 'type="None"', 'value="42"']
+    helpers.test_control_html(gui, html_string, expected_list)
+
+def test_metric_html_none_lowercase(gui: Gui, helpers):
+    html_string = '<taipy:metric type="none" value="42" />'
+    expected_list = ["<Metric", 'type="none"', 'value="42"']
+    helpers.test_control_html(gui, html_string, expected_list)
+
+def test_metric_html_circular(gui: Gui, helpers):
+    html_string = '<taipy:metric type="circular" value="42" />'
+    expected_list = ["<Metric", 'type="circular"', 'value="42"']
+    helpers.test_control_html(gui, html_string, expected_list)
+
+def test_metric_html_linear(gui: Gui, helpers):
+    html_string = '<taipy:metric type="linear" value="42" />'
+    expected_list = ["<Metric", 'type="linear"', 'value="42"']
+    helpers.test_control_html(gui, html_string, expected_list)

--- a/tests/gui/control/test_metric.py
+++ b/tests/gui/control/test_metric.py
@@ -34,7 +34,7 @@ def test_metric_md_linear(gui: Gui, helpers):
 
 def test_metric_html_none(gui: Gui, helpers):
     html_string = '<taipy:metric type="None" value="42" />'
-    expected_list = ["<Metric", 'type="None"', 'value=42']
+    expected_list = ["<Metric", 'type="None"', 'value={42.0}']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_none_lowercase(gui: Gui, helpers):

--- a/tests/gui/control/test_metric.py
+++ b/tests/gui/control/test_metric.py
@@ -14,22 +14,22 @@ from taipy.gui import Gui
 
 def test_metric_md_none(gui: Gui, helpers):
     md_string = "<|metric|type=None|value=42|>"
-    expected_list = ["<Metric", 'type="None"', 'value=42']
+    expected_list = ["<Metric", 'type="None"', 'value={42.0}']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_none_lowercase(gui: Gui, helpers):
     md_string = "<|metric|type=none|value=42|>"
-    expected_list = ["<Metric", 'type="none"', 'value=42']
+    expected_list = ["<Metric", 'type="none"', 'value={42.0}']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_circular(gui: Gui, helpers):
     md_string = "<|metric|type=circular|value=42|>"
-    expected_list = ["<Metric", 'type="circular"', 'value=42']
+    expected_list = ["<Metric", 'type="circular"', 'value={42.0}']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_linear(gui: Gui, helpers):
     md_string = "<|metric|type=linear|value=42|>"
-    expected_list = ["<Metric", 'type="linear"', 'value=42']
+    expected_list = ["<Metric", 'type="linear"', 'value={42.0}']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_html_none(gui: Gui, helpers):
@@ -39,15 +39,15 @@ def test_metric_html_none(gui: Gui, helpers):
 
 def test_metric_html_none_lowercase(gui: Gui, helpers):
     html_string = '<taipy:metric type="none" value="42" />'
-    expected_list = ["<Metric", 'type="none"', 'value=42']
+    expected_list = ["<Metric", 'type="none"', 'value={42.0}']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_circular(gui: Gui, helpers):
     html_string = '<taipy:metric type="circular" value="42" />'
-    expected_list = ["<Metric", 'type="circular"', 'value=42']
+    expected_list = ["<Metric", 'type="circular"', 'value={42.0}']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_linear(gui: Gui, helpers):
     html_string = '<taipy:metric type="linear" value="42" />'
-    expected_list = ["<Metric", 'type="linear"', 'value=42']
+    expected_list = ["<Metric", 'type="linear"', 'value={42.0}']
     helpers.test_control_html(gui, html_string, expected_list)

--- a/tests/gui/control/test_metric.py
+++ b/tests/gui/control/test_metric.py
@@ -14,40 +14,40 @@ from taipy.gui import Gui
 
 def test_metric_md_none(gui: Gui, helpers):
     md_string = "<|metric|type=None|value=42|>"
-    expected_list = ["<Metric", 'type="None"', 'value="42"']
+    expected_list = ["<Metric", 'type="None"', 'value="42.0"']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_none_lowercase(gui: Gui, helpers):
     md_string = "<|metric|type=none|value=42|>"
-    expected_list = ["<Metric", 'type="none"', 'value="42"']
+    expected_list = ["<Metric", 'type="none"', 'value="42.0"']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_circular(gui: Gui, helpers):
     md_string = "<|metric|type=circular|value=42|>"
-    expected_list = ["<Metric", 'type="circular"', 'value="42"']
+    expected_list = ["<Metric", 'type="circular"', 'value="42.0"']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_linear(gui: Gui, helpers):
     md_string = "<|metric|type=linear|value=42|>"
-    expected_list = ["<Metric", 'type="linear"', 'value="42"']
+    expected_list = ["<Metric", 'type="linear"', 'value="42.0"']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_html_none(gui: Gui, helpers):
     html_string = '<taipy:metric type="None" value="42" />'
-    expected_list = ["<Metric", 'type="None"', 'value="42"']
+    expected_list = ["<Metric", 'type="None"', 'value="42.0"']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_none_lowercase(gui: Gui, helpers):
     html_string = '<taipy:metric type="none" value="42" />'
-    expected_list = ["<Metric", 'type="none"', 'value="42"']
+    expected_list = ["<Metric", 'type="none"', 'value="42.0"']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_circular(gui: Gui, helpers):
     html_string = '<taipy:metric type="circular" value="42" />'
-    expected_list = ["<Metric", 'type="circular"', 'value="42"']
+    expected_list = ["<Metric", 'type="circular"', 'value="42.0"']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_linear(gui: Gui, helpers):
     html_string = '<taipy:metric type="linear" value="42" />'
-    expected_list = ["<Metric", 'type="linear"', 'value="42"']
+    expected_list = ["<Metric", 'type="linear"', 'value="42.0"']
     helpers.test_control_html(gui, html_string, expected_list)

--- a/tests/gui/control/test_metric.py
+++ b/tests/gui/control/test_metric.py
@@ -14,40 +14,40 @@ from taipy.gui import Gui
 
 def test_metric_md_none(gui: Gui, helpers):
     md_string = "<|metric|type=None|value=42|>"
-    expected_list = ["<Metric", 'type="None"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="None"', 'value=42']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_none_lowercase(gui: Gui, helpers):
     md_string = "<|metric|type=none|value=42|>"
-    expected_list = ["<Metric", 'type="none"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="none"', 'value=42']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_circular(gui: Gui, helpers):
     md_string = "<|metric|type=circular|value=42|>"
-    expected_list = ["<Metric", 'type="circular"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="circular"', 'value=42']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_md_linear(gui: Gui, helpers):
     md_string = "<|metric|type=linear|value=42|>"
-    expected_list = ["<Metric", 'type="linear"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="linear"', 'value=42']
     helpers.test_control_md(gui, md_string, expected_list)
 
 def test_metric_html_none(gui: Gui, helpers):
     html_string = '<taipy:metric type="None" value="42" />'
-    expected_list = ["<Metric", 'type="None"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="None"', 'value=42']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_none_lowercase(gui: Gui, helpers):
     html_string = '<taipy:metric type="none" value="42" />'
-    expected_list = ["<Metric", 'type="none"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="none"', 'value=42']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_circular(gui: Gui, helpers):
     html_string = '<taipy:metric type="circular" value="42" />'
-    expected_list = ["<Metric", 'type="circular"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="circular"', 'value=42']
     helpers.test_control_html(gui, html_string, expected_list)
 
 def test_metric_html_linear(gui: Gui, helpers):
     html_string = '<taipy:metric type="linear" value="42" />'
-    expected_list = ["<Metric", 'type="linear"', 'value="42.0"']
+    expected_list = ["<Metric", 'type="linear"', 'value=42']
     helpers.test_control_html(gui, html_string, expected_list)


### PR DESCRIPTION
Added support for None in tgb.metric(), removed "none"
resolves #2143 