### PR TITLE
CLean parameters for the datanode track_edit method.

### DIFF
--- a/taipy/core/data/csv.py
+++ b/taipy/core/data/csv.py
@@ -116,16 +116,17 @@ class CSVDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
     def storage_type(cls) -> str:
         return cls.__STORAGE_TYPE
 
-    def write_with_column_names(self, data: Any, columns: Optional[List[str]] = None, job_id: Optional[JobId] = None):
+    def write_with_column_names(self, data: Any, columns: Optional[List[str]] = None, editor_id: Optional[str] = None):
         """Write a selection of columns.
 
         Arguments:
             data (Any): The data to write.
             columns (Optional[List[str]]): The list of column names to write.
-            job_id (JobId): An optional identifier of the writer.
+            editor_id (str): An optional identifier of the writer.
         """
         self._write(data, columns)
-        self.track_edit(timestamp=datetime.now(), job_id=job_id)
+        timestamp = datetime.now()
+        self.track_edit(editor_id=editor_id, timestamp=timestamp)
 
     def _read(self):
         return self._read_from_path()

--- a/taipy/core/data/csv.py
+++ b/taipy/core/data/csv.py
@@ -124,8 +124,7 @@ class CSVDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             editor_id (str): An optional identifier of the writer.
         """
         self._write(data, columns)
-        timestamp = datetime.now()
-        self.track_edit(editor_id=editor_id, timestamp=timestamp)
+        self.track_edit(editor_id=editor_id, timestamp=datetime.now())
 
     def _read(self):
         return self._read_from_path()

--- a/taipy/core/data/csv.py
+++ b/taipy/core/data/csv.py
@@ -20,7 +20,6 @@ from taipy.common.config.common.scope import Scope
 
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
-from ..job.job_id import JobId
 from ._file_datanode_mixin import _FileDataNodeMixin
 from ._tabular_datanode_mixin import _TabularDataNodeMixin
 from .data_node import DataNode

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -11,6 +11,7 @@
 
 import functools
 import os
+import typing
 import uuid
 from abc import abstractmethod
 from datetime import datetime, timedelta
@@ -468,7 +469,7 @@ class DataNode(_Entity, _Labeled):
             comment (Optional[str]): The optional comment of the edit.
             **options (Any): User-custom attributes to attach to the edit.
         """
-        edit: Dict[str, Any] = {k: v for k, v in options.items() if v is not None}
+        edit = {k: v for k, v in options.items() if v is not None}
         if job_id:
             edit[EDIT_JOB_ID_KEY] = job_id
         if editor_id:
@@ -479,7 +480,7 @@ class DataNode(_Entity, _Labeled):
             timestamp = self._get_last_modified_datetime(self._properties.get(self._PATH_KEY)) or datetime.now()
         edit[EDIT_TIMESTAMP_KEY] = timestamp
         self.last_edit_date = edit.get(EDIT_TIMESTAMP_KEY)
-        self._edits.append(edit) # type: ignore
+        self._edits.append(typing.cast(Edit, edit))
         self.edits = self._edits
 
     def lock_edit(self, editor_id: Optional[str] = None):

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -33,7 +33,7 @@ from ..job.job_id import JobId
 from ..notification.event import Event, EventEntityType, EventOperation, _make_event
 from ..reason import DataNodeEditInProgress, DataNodeIsNotWritten
 from ._filter import _FilterDataNode
-from .data_node_id import DataNodeId, Edit, EDIT_COMMENT_KEY, EDIT_TIMESTAMP_KEY, EDIT_EDITOR_ID_KEY, EDIT_JOB_ID_KEY
+from .data_node_id import EDIT_COMMENT_KEY, EDIT_EDITOR_ID_KEY, EDIT_JOB_ID_KEY, EDIT_TIMESTAMP_KEY, DataNodeId, Edit
 from .operator import JoinOperator
 
 
@@ -199,6 +199,11 @@ class DataNode(_Entity, _Labeled):
         Additional metadata related to the edition made to the data node can also be provided in Edits.
         """
         return self._edits
+
+    @edits.setter  # type: ignore
+    @_self_setter(_MANAGER_NAME)
+    def edits(self, val):
+        self._edits = val
 
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
@@ -475,6 +480,7 @@ class DataNode(_Entity, _Labeled):
         edit[EDIT_TIMESTAMP_KEY] = timestamp
         self.last_edit_date = edit.get(EDIT_TIMESTAMP_KEY)
         self._edits.append(edit) # type: ignore
+        self.edits = self._edits
 
     def lock_edit(self, editor_id: Optional[str] = None):
         """Lock the data node modification.

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -33,7 +33,7 @@ from ..job.job_id import JobId
 from ..notification.event import Event, EventEntityType, EventOperation, _make_event
 from ..reason import DataNodeEditInProgress, DataNodeIsNotWritten
 from ._filter import _FilterDataNode
