### PR TITLE
fix: make sure path is in unix format

### DIFF
--- a/taipy/core/_entity/_properties.py
+++ b/taipy/core/_entity/_properties.py
@@ -13,6 +13,7 @@ from collections import UserDict
 
 from taipy.common.config.common._template_handler import _TemplateHandler as _tpl
 
+from ..common._utils import _normalize_path
 from ..notification import EventOperation, Notifier, _make_event
 
 
@@ -26,6 +27,8 @@ class _Properties(UserDict):
         self._pending_deletions = set()
 
     def __setitem__(self, key, value):
+        if key == "path":
+            value = _normalize_path(value)
         super(_Properties, self).__setitem__(key, value)
 
         if hasattr(self, "_entity_owner"):

--- a/taipy/core/common/_utils.py
+++ b/taipy/core/common/_utils.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import functools
+import re
 import time
 from collections import namedtuple
 from importlib import import_module
@@ -77,6 +78,10 @@ def _fct_to_dict(obj):
 
 def _fcts_to_dict(objs):
     return [d for obj in objs if (d := _fct_to_dict(obj)) is not None]
+
+
+def _normalize_path(path: str) -> str:
+    return re.sub(r"[\\]+", "/", path)
 
 
 _Subscriber = namedtuple("_Subscriber", "callback params")

--- a/taipy/core/config/data_node_config.py
+++ b/taipy/core/config/data_node_config.py
@@ -10,7 +10,6 @@
 # specific language governing permissions and limitations under the License.
 
 import json
-import re
 from copy import copy
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -22,6 +21,7 @@ from taipy.common.config.common._template_handler import _TemplateHandler as _tp
 from taipy.common.config.common.scope import Scope
 from taipy.common.config.section import Section
 
+from ..common._utils import _normalize_path
 from ..common._warnings import _warn_deprecated
 from ..common.mongo_default_document import MongoDefaultDocument
 
@@ -277,7 +277,7 @@ class DataNodeConfig(Section):
         self._scope = scope
         self._validity_period = validity_period
         if "path" in properties:
-            properties["path"] = self._normalize_path(properties["path"])
+            properties["path"] = _normalize_path(properties["path"])
         super().__init__(id, **properties)
 
         # modin exposed type is deprecated since taipy 3.1.0
@@ -294,10 +294,6 @@ class DataNodeConfig(Section):
 
     def __getattr__(self, item: str) -> Optional[Any]:
         return _tpl._replace_templates(self._properties.get(item))
-
-    @staticmethod
-    def _normalize_path(path: str) -> str:
-        return re.sub(r"[\\]+", "/", path)
 
     @property
     def storage_type(self) -> str:

--- a/taipy/core/config/data_node_config.py
+++ b/taipy/core/config/data_node_config.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import json
+import re
 from copy import copy
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -275,6 +276,8 @@ class DataNodeConfig(Section):
         self._storage_type = storage_type
         self._scope = scope
         self._validity_period = validity_period
+        if "path" in properties:
+            properties["path"] = self._normalize_path(properties["path"])
         super().__init__(id, **properties)
 
         # modin exposed type is deprecated since taipy 3.1.0
@@ -291,6 +294,10 @@ class DataNodeConfig(Section):
 
     def __getattr__(self, item: str) -> Optional[Any]:
         return _tpl._replace_templates(self._properties.get(item))
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        return re.sub(r"[\\]+", "/", path)
 
     @property
     def storage_type(self) -> str:
@@ -322,7 +329,7 @@ class DataNodeConfig(Section):
 
     @property
     def validity_period(self) -> Optional[timedelta]:
-        """ The validity period of the data nodes instantiated from the data node config.
+        """The validity period of the data nodes instantiated from the data node config.
 
         It corresponds to the duration since the last edit date for which the data node
         can be considered valid. Once the validity period has passed, the data node is

--- a/taipy/core/data/_file_datanode_mixin.py
+++ b/taipy/core/data/_file_datanode_mixin.py
@@ -11,7 +11,6 @@
 
 import os
 import pathlib
-import re
 import shutil
 from datetime import datetime
 from os.path import isfile
