### PR TITLE
non action lambda: do not try to set constants from non scalar or list

### DIFF
--- a/taipy/gui/builder/_utils.py
+++ b/taipy/gui/builder/_utils.py
@@ -39,10 +39,11 @@ class _TransformVarToValue(ast.NodeTransformer):
         if var_parts[0] in self.non_vars:
             return node
         value = _get_value_in_frame(self.frame, var_parts[0])
-        if callable(value):
-            return node
         if len(var_parts) > 1:
             value = attrgetter(var_parts[1])(value)
+        if not isinstance(value, (str, int, float, bool, list, tuple)):
+            # transform into constants only what can be (ie not callable or generator for example)
+            return node
         return ast.Constant(value=value, kind=None)
 
 


### PR DESCRIPTION
resolves #2212

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
non action lambda: do not try to set constants from non scalar or list

## Related Tickets & Documents
- Closes #2212 

## How to reproduce the issue

```py
import numpy as np

import taipy.gui.builder as tgb
from taipy import Gui

rng = np.random.default_rng()
size = 1

with tgb.Page() as main_page:
    tgb.text(lambda size: rng.random(size).sum() > 0)
    with tgb.part(render=lambda size: rng.random(size).sum() > 0):
        tgb.text("Random sum is greater than 0")

if __name__ == "__main__":
    gui = Gui(main_page)
    gui.run(title="2212 [🐛 BUG] Issue using lambda when passing state variable to a method")

```

## Checklist

- [ ] Does this solution meet the acceptance criteria of the related issue?
- [ ] Is the related issue checklist completed?
- [ ] Does this PR adds unit tests for the developed code? If not, why?
- [ ] End-to-End tests have been added or updated?
- [ ] Was the documentation updated, or a dedicated issue for documentation created? (If applicable)
- [ ] Is the release notes updated? (If applicable)