-from .data_node_id import DataNodeId, Edit
+from .data_node_id import DataNodeId, Edit, EDIT_COMMENT_KEY, EDIT_TIMESTAMP_KEY, EDIT_EDITOR_ID_KEY, EDIT_JOB_ID_KEY
 from .operator import JoinOperator
 
 
@@ -415,19 +415,19 @@ class DataNode(_Entity, _Labeled):
             )
             return None
 
-    def append(self, data, job_id: Optional[JobId] = None, **kwargs: Dict[str, Any]):
+    def append(self, data, editor_id: Optional[str] = None, **kwargs: Dict[str, Any]):
         """Append some data to this data node.
 
         Arguments:
             data (Any): The data to write to this data node.
-            job_id (JobId): An optional identifier of the writer.
+            editor_id (str): An optional identifier of the editor.
             **kwargs (dict[str, any]): Extra information to attach to the edit document
                 corresponding to this write.
         """
         from ._data_manager_factory import _DataManagerFactory
 
         self._append(data)
-        self.track_edit(job_id=job_id, **kwargs)
+        self.track_edit(editor_id=editor_id, **kwargs)
         self.unlock_edit()
         _DataManagerFactory._build_manager()._set(self)
 
@@ -436,7 +436,7 @@ class DataNode(_Entity, _Labeled):
 
         Arguments:
             data (Any): The data to write to this data node.
-            job_id (JobId): An optional identifier of the writer.
+            job_id (JobId): An optional identifier of the job writing the data.
             **kwargs (dict[str, any]): Extra information to attach to the edit document
                 corresponding to this write.
         """
@@ -447,20 +447,34 @@ class DataNode(_Entity, _Labeled):
         self.unlock_edit()
         _DataManagerFactory._build_manager()._set(self)
 
-    def track_edit(self, **options):
+    def track_edit(self,
+                   job_id: Optional[str] = None,
+                   editor_id: Optional[str] = None,
+                   timestamp: Optional[datetime] = None,
+                   comment: Optional[str] = None,
+                   **options: Dict[str, Any]):
         """Creates and adds a new entry in the edits attribute without writing the data.
 
         Arguments:
-            options (dict[str, any]): track `timestamp`, `comments`, `job_id`. The others are user-custom, users can
-                use options to attach any information to an external edit of a data node.
+            job_id (Optional[str]): The optional identifier of the job writing the data.
+            editor_id (Optional[str]): The optional identifier of the editor writing the data.
+            timestamp (Optional[datetime]): The optional timestamp of the edit. If not provided, the
+                current time is used.
+            comment (Optional[str]): The optional comment of the edit.
+            options (dict[str, any]): User-custom attributes to attach to the edit.
         """
-        edit = {k: v for k, v in options.items() if v is not None}
-        if "timestamp" not in edit:
-            edit["timestamp"] = (
-                self._get_last_modified_datetime(self._properties.get(self._PATH_KEY, None)) or datetime.now()
-            )
-        self.last_edit_date = edit.get("timestamp")
-        self._edits.append(edit)
+        edit: Dict[str, Any] = {k: v for k, v in options.items() if v is not None}
+        if job_id:
+            edit[EDIT_JOB_ID_KEY] = job_id
+        if editor_id:
+            edit[EDIT_EDITOR_ID_KEY] = editor_id
+        if comment:
+            edit[EDIT_COMMENT_KEY] = comment
+        if not timestamp:
+            timestamp = self._get_last_modified_datetime(self._properties.get(self._PATH_KEY)) or datetime.now()
+        edit[EDIT_TIMESTAMP_KEY] = timestamp
+        self.last_edit_date = edit.get(EDIT_TIMESTAMP_KEY)
+        self._edits.append(edit) # type: ignore
 
     def lock_edit(self, editor_id: Optional[str] = None):
         """Lock the data node modification.

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -420,13 +420,13 @@ class DataNode(_Entity, _Labeled):
             )
             return None
 
