### PR TITLE
Support False value for MockState attribute

### DIFF
--- a/taipy/gui/mock/mock_state.py
+++ b/taipy/gui/mock/mock_state.py
@@ -37,7 +37,7 @@ class MockState(State):
         return self._gui
 
     def __getattribute__(self, name: str) -> t.Any:
-        if attr := t.cast(dict, super().__getattribute__(MockState.__VARS)).get(name):
+        if (attr := t.cast(dict, super().__getattribute__(MockState.__VARS)).get(name, None)) is not None:
             return attr
         try:
             return super().__getattribute__(name)

--- a/tests/gui/mock/test_mock_state.py
+++ b/tests/gui/mock/test_mock_state.py
@@ -100,3 +100,7 @@ def test_callback():
     ms = MockState(Gui(""), a=1)
     on_action(ms)
     assert ms.a == 2
+
+def test_false():
+    ms = MockState(Gui(""), a=False)
+    assert ms.a is False


### PR DESCRIPTION
resolves #2172

```py
from taipy.gui import Gui
from taipy.gui.mock.mock_state import MockState

ms = MockState(
    Gui(""),
    agree_disagree1=True,
    agree_disagree2=False,
)
print(ms.agree_disagree2)

```