@@ -21,6 +20,7 @@ from taipy.common.config import Config
 from taipy.common.logger._taipy_logger import _TaipyLogger
 
 from .._entity._reload import _self_reload
+from ..common._utils import _normalize_path
 from ..reason import InvalidUploadFile, NoFileToDownload, NotAFile, ReasonCollection, UploadFileCanNotBeRead
 from .data_node import DataNode
 from .data_node_id import Edit
@@ -61,11 +61,11 @@ class _FileDataNodeMixin(object):
     @_self_reload(DataNode._MANAGER_NAME)
     def path(self) -> str:
         """The path to the file data of the data node."""
-        return self._path
+        return _normalize_path(self._path)
 
     @path.setter
     def path(self, value) -> None:
-        _path = self._normalize_path(value)
+        _path = _normalize_path(value)
         self._path = _path
         self.properties[self._PATH_KEY] = _path  # type: ignore[attr-defined]
         self.properties[self._IS_GENERATED_KEY] = False  # type: ignore[attr-defined]
@@ -182,7 +182,3 @@ class _FileDataNodeMixin(object):
         if os.path.exists(old_path):
             shutil.move(old_path, new_path)
         return new_path
-
-    @staticmethod
-    def _normalize_path(path: str) -> str:
-        return re.sub(r"[\\]+", "/", path)

--- a/taipy/core/data/_file_datanode_mixin.py
+++ b/taipy/core/data/_file_datanode_mixin.py
@@ -11,6 +11,7 @@
 
 import os
 import pathlib
+import re
 import shutil
 from datetime import datetime
 from os.path import isfile
@@ -64,9 +65,10 @@ class _FileDataNodeMixin(object):
 
     @path.setter
     def path(self, value) -> None:
