### PR TITLE
Fix - Always initialize the _Reloader method before calling to the _Reloader._get_manager()

### DIFF
--- a/taipy/core/_entity/_entity.py
+++ b/taipy/core/_entity/_entity.py
@@ -37,4 +37,3 @@ class _Entity:
 
         for event in self._in_context_attributes_changed_collector:
             Notifier.publish(event)
-        _Reloader._get_manager(self._MANAGER_NAME)._set(self)

--- a/taipy/core/_entity/_entity.py
+++ b/taipy/core/_entity/_entity.py
@@ -33,7 +33,7 @@ class _Entity:
             for to_delete_key in self._properties._pending_deletions:
                 self._properties.data.pop(to_delete_key, None)
             self._properties.data.update(self._properties._pending_changes)
-        _Reloader._get_manager(self._MANAGER_NAME)._set(self)
+        _Reloader()._get_manager(self._MANAGER_NAME)._set(self)
 
         for event in self._in_context_attributes_changed_collector:
             Notifier.publish(event)

--- a/taipy/core/_entity/_reload.py
+++ b/taipy/core/_entity/_reload.py
@@ -104,7 +104,6 @@ def _self_setter(manager):
         @functools.wraps(fct)
         def _do_set_entity(self, *args, **kwargs):
             fct(self, *args, **kwargs)
-            entity_manager = _Reloader._get_manager(manager)
             value = args[0] if len(args) == 1 else args
             event = _make_event(
                 self,
@@ -115,7 +114,7 @@ def _self_setter(manager):
             if not self._is_in_context:
                 entity = _Reloader()._reload(manager, self)
                 fct(entity, *args, **kwargs)
-                entity_manager._set(entity)
+                _Reloader._get_manager(manager)._set(entity)
                 Notifier.publish(event)
             else:
                 self._in_context_attributes_changed_collector.append(event)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

Previously, the `_Reloader.get_manager()` method can be called when there is no `_Reloader` singleton yet.

It happens in the `_self_setter` decorator and in `_Entity` context.

This PR makes sure a `_Reloader` singleton is initialized before we call to the `_Reloader.get_manager()`