### PR TITLE
fix: reference fixture instead of mock when injecting param in url

### DIFF
--- a/tests/rest/test_datanode.py
+++ b/tests/rest/test_datanode.py
@@ -33,8 +33,9 @@ def test_delete_datanode(client):
     rep = client.get(user_url)
     assert rep.status_code == 404
 
-    with mock.patch("taipy.core.data._data_manager._DataManager._delete"), mock.patch(
-        "taipy.core.data._data_manager._DataManager._get"
+    with (
+        mock.patch("taipy.core.data._data_manager._DataManager._delete"),
+        mock.patch("taipy.core.data._data_manager._DataManager._get"),
     ):
         # test get_datanode
         rep = client.delete(url_for("api.datanode_by_id", datanode_id="foo"))
@@ -63,7 +64,7 @@ def test_get_all_datanodes(client, default_datanode_config_list):
     for ds in range(10):
         with mock.patch("taipy.rest.api.resources.datanode.DataNodeList.fetch_config") as config_mock:
             config_mock.return_value = default_datanode_config_list[ds]
-            datanodes_url = url_for("api.datanodes", config_id=config_mock.name)
+            datanodes_url = url_for("api.datanodes", config_id=default_datanode_config_list[ds].name)
             client.post(datanodes_url)
 
     rep = client.get(datanodes_url)

--- a/tests/rest/test_scenario.py
+++ b/tests/rest/test_scenario.py
@@ -34,8 +34,9 @@ def test_delete_scenario(client):
     rep = client.get(user_url)
     assert rep.status_code == 404
 
-    with mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._delete"), mock.patch(
-        "taipy.core.scenario._scenario_manager._ScenarioManager._get"
+    with (
+        mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._delete"),
+        mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._get"),
     ):
         # test get_scenario
         rep = client.delete(url_for("api.scenario_by_id", scenario_id="foo"))
@@ -64,7 +65,7 @@ def test_get_all_scenarios(client, default_sequence, default_scenario_config_lis
     for ds in range(10):
         with mock.patch("taipy.rest.api.resources.scenario.ScenarioList.fetch_config") as config_mock:
             config_mock.return_value = default_scenario_config_list[ds]
-            scenarios_url = url_for("api.scenarios", config_id=config_mock.name)
+            scenarios_url = url_for("api.scenarios", config_id=default_scenario_config_list[ds].name)
             client.post(scenarios_url)
 
     rep = client.get(scenarios_url)

--- a/tests/rest/test_sequence.py
+++ b/tests/rest/test_sequence.py
@@ -36,8 +36,9 @@ def test_delete_sequence(client):
     rep = client.get(user_url)
     assert rep.status_code == 404
 
-    with mock.patch("taipy.core.sequence._sequence_manager._SequenceManager._delete"), mock.patch(
-        "taipy.core.sequence._sequence_manager._SequenceManager._get"
+    with (
+        mock.patch("taipy.core.sequence._sequence_manager._SequenceManager._delete"),
+        mock.patch("taipy.core.sequence._sequence_manager._SequenceManager._get"),
     ):
         # test get_sequence
         rep = client.delete(url_for("api.sequence_by_id", sequence_id="foo"))
@@ -73,7 +74,7 @@ def test_get_all_sequences(client, default_scenario_config_list):
     for ds in range(10):
         with mock.patch("taipy.rest.api.resources.scenario.ScenarioList.fetch_config") as config_mock:
             config_mock.return_value = default_scenario_config_list[ds]
-            scenario_url = url_for("api.scenarios", config_id=config_mock.name)
+            scenario_url = url_for("api.scenarios", config_id=default_scenario_config_list[ds].name)
             client.post(scenario_url)
 
     sequences_url = url_for("api.sequences")

--- a/tests/rest/test_task.py
+++ b/tests/rest/test_task.py
@@ -34,8 +34,9 @@ def test_delete_task(client):
     rep = client.get(user_url)
     assert rep.status_code == 404
 
-    with mock.patch("taipy.core.task._task_manager._TaskManager._delete"), mock.patch(
-        "taipy.core.task._task_manager._TaskManager._get"
+    with (
+        mock.patch("taipy.core.task._task_manager._TaskManager._delete"),
+        mock.patch("taipy.core.task._task_manager._TaskManager._get"),
     ):
         # test get_task
         rep = client.delete(url_for("api.task_by_id", task_id="foo"))
@@ -64,7 +65,7 @@ def test_get_all_tasks(client, task_data, default_task_config_list):
     for ds in range(10):
         with mock.patch("taipy.rest.api.resources.task.TaskList.fetch_config") as config_mock:
             config_mock.return_value = default_task_config_list[ds]
-            tasks_url = url_for("api.tasks", config_id=config_mock.name)
+            tasks_url = url_for("api.tasks", config_id=default_task_config_list[ds].name)
             client.post(tasks_url)
 
     rep = client.get(tasks_url)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There were 4 failling unit tests on Taipy Rest, all related to mocking a list of Configs to create objects on the database and them fetch them through the rest api. The mock setup stoped working, Im not sure of the reason, I suppose it was due to a lib update.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #2198 
- Closes #2198 

## How to reproduce the issue

To reproduce the issue, make sure to install a fresh virtual envrironment with the Taipy dependencies and them run 
`pytest tests/rest`.


## Checklist
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Does this solution meet the acceptance criteria of the related issue?
- [x] Is the related issue checklist completed? <- Partially, there are checks that aren't applicable.
- [x] Does this PR adds unit tests for the developed code? If not, why? <- The issue wasn't a bug in Taipy Code, was a bug on the test setup
- [ ] End-to-End tests have been added or updated? <- The issue wasn't a bug in Taipy Code, was a bug on the test setup
- [ ] Was the documentation updated, or a dedicated issue for documentation created? (If applicable) Not Applicable
- [ ] Is the release notes updated? (If applicable) Not Applicable
