### PR TITLE
authorization for submission access

### DIFF
--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -70,6 +70,7 @@ from ._adapters import (
     _GuiCoreScenarioProperties,
     _invoke_action,
 )
+from ._utils import ClientStatus
 from .filters import CustomScenarioFilter
 
 
@@ -92,7 +93,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
         self.data_nodes_by_owner: t.Optional[t.Dict[t.Optional[str], t.List[DataNode]]] = None
         self.scenario_configs: t.Optional[t.List[t.Tuple[str, str]]] = None
         self.jobs_list: t.Optional[t.List[Job]] = None
-        self.client_submission: t.Dict[str, SubmissionStatus] = {}
+        self.client_submission: t.Dict[str, ClientStatus] = {}
         # register to taipy core notification
         reg_id, reg_queue = Notifier.register()
         # locks
@@ -162,28 +163,32 @@ class _GuiCoreContext(CoreEventConsumerBase):
         self.broadcast_core_changed({"scenario": scenario_id or True})
 
     def submission_status_callback(self, submission_id: t.Optional[str] = None, event: t.Optional[Event] = None):
-        if not submission_id or not is_readable(t.cast(SubmissionId, submission_id)):
+        if not submission_id:
             return
         submission = None
         new_status = None
         payload: t.Optional[t.Dict[str, t.Any]] = None
         client_id: t.Optional[str] = None
         try:
-            last_status = self.client_submission.get(submission_id)
-            if not last_status:
+            last_client_status = self.client_submission.get(submission_id)
+            if not last_client_status:
                 return
 
-            submission = t.cast(Submission, core_get(submission_id))
-            if not submission or not submission.entity_id:
-                return
+            client_id = last_client_status.client_id
 
-            payload = {}
-            new_status = t.cast(SubmissionStatus, submission.submission_status)
+            with self.gui._get_authorization(client_id):
+                if not is_readable(t.cast(SubmissionId, submission_id)):
+                    return
+                submission = t.cast(Submission, core_get(submission_id))
+                if not submission or not submission.entity_id:
+                    return
 
-            client_id = submission.properties.get("client_id")
-            if client_id:
-                running_tasks = {}
-                with self.gui._get_authorization(client_id):
+                payload = {}
+                new_status = t.cast(SubmissionStatus, submission.submission_status)
+
+                if client_id:
+                    running_tasks = {}
+                    # with self.gui._get_authorization(client_id):
                     for job in submission.jobs:
                         job = job if isinstance(job, Job) else t.cast(Job, core_get(job))
                         running_tasks[job.task.id] = (
@@ -195,7 +200,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
                         )
                     payload.update(tasks=running_tasks)
 
-                    if last_status is not new_status:
+                    if last_client_status.submission_status is not new_status:
                         # callback
                         submission_name = submission.properties.get("on_submission")
                         if submission_name:
@@ -213,15 +218,15 @@ class _GuiCoreContext(CoreEventConsumerBase):
                                 submission.properties.get("module_context"),
                             )
 
-            with self.submissions_lock:
-                if new_status in (
-                    SubmissionStatus.COMPLETED,
-                    SubmissionStatus.FAILED,
-                    SubmissionStatus.CANCELED,
-                ):
+            if new_status in (
+                SubmissionStatus.COMPLETED,
+                SubmissionStatus.FAILED,
+                SubmissionStatus.CANCELED,
+            ):
+                with self.submissions_lock:
                     self.client_submission.pop(submission_id, None)
-                else:
-                    self.client_submission[submission_id] = new_status
+            else:
+                last_client_status.submission_status = new_status
 
         except Exception as e:
             _warn(f"Submission ({submission_id}) is not available", e)
@@ -634,11 +639,11 @@ class _GuiCoreContext(CoreEventConsumerBase):
                     client_id=self.gui._get_client_id(),
                     module_context=self.gui._get_locals_context(),
                 )
+                client_status = ClientStatus(self.gui._get_client_id(), submission_entity.submission_status)
                 with self.submissions_lock:
