### PR TITLE
Fix - Set default value for _in_context_attributes_changed_collector

### DIFF
--- a/taipy/core/_entity/_entity.py
+++ b/taipy/core/_entity/_entity.py
@@ -19,7 +19,7 @@ class _Entity:
     _ID_PREFIX: str
     _MANAGER_NAME: str
     _is_in_context = False
-    _in_context_attributes_changed_collector: List
+    _in_context_attributes_changed_collector: List = []
 
     def __enter__(self):
         self._is_in_context = True


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes the problem in https://github.com/Avaiga/taipy-enterprise/pull/559.

When the `_in_context_attributes_changed_collector` has no value at initialization, and the `__getattr__` of an `_Entity` is called, it will raise `AttributeError`.