### PR TITLE
Scenario Selector selection on creation

### DIFF
--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -516,7 +516,11 @@ class _GuiCoreContext(CoreEventConsumerBase):
             finally:
                 self.scenario_refresh(scenario_id)
                 if (scenario or user_scenario) and (sel_scenario_var := args[1] if isinstance(args[1], str) else None):
-                    self.gui._update_var(sel_scenario_var, scenario or user_scenario, on_change=args[2])
+                    self.gui._update_var(
+                        sel_scenario_var[6:] if sel_scenario_var.startswith("_TpLv_") else sel_scenario_var,
+                        scenario or user_scenario,
+                        on_change=args[2],
+                    )
         if scenario:
             if not (reason := is_editable(scenario)):
                 state.assign(error_var, f"Scenario {scenario_id or name} is not editable: {_get_reason(reason)}.")
@@ -1124,10 +1128,8 @@ class _GuiCoreContext(CoreEventConsumerBase):
         if id and is_readable(t.cast(DataNodeId, id)) and (dn := core_get(id)) and isinstance(dn, DataNode):
             try:
                 return [
-                        (k, f"{v}")
-                        for k, v in dn._get_user_properties().items()
-                        if k != _GuiCoreContext.__PROP_ENTITY_NAME
-                    ]
+                    (k, f"{v}") for k, v in dn._get_user_properties().items() if k != _GuiCoreContext.__PROP_ENTITY_NAME
+                ]
             except Exception:
                 return None
         return None


### PR DESCRIPTION
resolves #2169

```py
import datetime as dt

import pandas as pd

import taipy as tp
import taipy.gui.builder as tgb
from taipy import Config, Frequency

data = pd.read_csv(
    "https://raw.githubusercontent.com/Avaiga/taipy-getting-started-core/develop/src/daily-min-temperatures.csv"
)


# Normal function used by Taipy
def predict(
    historical_temperature: pd.DataFrame, date_to_forecast: dt.datetime
) -> float:
    print(f"Running baseline...")
    historical_temperature["Date"] = pd.to_datetime(historical_temperature["Date"])
    historical_same_day = historical_temperature.loc[
        (historical_temperature["Date"].dt.day == date_to_forecast.day)
        & (historical_temperature["Date"].dt.month == date_to_forecast.month)
    ]
    return historical_same_day["Temp"].mean()


# Configuration of Data Nodes
historical_temperature_cfg = Config.configure_data_node("historical_temperature")
date_to_forecast_cfg = Config.configure_data_node("date_to_forecast")
predictions_cfg = Config.configure_data_node("predictions", storage_type="json")

# Configuration of tasks
predictions_cfg = Config.configure_task(
    "predict",
    predict,
    [historical_temperature_cfg, date_to_forecast_cfg],
    predictions_cfg,
)

# Configuration of scenario
scenario_cfg = Config.configure_scenario(
    id="my_scenario", task_configs=[predictions_cfg], frequency=Frequency.MONTHLY
)


if __name__ == "__main__":
    # Run of the Core
    tp.Core().run()

    # Creation of the scenario and execution
    scenario = tp.create_scenario(scenario_cfg)
    tp.create_scenario(scenario_cfg, name="Hello World")

    with tgb.Page() as page:
        tgb.scenario_selector("{scenario}")
        tgb.scenario("{scenario}")

    tp.Gui(page).run(title="2169 [🐛 BUG] Scenario Selector - Cannot select scenario after scenario creation")

```