### PR TITLE
fix #1814 update_content for debug off

### DIFF
--- a/taipy/gui/partial.py
+++ b/taipy/gui/partial.py
@@ -12,7 +12,8 @@
 from __future__ import annotations
 
 import typing as t
-
+import time
+from threading import Lock
 from ._page import _Page
 from ._warnings import _warn
 from .state import State
@@ -44,6 +45,9 @@ class Partial(_Page):
     _PARTIALS = "__partials"
 
     __partials: t.Dict[str, Partial] = {}
+    __update_lock = Lock()
+    __last_update_time: t.Dict[str, float] = {}
+    __update_interval: 0.05
 
     def __init__(self, route: t.Optional[str] = None):
         super().__init__()
@@ -52,6 +56,14 @@ class Partial(_Page):
             Partial.__partials[self._route] = self
         else:
             self._route = route
+        self.__last_update_time[self._route] = 0.0
+        self.__pending_content = None
+        self.__pending_state = None
+
+    def _should_update(self) -> bool:
+        current_time = time.time()
+        last_update = self.__last_update_time(self._route, 0)
+        return (current_time - last_update) >= self.__update_interval
 
     def update_content(self, state: State, content: t.Union[str, "Page"]):
         """Update partial content.
@@ -60,10 +72,24 @@ class Partial(_Page):
             state (State^): The current user state as received in any callback.
             content (str): The new content to use and display.
         """
-        if state and state._gui and callable(state._gui._update_partial):
-            state._gui._update_partial(self.__copy(content))
-        else:
-            _warn("'Partial.update_content()' must be called in the context of a callback.")
+        with self.__update_lock:
+            if state and state._gui and callable(state._gui._update_partial):
+                state._gui._update_partial(self.__copy(content))
+            else:
+                _warn("'Partial.update_content()' must be called in the context of a callback.")
+
+            self.__pending_content = content
+            self.__pending_state = state
+
+            if self._should_update():
+                try:
+                    state._gui._update_partial(self.__copy(contend))
+                    self.__last_update_time[self._route] = time.time()
+                    self.__pending_content = None
+                    self.__pending_state = None
+                except Exception as e:
+                    _warn(f"Failed to update partial content: {str(e)}")
+
 
     def __copy(self, content:  t.Union[str, "Page"]) -> Partial:
         new_partial = Partial(self._route)
@@ -78,3 +104,16 @@ class Partial(_Page):
                 else None
             )
         return new_partial
+
+    def _process_pending_update(self):
+        with self.__update_lock:
+            if self.__pending_content and self.__pending_state and self._should_update():
+                try:
+                    self.__pending_state.__gui._update_partial(
+                        self.__copy(self.__pending_content)
+                    )
+                    self.__last_update_time[self._route] = time.time()
+                    self.__pending_content = None
+                    self.__pending_state = None
+                except Exception as e:
+                    _warn(f"Failed to update partial content: {str(e)}")

--- a/tests/gui/gui_specific/test_partial.py
+++ b/tests/gui/gui_specific/test_partial.py
@@ -11,9 +11,11 @@
 
 import json
 import warnings
+import time
+import pytest
 from types import SimpleNamespace
 
-from taipy.gui import Gui, Markdown
+from taipy.gui import Gui, Markdown, State
 
 
 def test_partial(gui: Gui):
@@ -44,3 +46,103 @@ def test_partial_update(gui: Gui):
         response_data = json.loads(response.get_data().decode("utf-8", "ignore"))
         assert response.status_code == 200
         assert "jsx" in response_data and "partial updated" in response_data["jsx"]