-                    self.client_submission[submission_entity.id] = submission_entity.submission_status
+                    self.client_submission[submission_entity.id] = client_status
                 if Config.core.mode == "development":
-                    with self.submissions_lock:
-                        self.client_submission[submission_entity.id] = SubmissionStatus.SUBMITTED
+                    client_status.submission_status = SubmissionStatus.SUBMITTED
                     self.submission_status_callback(submission_entity.id)
                 _GuiCoreContext.__assign_var(state, error_var, "")
         except Exception as e:

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -70,7 +70,7 @@ from ._adapters import (
     _GuiCoreScenarioProperties,
     _invoke_action,
 )
-from ._utils import ClientStatus
+from ._utils import _ClientStatus
 from .filters import CustomScenarioFilter
 
 
@@ -93,7 +93,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
         self.data_nodes_by_owner: t.Optional[t.Dict[t.Optional[str], t.List[DataNode]]] = None
         self.scenario_configs: t.Optional[t.List[t.Tuple[str, str]]] = None
         self.jobs_list: t.Optional[t.List[Job]] = None
-        self.client_submission: t.Dict[str, ClientStatus] = {}
+        self.client_submission: t.Dict[str, _ClientStatus] = {}
         # register to taipy core notification
         reg_id, reg_queue = Notifier.register()
         # locks
@@ -639,7 +639,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
                     client_id=self.gui._get_client_id(),
                     module_context=self.gui._get_locals_context(),
                 )
-                client_status = ClientStatus(self.gui._get_client_id(), submission_entity.submission_status)
+                client_status = _ClientStatus(self.gui._get_client_id(), submission_entity.submission_status)
                 with self.submissions_lock:
                     self.client_submission[submission_entity.id] = client_status
                 if Config.core.mode == "development":

--- a/taipy/gui_core/_utils.py
+++ b/taipy/gui_core/_utils.py
@@ -1,0 +1,20 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+from dataclasses import dataclass
+import typing as t
+
+from taipy.core.submission.submission_status import SubmissionStatus
+
+
+@dataclass
+class ClientStatus:
+    client_id: t.Optional[str]
+    submission_status: SubmissionStatus

--- a/taipy/gui_core/_utils.py
+++ b/taipy/gui_core/_utils.py
@@ -15,6 +15,6 @@ from taipy.core.submission.submission_status import SubmissionStatus
 
 
 @dataclass
-class ClientStatus:
+class _ClientStatus:
     client_id: t.Optional[str]
     submission_status: SubmissionStatus

--- a/taipy/gui_core/_utils.py
+++ b/taipy/gui_core/_utils.py
@@ -8,8 +8,8 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-from dataclasses import dataclass
 import typing as t
+from dataclasses import dataclass
 
 from taipy.core.submission.submission_status import SubmissionStatus
 

--- a/tests/gui_core/test_context_is_readable.py
+++ b/tests/gui_core/test_context_is_readable.py
@@ -29,6 +29,7 @@ from taipy.core.submission.submission import Submission, SubmissionStatus
 from taipy.core.task._task_manager_factory import _TaskManagerFactory
 from taipy.gui import Gui
 from taipy.gui_core._context import _GuiCoreContext
+from taipy.gui_core._utils import _ClientStatus
 
 a_cycle = Cycle(Frequency.DAILY, {}, datetime.now(), datetime.now(), datetime.now(), id=CycleId("CYCLE_id"))
 a_scenario = Scenario("scenario_config_id", None, {}, sequences={"sequence": {}})
@@ -201,7 +202,7 @@ class TestGuiCoreContext_is_readable:
             def sub_cb():
                 return True
 
-            gui_core_context.client_submission[a_submission.id] = SubmissionStatus.UNDEFINED
+            gui_core_context.client_submission[a_submission.id] = _ClientStatus("", SubmissionStatus.UNDEFINED)
             gui_core_context.submission_status_callback(a_submission.id)
             mockget.assert_called()
             found = False

