### PR TITLE
file_selector example

### DIFF
--- a/doc/gui/examples/controls/file_selector_image.py
+++ b/doc/gui/examples/controls/file_selector_image.py
@@ -22,16 +22,16 @@ from taipy.gui import Gui, State
 path = ""
 image = None
 
-page = """
-<|{path}|file_selector|on_action=upload|extensions=png,jpg|>
-<|{image}|image|>
-"""
-
 def upload(state: State):
     img = Image.open(state.path)
     img_byte_arr = io.BytesIO()
     img.save(img_byte_arr, format="PNG")
     state.image = img_byte_arr.getvalue()
+
+page = """
+<|{path}|file_selector|on_action=upload|extensions=png,jpg|>
+<|{image}|image|>
+"""
 
 if __name__ == "__main__":
     Gui(page).run(title="File Selector - With image")

--- a/doc/gui/examples/controls/file_selector_image.py
+++ b/doc/gui/examples/controls/file_selector_image.py
@@ -1,0 +1,36 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+# -----------------------------------------------------------------------------------------
+# To execute this script, make sure that the taipy-gui package is installed in your
+# Python environment and run:
+#     python <script>
+# -----------------------------------------------------------------------------------------
+import io
+
+from PIL import Image
+
+from taipy.gui import Gui, State
+
+path = ""
+image = None
+
+page = """
+<|{path}|file_selector|on_action=upload|extensions=png,jpg|> <|{image}|image|>
+"""
+
+def upload(state: State):
+    img = Image.open(state.path)
+    img_byte_arr = io.BytesIO()
+    img.save(img_byte_arr, format="PNG")
+    state.image = img_byte_arr.getvalue()
+
+if __name__ == "__main__":
+    Gui(page).run(title="File Selector - With image")

--- a/doc/gui/examples/controls/file_selector_image.py
+++ b/doc/gui/examples/controls/file_selector_image.py
@@ -23,7 +23,8 @@ path = ""
 image = None
 
 page = """
-<|{path}|file_selector|on_action=upload|extensions=png,jpg|> <|{image}|image|>
+<|{path}|file_selector|on_action=upload|extensions=png,jpg|>
+<|{image}|image|>
 """
 
 def upload(state: State):

--- a/doc/gui/examples/controls/file_selector_simple.py
+++ b/doc/gui/examples/controls/file_selector_simple.py
@@ -20,5 +20,6 @@ filename = "<unknown>"
 page = """<|{filename}|file_selector|>
 <|selected File: {filename}|>
 """
+
 if __name__ == "__main__":
     Gui(page).run(title="File Selector - Simple")

--- a/doc/gui/examples/controls/file_selector_simple.py
+++ b/doc/gui/examples/controls/file_selector_simple.py
@@ -1,0 +1,33 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+# -----------------------------------------------------------------------------------------
+# To execute this script, make sure that the taipy-gui package is installed in your
+# Python environment and run:
+#     python <script>
+# -----------------------------------------------------------------------------------------
+import taipy.gui.builder as tgb
+from taipy.gui import Gui, State
+
+filename = "<unknown>"
+
+
+def print_filename(state: State):
+    print("filename is ", state.filename)  # noqa: T201
+
+def on_change(state: State, var: str, val: str):
+    print(f"on_change(state: State, var: {var}, val: {val})")  # noqa: T201
+
+with tgb.Page() as page:
+    tgb.file_selector("{filename}", on_action=print_filename)
+    tgb.text("selected File: {filename}")
+
+if __name__ == "__main__":
+    Gui(page).run(title="File Selector - Simple")

--- a/doc/gui/examples/controls/file_selector_simple.py
+++ b/doc/gui/examples/controls/file_selector_simple.py
@@ -13,21 +13,12 @@
 # Python environment and run:
 #     python <script>
 # -----------------------------------------------------------------------------------------
-import taipy.gui.builder as tgb
-from taipy.gui import Gui, State
+from taipy.gui import Gui
 
 filename = "<unknown>"
 
-
-def print_filename(state: State):
-    print("filename is ", state.filename)  # noqa: T201
-
-def on_change(state: State, var: str, val: str):
-    print(f"on_change(state: State, var: {var}, val: {val})")  # noqa: T201
-
-with tgb.Page() as page:
-    tgb.file_selector("{filename}", on_action=print_filename)
-    tgb.text("selected File: {filename}")
-
+page = """<|{filename}|file_selector|>
+<|selected File: {filename}|>
+"""
 if __name__ == "__main__":
     Gui(page).run(title="File Selector - Simple")

--- a/taipy/gui/state.py
+++ b/taipy/gui/state.py
@@ -11,11 +11,11 @@
 
 import inspect
 import typing as t
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from contextlib import nullcontext
 from operator import attrgetter
 from pathlib import Path
-from types import FrameType
+from types import FrameType, SimpleNamespace
 
 from flask import has_app_context
 
@@ -26,7 +26,7 @@ if t.TYPE_CHECKING:
     from .gui import Gui
 
 
-class State(ABC):
+class State(SimpleNamespace):
     """Accessor to the bound variables from callbacks.
 
     `State` is used when you need to access the value of variables


### PR DESCRIPTION
🛑make `State` inherit from `SimpleNamespace` so that the linters don't mark `state.var` as an error
Should this single line change to State be backported to 4.0  @FabienLelaquais ?