### PR TITLE
improve exception reporting in expressions

### DIFF
--- a/taipy/gui/_page.py
+++ b/taipy/gui/_page.py
@@ -17,6 +17,8 @@ import re
 import typing as t
 import warnings
 
+from ._warnings import TaipyGuiAlwaysWarning
+
 if t.TYPE_CHECKING:
     from ._renderers import Page
     from .gui import Gui
@@ -40,7 +42,15 @@ class _Page(object):
             warnings.resetwarnings()
             with gui._set_locals_context(self._renderer._get_module_name()):
                 self._rendered_jsx = self._renderer.render(gui)
-            if not silent:
+            if silent:
+                s = ""
+                for wm in w:
+                    if wm.category is TaipyGuiAlwaysWarning:
+                        s += f" - {wm.message}\n"
+                if s:
+                    logging.warning("\033[1;31m\n" + s)
+
+            else:
                 if (
                     self._rendered_jsx
                     and isinstance(self._rendered_jsx, str)

--- a/taipy/gui/_warnings.py
+++ b/taipy/gui/_warnings.py
@@ -30,15 +30,24 @@ class TaipyGuiWarning(UserWarning):
         )
 
 
-def _warn(message: str, e: t.Optional[BaseException] = None):
+class TaipyGuiAlwaysWarning(TaipyGuiWarning):
+    pass
+
+
+def _warn(
+    message: str,
+    e: t.Optional[BaseException] = None,
+    always_show: t.Optional[bool] = False,
+):
     warnings.warn(
         (
-            f"{message}:\n{''.join(traceback.format_exception(type(e), e, e.__traceback__))}"
+            f"{message}:\n{''.join(traceback.format_exception(e))}"
             if e and TaipyGuiWarning._tp_debug_mode
-            else f"{message}:\n{e}"
+            else f"{message}:\n"
+            + "".join(traceback.format_exception(None, e, e.__traceback__.tb_next if e.__traceback__ else None))
             if e
             else message
         ),
-        TaipyGuiWarning,
+        TaipyGuiWarning if not always_show else TaipyGuiAlwaysWarning,
         stacklevel=2,
     )

--- a/tests/gui/helpers.py
+++ b/tests/gui/helpers.py
@@ -18,7 +18,7 @@ import warnings
 
 from taipy.gui import Gui, Html, Markdown
 from taipy.gui._renderers.builder import _Builder
-from taipy.gui._warnings import TaipyGuiAlwaysWarning, TaipyGuiWarning
+from taipy.gui._warnings import TaipyGuiWarning
 from taipy.gui.utils._variable_directory import _reset_name_map
 from taipy.gui.utils.expr_var_name import _reset_expr_var_name
 
@@ -165,4 +165,4 @@ class Helpers:
 
     @staticmethod
     def get_taipy_warnings(warns: t.List[warnings.WarningMessage]) -> t.List[warnings.WarningMessage]:
-        return [w for w in warns if w.category is TaipyGuiWarning or w.category is TaipyGuiAlwaysWarning]
+        return [w for w in warns if issubclass(w.category, TaipyGuiWarning)]

--- a/tests/gui/helpers.py
+++ b/tests/gui/helpers.py
@@ -18,7 +18,7 @@ import warnings
 
 from taipy.gui import Gui, Html, Markdown
 from taipy.gui._renderers.builder import _Builder
-from taipy.gui._warnings import TaipyGuiWarning
+from taipy.gui._warnings import TaipyGuiAlwaysWarning, TaipyGuiWarning
 from taipy.gui.utils._variable_directory import _reset_name_map
 from taipy.gui.utils.expr_var_name import _reset_expr_var_name
 
@@ -165,4 +165,4 @@ class Helpers:
 
     @staticmethod
     def get_taipy_warnings(warns: t.List[warnings.WarningMessage]) -> t.List[warnings.WarningMessage]:
-        return [w for w in warns if w.category is TaipyGuiWarning]
+        return [w for w in warns if w.category is TaipyGuiWarning or w.category is TaipyGuiAlwaysWarning]

--- a/tools/release/bump_version.py
+++ b/tools/release/bump_version.py
@@ -93,5 +93,5 @@ if __name__ == "__main__":
     for _path in paths:
         _version = extract_version(_path)
         bump_ext_version(_version, _path)
-    print(f"NEW_VERSION={_version.dev_name}")
+    print(f"NEW_VERSION={_version.dev_name}") # noqa T201 # type: ignore[reportPossiblyUnboundVariable]
 


### PR DESCRIPTION
resolves #2144

- replace lambda generated name by `<lambda>`
- do not report taipy source code on exception if not in debug

```py
import taipy.gui.builder as tgb
from taipy.gui import Gui

color_wl = 530.355


def compute_metric(color_wl):
    raise Exception("Error")


with tgb.Page() as page:
    tgb.metric(
        value=lambda color_wl: compute_metric(color_wl),
    )
    tgb.button("change color", on_action=lambda s: s.assign("color_wl", 200))

Gui(page).run(title="2144 Display/Notify developers of errors inside lambda functions")

```