+
+def test_partial_update_debug_modes(gui: Gui):
+    with warnings.catch_warnings(record=True):
+        partial = gui.add_partial(Markdown("#Initial content"))
+        gui.run(run_server=False, single_client=True)
+        client = gui._server.test_client()
+        fake_state = SimpleNamespace()
+        fake_state._gui = gui
+
+        gui._config.debug = True
+        partial.update_content(fake_state, "#Debug mode content")
+        response = client.get(f"/taipy-jsx/{gui._config.partial_routes[0]}")
+        debug_data = json.loads(response.get_data().decode("utf-8", "ignore"))
+
+        gui._config.debug = False
+        partial.update_content(fake_state, "#Non-debug mode content")
+        response = client.get(f"/taipy-jsx/{gui._config.partial_routes[0]}")
+        non_debug_data = json.loads(response.get_data().decode("utf-8", "ignore"))
+
+        assert "jsx" in debug_data and "jsx" in non_debug_data
+        assert debug_data["jsx"] != non_debug_data["jsx"]
+        assert "Non-debug mode content" in non_debug_data["jsx"]
+
+def test_rapid_updates(gui: Gui):
+    with warnings.catch_warnings(record=True):
+        partial = gui.add_partial(Markdown("#Initial content"))
+        gui.run(run_server=False, single_client=True)
+        client = gui._server.test_client()
+        fake_state = SimpleNamespace()
+        fake_state._gui = gui
+
+        update_count = 5
+        for i in range(update_count):
+            partial.update_content(fake_state, f"#Update {i}")
+            time.sleep(0.1)
+
+        time.sleep(0.2)
+
+        response = client.get(f"/taipy-jsx/{gui._config.partial_routes[0]}")
+        final_data = json.loads(response.get_data().decode("utf-8", "ignore"))
+        assert f"Update {update_count - 1}" in final_data["jsx"]
+
+def test_streaming_updates(gui: Gui):
+    with warnings.catch_warnings(record=True):
+        partial = gui.add_partial(Markdown("#Initial content"))
+        gui.run(run_server=False, single_client=True)
+        client = gui._server.test_client()
+        fake_state = SimpleNamespace()
+        fake_state._gui = gui
+
+        update_texts = ["Start", "Middle", "End"]
+        for text in update_texts:
+            partial.update_content(fake_state, f"#{text}")
+            time.sleep(0.1)
+
+        response = client.get(f"/taipy-jsx/{gui._config.partial_routes[0]}")
+        final_data = json.loads(response.get_data().decode("utf-8", "ignore"))
+        assert "End" in final_data["jsx"]
+
+def test_error_handling(gui: Gui):
+    with warnings.catch_warnings(record=True):
+        partial = gui.add_partial(Markdown("#Initial content"))
+        gui.run(run_server=False, single_client=True)
+
+        invalid_state = SimpleNamespace()
+        invalid_state._gui = None
+        partial.update_content(invalid_state, "#Should not update")
+
+        assert len(w) > 0
+        assert any("callback" in str(warning.message) for warning in w)
+
+def test_concurrent_updates(gui: Gui):
+    with warnings.catch_warnings(record=True):
+        partial = gui.add_partial(Markdown("#Initial content"))
+        gui.run(run_server=False, single_client=True)
+        client = gui._server.test_client()
+        fake_state = SimpleNamespace()
+        fake_state._gui = gui
+
+        from threading import Thread
+        import queue
+
+        update_queue = queue.Queue()
+        def update_worker():
+            for i in range(5):
+                partial.update_content(fake_state, f"#Thread update {i}")
+                update_queue.put(i)
+                time.sleep(0.1)
+
+        threads = [Thread(target=update_worker) for _ in range(3)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        time.sleep(0.2)
+
+        response = client.get(f"/taipy-jsx/{gui._config.partial_routes[0]}")
+        final_data = json.loads(response.get_data().decode("utf-8", "ignore"))
+        assert "Thread update" in final_data["jsx"]


### PR DESCRIPTION
This PR fix https://github.com/Avaiga/taipy/issues/1814

Description:
Fixes issue with update_content() behavior inconsistency in debug vs. non-debug modes.

Summary of Changes:

Introduced a queue-based system (UpdateQueue) to batch and control the frequency of updates for partials.

Implemented two batch intervals:
STREAM_MODE_BATCH_INTERVAL for smooth updates during streaming (0.05s).
STANDARD_BATCH_INTERVAL for non-streaming updates (0.2s).

Added thread safety using locks to ensure consistent updates and prevent race conditions.

Created a new method _process_updates() to handle queued updates and apply only the most recent change.

Added a force_update() method for forced updates when necessary.

Impact:
This fix addresses the "chunky" updates observed when debug mode is off, ensuring smoother and more consistent content updates across all modes.