-    def append(self, data, editor_id: Optional[str] = None, **kwargs: Dict[str, Any]):
+    def append(self, data, editor_id: Optional[str] = None, **kwargs: Any):
         """Append some data to this data node.
 
         Arguments:
             data (Any): The data to write to this data node.
             editor_id (str): An optional identifier of the editor.
-            **kwargs (dict[str, any]): Extra information to attach to the edit document
+            **kwargs (Any): Extra information to attach to the edit document
                 corresponding to this write.
         """
         from ._data_manager_factory import _DataManagerFactory
@@ -436,13 +436,13 @@ class DataNode(_Entity, _Labeled):
         self.unlock_edit()
         _DataManagerFactory._build_manager()._set(self)
 
-    def write(self, data, job_id: Optional[JobId] = None, **kwargs: Dict[str, Any]):
+    def write(self, data, job_id: Optional[JobId] = None, **kwargs: Any):
         """Write some data to this data node.
 
         Arguments:
             data (Any): The data to write to this data node.
             job_id (JobId): An optional identifier of the job writing the data.
-            **kwargs (dict[str, any]): Extra information to attach to the edit document
+            **kwargs (Any): Extra information to attach to the edit document
                 corresponding to this write.
         """
         from ._data_manager_factory import _DataManagerFactory
@@ -457,7 +457,7 @@ class DataNode(_Entity, _Labeled):
                    editor_id: Optional[str] = None,
                    timestamp: Optional[datetime] = None,
                    comment: Optional[str] = None,
-                   **options: Dict[str, Any]):
+                   **options: Any):
         """Creates and adds a new entry in the edits attribute without writing the data.
 
         Arguments:
@@ -466,7 +466,7 @@ class DataNode(_Entity, _Labeled):
             timestamp (Optional[datetime]): The optional timestamp of the edit. If not provided, the
                 current time is used.
             comment (Optional[str]): The optional comment of the edit.
-            options (dict[str, any]): User-custom attributes to attach to the edit.
+            **options (Any): User-custom attributes to attach to the edit.
         """
         edit: Dict[str, Any] = {k: v for k, v in options.items() if v is not None}
         if job_id:

--- a/taipy/core/data/data_node_id.py
+++ b/taipy/core/data/data_node_id.py
@@ -17,3 +17,7 @@ DataNodeId.__doc__ = """Type that holds a `DataNode^` identifier."""
 Edit = NewType("Edit", Dict[str, Any])
 """Type that holds a `DataNode^` edit information."""
 Edit.__doc__ = """Type that holds a `DataNode^` edit information."""
+EDIT_TIMESTAMP_KEY = "timestamp"
+EDIT_JOB_ID_KEY = "job_id"
+EDIT_COMMENT_KEY = "comment"
+EDIT_EDITOR_ID_KEY = "editor_id"

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -119,13 +119,13 @@ class ExcelDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
         """Return the storage type of the data node: "excel"."""
         return cls.__STORAGE_TYPE
 
-    def write_with_column_names(self, data: Any, columns: List[str] = None, job_id: Optional[JobId] = None) -> None:
+    def write_with_column_names(self, data: Any, columns: List[str] = None, editor_id: Optional[str] = None) -> None:
         """Write a set of columns.
 
         Arguments:
             data (Any): The data to write.
             columns (List[str]): The list of column names to write.
-            job_id (Optional[JobId]): An optional identifier of the writer.
+            editor_id (Optional[str]): An optional identifier of the writer.
         """
         if isinstance(data, Dict) and all(isinstance(x, (pd.DataFrame, np.ndarray)) for x in data.values()):
             self._write_excel_with_multiple_sheets(data, columns=columns)
@@ -134,7 +134,7 @@ class ExcelDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             if columns:
                 df = self._set_column_if_dataframe(df, columns)
             self._write_excel_with_single_sheet(df.to_excel, self.path, index=False)
-        self.track_edit(timestamp=datetime.now(), job_id=job_id)
+        self.track_edit(timestamp=datetime.now(), editor_id=editor_id)
 
     @staticmethod
     def _check_exposed_type(exposed_type):

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -21,7 +21,6 @@ from taipy.common.config.common.scope import Scope
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import ExposedTypeLengthMismatch, NonExistingExcelSheet, SheetNameLengthMismatch
-from ..job.job_id import JobId
 from ._file_datanode_mixin import _FileDataNodeMixin
 from ._tabular_datanode_mixin import _TabularDataNodeMixin
 from .data_node import DataNode