--- a/tests/gui_core/test_context_is_readable.py
+++ b/tests/gui_core/test_context_is_readable.py
@@ -27,7 +27,7 @@ from taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactor
 from taipy.core.submission._submission_manager_factory import _SubmissionManagerFactory
 from taipy.core.submission.submission import Submission, SubmissionStatus
 from taipy.core.task._task_manager_factory import _TaskManagerFactory
-from taipy.gui import Gui
+from taipy.gui import Gui, State
 from taipy.gui_core._context import _GuiCoreContext
 from taipy.gui_core._utils import _ClientStatus
 
@@ -67,9 +67,14 @@ def mock_core_get(entity_id):
     return a_task
 
 
-class MockState:
+class MockState(State):
     def __init__(self, **kwargs) -> None:
-        self.assign = kwargs.get("assign")
+        self.assign = t.cast(t.Callable, kwargs.get("assign")) # type: ignore[method-assign]
+        self.gui = t.cast(Gui, kwargs.get("gui"))
+    def get_gui(self):
+        return self.gui
+    def broadcast(self, name: str, value: t.Any):
+        pass
 
 
 class TestGuiCoreContext_is_readable:
@@ -97,7 +102,7 @@ class TestGuiCoreContext_is_readable:
     def test_cycle_adapter(self):
         with patch("taipy.gui_core._context.core_get", side_effect=mock_core_get):
             gui_core_context = _GuiCoreContext(Mock())
-            gui_core_context.scenario_by_cycle = {"a": 1}
+            gui_core_context.scenario_by_cycle = t.cast(dict, {"a": 1})
             outcome = gui_core_context.cycle_adapter(a_cycle)
             assert isinstance(outcome, list)
             assert outcome[0] == a_cycle.id
