### PR TITLE
Backport: Table cell style not applied when columns refreshed with rebuild

### DIFF
--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -59,7 +59,7 @@ class _Builder:
 
     __BLOCK_CONTROLS = ["dialog", "expandable", "pane", "part"]
 
-    __TABLE_COLUMNS_DEPS = [
+    __TABLE_COLUMNS_DEPS = {
         "data",
         "columns",
         "date_format",
@@ -73,7 +73,10 @@ class _Builder:
         "style",
         "tooltip",
         "lov",
-    ]
+        "row_class_name",
+        "cell_class_name",
+        "format_fn"
+    }
 
     def __init__(
         self,


### PR DESCRIPTION
bakport of (#2171)

* Table cell style not applied when columns refreshed with rebuild=True 
 
resolves #2005

* add format_fn property make the list a set

---------