### PR TITLE
Slight adjustment in the chat control doc.

### DIFF
--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1732,13 +1732,6 @@
                         "doc": "The list of messages. Each item of this list must consist of a list of three strings: a message identifier, a message content, a user identifier, and an image URL."
                     },
                     {
-                        "name": "max_file_size",
-                        "type": "int",
-                        "default_value": "1 * 1024 * 1024 (1MB)",
-                        "doc": "The maximum file size can be uploaded to a chat message."
-
-                    },
-                    {
                         "name": "users",
                         "type": "dynamic(list[Union[str,Icon]])",
                         "doc": "The list of users. See the <a href=\"../../../../../userman/gui/binding/#list-of-values\">section on List of Values</a> for more details."
@@ -1796,6 +1789,12 @@
                         "type": "str",
                         "default_value": "\"markdown\"",
                         "doc": "Define the way the messages are processed when they are displayed:\n<ul><li>&quot;raw&quot; no processing</li><li>&quot;pre&quot;: keeps spaces and new lines</li><li>&quot;markdown&quot; or &quot;md&quot;: basic support for Markdown.</li></ul>"
+                    },
+                    {
+                        "name": "max_file_size",
+                        "type": "int",
+                        "default_value": "1024 * 1024",
+                        "doc": "The maximum allowable file size, in bytes, for files uploaded to a chat message.\nThe default is 1 MB."
                     }
                 ]
             }


### PR DESCRIPTION
Related to [taipy-doc#1178](https://github.com/Avaiga/taipy-doc/issues/1178).

Fixes the default value for max_file_size that is not a valid Python expression (therefore cannot be used for the Page Builder API documentation generation).