--- a/taipy/core/data/parquet.py
+++ b/taipy/core/data/parquet.py
@@ -163,14 +163,14 @@ class ParquetDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
         """Return the storage type of the data node: "parquet"."""
         return cls.__STORAGE_TYPE
 
-    def _write_with_kwargs(self, data: Any, job_id: Optional[JobId] = None, **write_kwargs):
+    def _write_with_kwargs(self, data: Any, editor_id: Optional[str] = None, **write_kwargs):
         """Write the data referenced by this data node.
 
         Keyword arguments here which are also present in the Data Node config will overwrite them.
 
         Arguments:
             data (Any): The data to write.
-            job_id (JobId): An optional identifier of the writer.
+            editor_id (str): An optional identifier of the writer.
             **write_kwargs (dict[str, any]): The keyword arguments passed to the function
                 `pandas.DataFrame.to_parquet()`.
         """
@@ -189,7 +189,7 @@ class ParquetDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
         # Ensure that the columns are strings, otherwise writing will fail with pandas 1.3.5
         df.columns = df.columns.astype(str)
         df.to_parquet(self._path, **kwargs)
-        self.track_edit(timestamp=datetime.now(), job_id=job_id)
+        self.track_edit(timestamp=datetime.now(), editor_id=editor_id)
 
     def read_with_kwargs(self, **read_kwargs):
         """Read data from this data node.

--- a/taipy/core/data/parquet.py
+++ b/taipy/core/data/parquet.py
@@ -21,7 +21,6 @@ from taipy.common.config.common.scope import Scope
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import UnknownCompressionAlgorithm, UnknownParquetEngine
-from ..job.job_id import JobId
 from ._file_datanode_mixin import _FileDataNodeMixin
 from ._tabular_datanode_mixin import _TabularDataNodeMixin
 from .data_node import DataNode

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -52,6 +52,8 @@ from taipy.core import delete as core_delete
 from taipy.core import get as core_get
 from taipy.core import submit as core_submit
 from taipy.core.data._file_datanode_mixin import _FileDataNodeMixin
+from taipy.core.data.data_node_id import EDIT_COMMENT_KEY, EDIT_EDITOR_ID_KEY, EDIT_JOB_ID_KEY, EDIT_TIMESTAMP_KEY
+
 from taipy.core.notification import CoreEventConsumerBase, EventEntityType
 from taipy.core.notification.event import Event, EventOperation
 from taipy.core.notification.notifier import Notifier
@@ -993,7 +995,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
         if id and (dn := core_get(id)) and isinstance(dn, DataNode):
             res = []
             for e in dn.edits:
-                job_id = e.get("job_id")
+                job_id = e.get(EDIT_JOB_ID_KEY)
                 job: t.Optional[Job] = None
                 if job_id:
                     if not (reason := is_readable(job_id)):
@@ -1002,11 +1004,11 @@ class _GuiCoreContext(CoreEventConsumerBase):
                         job = core_get(job_id)
                 res.append(
                     (
-                        e.get("timestamp"),
-                        job_id if job_id else e.get("writer_identifier", ""),
+                        e.get(EDIT_TIMESTAMP_KEY),
+                        job_id if job_id else e.get(EDIT_EDITOR_ID_KEY, ""),
                         f"Execution of task {job.task.get_simple_label()}."
                         if job and job.task
-                        else e.get("comment", ""),
+                        else e.get(EDIT_COMMENT_KEY, ""),
                     )
                 )
             return sorted(res, key=lambda r: r[0], reverse=True)

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -53,7 +53,6 @@ from taipy.core import get as core_get
 from taipy.core import submit as core_submit
 from taipy.core.data._file_datanode_mixin import _FileDataNodeMixin
 from taipy.core.data.data_node_id import EDIT_COMMENT_KEY, EDIT_EDITOR_ID_KEY, EDIT_JOB_ID_KEY, EDIT_TIMESTAMP_KEY
-
 from taipy.core.notification import CoreEventConsumerBase, EventEntityType
 from taipy.core.notification.event import Event, EventOperation
 from taipy.core.notification.notifier import Notifier

--- a/tests/core/notification/test_events_published.py
+++ b/tests/core/notification/test_events_published.py
@@ -145,13 +145,13 @@ def test_events_published_for_writing_dn():
     all_evts = RecordingConsumer(register_id_0, register_queue_0)
     all_evts.start()
 
-    # Write input manually trigger 4 data node update events
-    # for last_edit_date, editor_id, editor_expiration_date and edit_in_progress
+    # Write input manually trigger 5 data node update events
+    # for last_edit_date, editor_id, editor_expiration_date, edit_in_progress and edits
     scenario.the_input.write("test")
     snapshot = all_evts.capture()
-    assert len(snapshot.collected_events) == 4
-    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 4
-    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 4
+    assert len(snapshot.collected_events) == 5
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 5
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 5
     all_evts.stop()
 
 
@@ -178,22 +178,23 @@ def test_events_published_for_scenario_submission():
     # 1 submission update event for is_completed
     scenario.submit()
     snapshot = all_evts.capture()
-    assert len(snapshot.collected_events) == 17
+    assert len(snapshot.collected_events) == 18
     assert snapshot.entity_type_collected.get(EventEntityType.CYCLE, 0) == 0
-    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 7
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 8
     assert snapshot.entity_type_collected.get(EventEntityType.TASK, 0) == 0
     assert snapshot.entity_type_collected.get(EventEntityType.SEQUENCE, 0) == 0
     assert snapshot.entity_type_collected.get(EventEntityType.SCENARIO, 0) == 1
     assert snapshot.entity_type_collected.get(EventEntityType.JOB, 0) == 4
     assert snapshot.entity_type_collected.get(EventEntityType.SUBMISSION, 0) == 5
     assert snapshot.operation_collected.get(EventOperation.CREATION, 0) == 2
-    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 14
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 15
     assert snapshot.operation_collected.get(EventOperation.SUBMISSION, 0) == 1
 
     assert snapshot.attr_name_collected["last_edit_date"] == 1
     assert snapshot.attr_name_collected["editor_id"] == 2
     assert snapshot.attr_name_collected["editor_expiration_date"] == 2
     assert snapshot.attr_name_collected["edit_in_progress"] == 2
+    assert snapshot.attr_name_collected["edits"] == 1
     assert snapshot.attr_name_collected["status"] == 3
     assert snapshot.attr_name_collected["jobs"] == 1
     assert snapshot.attr_name_collected["submission_status"] == 3

--- a/tests/core/notification/test_published_ready_to_run_event.py
+++ b/tests/core/notification/test_published_ready_to_run_event.py
@@ -61,9 +61,9 @@ def test_write_never_written_input_does_not_publish_submittable_event():
     snapshot = all_evts.capture()
 
     # Since it is a lazy property, no submittable event is published. Only the data node update events are published.
-    assert len(snapshot.collected_events) == 4
-    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 4
-    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 4
+    assert len(snapshot.collected_events) == 5
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 5
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 5
 
 
 def test_write_never_written_input_publish_submittable_event_if_scenario_in_property():
@@ -85,12 +85,12 @@ def test_write_never_written_input_publish_submittable_event_if_scenario_in_prop
     snapshot = all_evts.capture()
 
     # Since it is a lazy property, no submittable event is published. Only the data node update events are published.
-    assert len(snapshot.collected_events) == 13
-    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 7
+    assert len(snapshot.collected_events) == 14
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 8
     assert snapshot.entity_type_collected.get(EventEntityType.TASK, 0) == 2
     assert snapshot.entity_type_collected.get(EventEntityType.SEQUENCE, 0) == 2
     assert snapshot.entity_type_collected.get(EventEntityType.SCENARIO, 0) == 2
-    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 13
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 14
     assert snapshot.attr_name_collected["is_submittable"] == 6
     assert snapshot.attr_value_collected["is_submittable"] == [False, False, False, True, True, True]
 
@@ -109,9 +109,9 @@ def test_write_output_does_not_publish_submittable_event():
     scenario.dn_2.write(15)
     snapshot = all_evts.capture()
 
-    assert len(snapshot.collected_events) == 4
-    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 4
-    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 4
+    assert len(snapshot.collected_events) == 5
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 5
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 5
     assert "is_submittable" not in snapshot.attr_name_collected
     assert "is_submittable" not in snapshot.attr_value_collected
     all_evts.stop()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
The PR aims to clean how the data node track edit method parameters are managed.
- A better split between the job_id and the editor_id.
- An explicit parameter naming so we can use constants as the edit keys.
- Unit tests
- Auto set the data node when an edit is added.

## Related Tickets & Documents

- Related Issue #2017 
- Closes #

## Checklist

- [x] Does this PR add unit tests for the developed code? If not, why?
- [x] Was the documentation updated or was a dedicated issue for documentation created? (If applicable)
- [x] Is the release notes updated? Not applicable