@@ -121,9 +126,9 @@ class TestGuiCoreContext_is_readable:
             gui_core_context = _GuiCoreContext(Mock())
             assign = Mock()
             gui_core_context.crud_scenario(
-                MockState(assign=assign),
+                MockState(assign=assign, gui=gui_core_context.gui),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         "",
                         "",
@@ -133,7 +138,7 @@ class TestGuiCoreContext_is_readable:
                         {"name": "name", "id": a_scenario.id},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_not_called()
 
@@ -142,7 +147,7 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.crud_scenario(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             "",
                             "",
@@ -152,7 +157,7 @@ class TestGuiCoreContext_is_readable:
                             {"name": "name", "id": a_scenario.id},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"
@@ -165,12 +170,12 @@ class TestGuiCoreContext_is_readable:
             gui_core_context.edit_entity(
                 MockState(assign=assign),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         {"name": "name", "id": a_scenario.id},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_called_once()
             assert assign.call_args.args[0] == "error_var"
@@ -181,12 +186,12 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.edit_entity(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             {"name": "name", "id": a_scenario.id},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"
@@ -199,10 +204,7 @@ class TestGuiCoreContext_is_readable:
             mockGui._get_authorization = lambda s: contextlib.nullcontext()
             gui_core_context = _GuiCoreContext(mockGui)
 
-            def sub_cb():
-                return True
-
-            gui_core_context.client_submission[a_submission.id] = _ClientStatus("", SubmissionStatus.UNDEFINED)
+            gui_core_context.client_submission[a_submission.id] = _ClientStatus("client_id", SubmissionStatus.UNDEFINED)
             gui_core_context.submission_status_callback(a_submission.id)
             mockget.assert_called()
             found = False
@@ -249,12 +251,12 @@ class TestGuiCoreContext_is_readable:
             gui_core_context.act_on_jobs(
                 MockState(assign=assign),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         {"id": [a_job.id], "action": "delete"},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_called_once()
             assert assign.call_args.args[0] == "error_var"
@@ -264,12 +266,12 @@ class TestGuiCoreContext_is_readable:
             gui_core_context.act_on_jobs(
                 MockState(assign=assign),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         {"id": [a_job.id], "action": "cancel"},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_called_once()
             assert assign.call_args.args[0] == "error_var"
@@ -280,12 +282,12 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.act_on_jobs(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             {"id": [a_job.id], "action": "delete"},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"
@@ -295,12 +297,12 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.act_on_jobs(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             {"id": [a_job.id], "action": "cancel"},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"
@@ -313,12 +315,12 @@ class TestGuiCoreContext_is_readable:
             gui_core_context.edit_data_node(
                 MockState(assign=assign),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         {"id": a_datanode.id},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_called_once()
             assert assign.call_args.args[0] == "error_var"
@@ -329,12 +331,12 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.edit_data_node(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             {"id": a_datanode.id},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"
@@ -349,12 +351,12 @@ class TestGuiCoreContext_is_readable:
             gui_core_context.lock_datanode_for_edit(
                 MockState(assign=assign),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         {"id": a_datanode.id},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_called_once()
             assert assign.call_args.args[0] == "error_var"
@@ -365,12 +367,12 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.lock_datanode_for_edit(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             {"id": a_datanode.id},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"
@@ -396,12 +398,12 @@ class TestGuiCoreContext_is_readable:
             gui_core_context.update_data(
                 MockState(assign=assign),
                 "",
-                {
+                t.cast(dict, {
                     "args": [
                         {"id": a_datanode.id},
                     ],
                     "error_id": "error_var",
-                },
+                }),
             )
             assign.assert_called()
             assert assign.call_args_list[0].args[0] == "error_var"
@@ -412,12 +414,12 @@ class TestGuiCoreContext_is_readable:
                 gui_core_context.update_data(
                     MockState(assign=assign),
                     "",
-                    {
+                    t.cast(dict, {
                         "args": [
                             {"id": a_datanode.id},
                         ],
                         "error_id": "error_var",
-                    },
+                    }),
                 )
                 assign.assert_called_once()
                 assert assign.call_args.args[0] == "error_var"


### PR DESCRIPTION
resolves Avaiga/taipy-enterprise#562

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Authorization for submission access

## Related Tickets & Documents
- Closes taipy-enterprise#562

## How to reproduce the issue

```py
from taipy import Config
import taipy as tp
from taipy.gui import Gui, notify
from taipy.gui import Gui
from taipy.auth import hash_taipy_password
from taipy.gui import State, navigate
import taipy.enterprise.gui as tp_enterprise
import os
from taipy import Config


os.environ["TAIPY_AUTH_HASH"] = "taipy"


passwords = {
    "florian": hash_taipy_password("florian"),
}

roles = {
    "florian": {"admin", "TAIPY_ADMIN"},
}

Config.configure_job_executions(mode="standalone", max_nb_of_workers=2)
Config.configure_authentication("taipy", passwords=passwords, roles=roles)


def on_login(state: State, id, login_args):
    username, password = "florian", "florian"
    credentials = tp_enterprise.login(state, username, password)
    print(credentials.roles)
    navigate(state, "Home", force=True)


# Normal function used by Taipy
def double(nb):
    return nb * 2


# Configuration of Data Nodes
input_cfg = Config.configure_data_node("input_dn", default_data=21)
output_cfg = Config.configure_data_node("output_dn")


# Configuration of tasks
first_task_cfg = Config.configure_task("double", double, input_cfg, output_cfg)


# Configuration of scenario
scenario_cfg = Config.configure_scenario(
    id="my_scenario",
    task_configs=[
        first_task_cfg,
    ],
    name="my_scenario",
)

if __name__ == "__main__":
    tp.Orchestrator().run()

    scenario_1 = None

    scenario_md = """
<|{scenario_1}|scenario_selector|>
<|{scenario_1}|scenario|>
"""

    pages = {
        "/": "<|navbar|>",
        "login": "<|Login|login|>",
        "Home": scenario_md,
    }

    Gui(pages=pages).run()
```

## Other branches or releases that this needs to be backported
_Describe which projects this change will impact and that needs to be backported._

## Checklist

- [ ] Does this solution meet the acceptance criteria of the related issue?
- [ ] Is the related issue checklist completed?
- [ ] Does this PR adds unit tests for the developed code? If not, why?
- [ ] End-to-End tests have been added or updated?
- [ ] Was the documentation updated, or a dedicated issue for documentation created? (If applicable)
- [ ] Is the release notes updated? (If applicable)