-        self._path = value
-        self.properties[self._PATH_KEY] = value
-        self.properties[self._IS_GENERATED_KEY] = False
+        _path = self._normalize_path(value)
+        self._path = _path
+        self.properties[self._PATH_KEY] = _path  # type: ignore[attr-defined]
+        self.properties[self._IS_GENERATED_KEY] = False  # type: ignore[attr-defined]
 
     def is_downloadable(self) -> ReasonCollection:
         """Check if the data node is downloadable.
@@ -180,3 +182,7 @@ class _FileDataNodeMixin(object):
         if os.path.exists(old_path):
             shutil.move(old_path, new_path)
         return new_path
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        return re.sub(r"[\\]+", "/", path)

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -405,3 +405,8 @@ def test_clean_config():
     assert dn1_config.validity_period is dn2_config.validity_period is None
     assert dn1_config.default_path is dn2_config.default_path is None
     assert dn1_config.properties == dn2_config.properties == {}
+
+
+def test_normalize_path():
+    data_node_config = Config.configure_data_node(id="data_nodes1", storage_type="csv", path=r"data\file.csv")
+    assert data_node_config.path == "data/file.csv"

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -807,3 +807,15 @@ class TestDataNode:
         edit_5 = data_node.edits[5]
         assert len(edit_5) == 1
         assert edit_5[EDIT_TIMESTAMP_KEY] == timestamp
+
+    def test_normalize_path(self):
+        dn = DataNode(
+            config_id="foo_bar",
+            scope=Scope.SCENARIO,
+            id=DataNodeId("an_id"),
+            path=r"data\foo\bar.csv",
+        )
+        assert dn.config_id == "foo_bar"
+        assert dn.scope == Scope.SCENARIO
+        assert dn.id == "an_id"
+        assert dn.properties["path"] == "data/foo/bar.csv"

--- a/tests/core/data/test_excel_data_node.py
+++ b/tests/core/data/test_excel_data_node.py
@@ -11,6 +11,7 @@
 
 import os
 import pathlib
+import re
 import uuid
 from datetime import datetime, timedelta
 from time import sleep
@@ -24,6 +25,7 @@ from pandas.testing import assert_frame_equal
 
 from taipy.common.config import Config
 from taipy.common.config.common.scope import Scope
+from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node_id import DataNodeId
@@ -183,7 +185,7 @@ class TestExcelDataNode:
     )
     def test_create_with_default_data(self, properties, exists):
         dn = ExcelDataNode("foo", Scope.SCENARIO, DataNodeId(f"dn_id_{uuid.uuid4()}"), properties=properties)
-        assert dn.path == os.path.join(Config.core.storage_folder.strip("/"), "excels", dn.id + ".xlsx")
+        assert dn.path == f"{Config.core.storage_folder}excels/{dn.id}.xlsx"
         assert os.path.exists(dn.path) is exists
 
     def test_read_write_after_modify_path(self):
@@ -423,7 +425,7 @@ class TestExcelDataNode:
         reasons = dn.is_downloadable()
         assert not reasons
         assert len(reasons._reasons) == 1
-        assert str(NoFileToDownload(path, dn.id)) in reasons.reasons
+        assert str(NoFileToDownload(_normalize_path(path), dn.id)) in reasons.reasons
 
     def test_is_not_downloadable_not_a_file(self):
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample")
@@ -431,12 +433,12 @@ class TestExcelDataNode:
         reasons = dn.is_downloadable()
         assert not reasons
         assert len(reasons._reasons) == 1
-        assert str(NotAFile(path, dn.id)) in reasons.reasons
+        assert str(NotAFile(_normalize_path(path), dn.id)) in reasons.reasons
 
     def test_get_download_path(self):
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.xlsx")
         dn = ExcelDataNode("foo", Scope.SCENARIO, properties={"path": path, "exposed_type": "pandas"})
-        assert dn._get_downloadable_path() == path
+        assert re.split(r"[\\/]", dn._get_downloadable_path()) == re.split(r"[\\/]", path)
 
     def test_get_downloadable_path_with_not_existing_file(self):
         dn = ExcelDataNode("foo", Scope.SCENARIO, properties={"path": "NOT_EXISTING.xlsx", "exposed_type": "pandas"})
@@ -457,7 +459,7 @@ class TestExcelDataNode:
 
         assert_frame_equal(dn.read()["Sheet1"], upload_content)  # The data of dn should change to the uploaded content
         assert dn.last_edit_date > old_last_edit_date
-        assert dn.path == old_xlsx_path  # The path of the dn should not change
+        assert dn.path == _normalize_path(old_xlsx_path)  # The path of the dn should not change
 
     def test_upload_with_upload_check_pandas(self, excel_file, tmpdir_factory):
         old_xlsx_path = tmpdir_factory.mktemp("data").join("df.xlsx").strpath
@@ -503,7 +505,7 @@ class TestExcelDataNode:
 
         assert_frame_equal(dn.read()["Sheet1"], old_data)  # The content of the dn should not change when upload fails
         assert dn.last_edit_date == old_last_edit_date  # The last edit date should not change when upload fails
-        assert dn.path == old_xlsx_path  # The path of the dn should not change
+        assert dn.path == _normalize_path(old_xlsx_path)  # The path of the dn should not change
 
         # The upload should succeed when check_data_column() return True
         assert dn._upload(excel_file, upload_checker=check_data_column)
@@ -552,7 +554,7 @@ class TestExcelDataNode:
 
         np.array_equal(dn.read()["Sheet1"], old_data)  # The content of the dn should not change when upload fails
         assert dn.last_edit_date == old_last_edit_date  # The last edit date should not change when upload fails
-        assert dn.path == old_excel_path  # The path of the dn should not change
+        assert dn.path == _normalize_path(old_excel_path)  # The path of the dn should not change
 
         # The upload should succeed when check_data_is_positive() return True
         assert dn._upload(new_excel_path, upload_checker=check_data_is_positive)

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -11,6 +11,7 @@
 
 import os
 import pathlib
+import re
 import uuid
 from datetime import datetime, timedelta
 from importlib import util
@@ -25,6 +26,7 @@ from pandas.testing import assert_frame_equal
 from taipy.common.config import Config
 from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
+from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node_id import DataNodeId
@@ -142,7 +144,7 @@ class TestParquetDataNode:
     )
     def test_create_with_default_data(self, properties, exists):
         dn = ParquetDataNode("foo", Scope.SCENARIO, DataNodeId(f"dn_id_{uuid.uuid4()}"), properties=properties)
-        assert dn.path == os.path.join(Config.core.storage_folder.strip("/"), "parquets", dn.id + ".parquet")
+        assert dn.path == f"{Config.core.storage_folder}parquets/{dn.id}.parquet"
         assert os.path.exists(dn.path) is exists
 
     @pytest.mark.parametrize("engine", __engine)
@@ -248,7 +250,7 @@ class TestParquetDataNode:
         reasons = dn.is_downloadable()
         assert not reasons
         assert len(reasons._reasons) == 1
-        assert str(NoFileToDownload(path, dn.id)) in reasons.reasons
+        assert str(NoFileToDownload(_normalize_path(path), dn.id)) in reasons.reasons
 
     def test_is_not_downloadable_not_a_file(self):
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample")
@@ -256,12 +258,12 @@ class TestParquetDataNode:
         reasons = dn.is_downloadable()
         assert not reasons
         assert len(reasons._reasons) == 1
-        assert str(NotAFile(path, dn.id)) in reasons.reasons
+        assert str(NotAFile(_normalize_path(path), dn.id)) in reasons.reasons
 
     def test_get_downloadable_path(self):
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.parquet")
         dn = ParquetDataNode("foo", Scope.SCENARIO, properties={"path": path, "exposed_type": "pandas"})
-        assert dn._get_downloadable_path() == path
+        assert re.split(r"[\\/]", dn._get_downloadable_path()) == re.split(r"[\\/]", path)
 
     def test_get_downloadable_path_with_not_existing_file(self):
         dn = ParquetDataNode("foo", Scope.SCENARIO, properties={"path": "NOT_EXISTING.parquet"})
@@ -287,7 +289,7 @@ class TestParquetDataNode:
 
         assert_frame_equal(dn.read(), upload_content)  # The content of the dn should change to the uploaded content
         assert dn.last_edit_date > old_last_edit_date
-        assert dn.path == old_parquet_path  # The path of the dn should not change
+        assert dn.path == _normalize_path(old_parquet_path)  # The path of the dn should not change
 
     def test_upload_with_upload_check_pandas(self, parquet_file_path, tmpdir_factory):
         old_parquet_path = tmpdir_factory.mktemp("data").join("df.parquet").strpath
@@ -332,7 +334,7 @@ class TestParquetDataNode:
 
         assert_frame_equal(dn.read(), old_data)  # The content of the dn should not change when upload fails
         assert dn.last_edit_date == old_last_edit_date  # The last edit date should not change when upload fails
-        assert dn.path == old_parquet_path  # The path of the dn should not change
+        assert dn.path == _normalize_path(old_parquet_path)  # The path of the dn should not change
 
         # The upload should succeed when check_data_column() return True
         assert dn._upload(parquet_file_path, upload_checker=check_data_column)
@@ -382,7 +384,7 @@ class TestParquetDataNode:
 
         np.array_equal(dn.read(), old_data)  # The content of the dn should not change when upload fails
         assert dn.last_edit_date == old_last_edit_date  # The last edit date should not change when upload fails
-        assert dn.path == old_parquet_path  # The path of the dn should not change
+        assert dn.path == _normalize_path(old_parquet_path)  # The path of the dn should not change
 
         # The upload should succeed when check_data_is_positive() return True
         assert dn._upload(new_parquet_path, upload_checker=check_data_is_positive)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When creating a file datanode(csv, excel, json, etc) on a windows host machine the path points to a location on the filesystem with the windows path syntax(`C:\Users\foo\file.csv`). If the user tries to run a unix base Docker container to execute the same code, an error will ocur because the python interpreter can't understand the path. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #2261  
- Closes #2261

## How to reproduce the issue

The steps to reproduce the issue can be found on the reported issue.


## Checklist
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Does this solution meet the acceptance criteria of the related issue?
- [ ] Is the related issue checklist completed?
- [x] Does this PR adds unit tests for the developed code? If not, why?
- [ ] End-to-End tests have been added or updated?
- [ ] Was the documentation updated, or a dedicated issue for documentation created? (If applicable)
- [ ] Is the release notes updated? (If applicable)
