### PR TITLE
Scenario delete

### DIFF
--- a/frontend/taipy/src/ScenarioViewer.tsx
+++ b/frontend/taipy/src/ScenarioViewer.tsx
@@ -406,6 +406,7 @@ const ScenarioViewer = (props: ScenarioViewerProps) => {
                     { action: props.onDelete, error_id: getUpdateVar(updateScVars, "error_id") },
                     undefined,
                     undefined,
+                    undefined,
                     true,
                     true,
                     { id: scId }

--- a/tests/gui_core/test_context_crud_scenario.py
+++ b/tests/gui_core/test_context_crud_scenario.py
@@ -35,18 +35,16 @@ def mock_core_get(entity_id):
         return datanode_b
     return None
 
-def mock_is_deletable_false(entity_id):
-    return False
-
 def mock_is_true(entity_id):
     return True
-
-mock_core_delete = Mock()
 
 class TestGuiCoreContext_crud_scenario:
     def test_crud_scenario_delete(self):
         gui_core_context = _GuiCoreContext(Mock())
         state = MockState(Mock())
+
+        mock_core_delete = Mock()
+
         with (
             patch("taipy.gui_core._context.core_get", side_effect=mock_core_get),
             patch("taipy.gui_core._context.is_deletable", side_effect=mock_is_true),

--- a/tests/gui_core/test_context_crud_scenario.py
+++ b/tests/gui_core/test_context_crud_scenario.py
@@ -1,0 +1,60 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import typing as t
+from unittest.mock import Mock, patch
+
+from taipy.common.config.common.scope import Scope
+from taipy.core import DataNode, Scenario
+from taipy.core.data.pickle import PickleDataNode
+from taipy.gui.mock.mock_state import MockState
+from taipy.gui_core._context import _GuiCoreContext
+
+scenario_a = Scenario("scenario_a_config_id", None, {"a_prop": "a"})
+scenario_b = Scenario("scenario_b_config_id", None, {"a_prop": "b"})
+scenarios: t.List[t.Union[t.List, Scenario, None]] = [scenario_a, scenario_b]
+
+
+datanode_a = PickleDataNode("datanode_a_config_id", Scope.SCENARIO)
+datanode_b = PickleDataNode("datanode_b_config_id", Scope.SCENARIO)
+datanodes: t.List[t.Union[t.List, DataNode, None]] = [datanode_a, datanode_b]
+
+
+def mock_core_get(entity_id):
+    if entity_id == datanode_a.id:
+        return datanode_a
+    if entity_id == datanode_b.id:
+        return datanode_b
+    return None
+
+def mock_is_deletable_false(entity_id):
+    return False
+
+def mock_is_true(entity_id):
+    return True
+
+mock_core_delete = Mock()
+
+class TestGuiCoreContext_crud_scenario:
+    def test_crud_scenario_delete(self):
+        gui_core_context = _GuiCoreContext(Mock())
+        state = MockState(Mock())
+        with (
+            patch("taipy.gui_core._context.core_get", side_effect=mock_core_get),
+            patch("taipy.gui_core._context.is_deletable", side_effect=mock_is_true),
+            patch("taipy.gui_core._context.core_delete", side_effect=mock_core_delete)
+        ):
+            gui_core_context.crud_scenario(
+                state,
+                "id",
+                t.cast(dict, {"args": [None, None, None, True, True, {"id": "a_scenario_id"}], "error_id": "error_id"}),
+            )
+            mock_core_delete.assert_called_once()


### PR DESCRIPTION
resolves #2219

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Can't delete scenario using scenario visual element

## Related Tickets & Documents

- Closes #2219 

## How to reproduce the issue

```py
from taipy.gui import Gui
import taipy.gui.builder as tgb

from taipy import Config
import taipy as tp


def update(input):
    return None


inputs_cfg = Config.configure_data_node("inputs")
outputs_cfg = Config.configure_data_node("outputs")
taska_cfg = Config.configure_task(
    "taska", function=update, input=[inputs_cfg], output=[outputs_cfg]
)

scenario_cfg = Config.configure_scenario(id="scenario", task_configs=[taska_cfg])


with tgb.Page() as page:
    with tgb.Page() as page:
        tgb.text("# *Inventory Management* - Forecast **Scenarios**", mode="md")
        tgb.html("hr")

        with tgb.layout("20 80", columns__mobile="1"):
            with tgb.part("sidebar"):
                tgb.text("**Create** and select scenarios", mode="md")
                tgb.scenario_selector("{scenario}")

            with tgb.part("main"):
                tgb.html("br")
                tgb.scenario("{scenario}")

if __name__ == "__main__":
    tp.Orchestrator().run()
    scenario = tp.create_scenario(scenario_cfg)

    Gui(page=page).run(title="2219 Scenario Delete")

```
## Other branches or releases that this needs to be backported
4.0 ?

## Checklist
- [x] Does this solution meet the acceptance criteria of the related issue?
- [x] Is the related issue checklist completed?
- [x] Does this PR adds unit tests for the developed code? If not, why?
- [ ] Is the release notes updated? (If applicable)
