### PR TITLE
fix flickering on empty table refresh

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
@@ -425,8 +425,8 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
     }, [pageSizeOptions, allowAllRows, pageSize]);
 
     const { rows, rowCount, filteredCount, compRows } = useMemo(() => {
-        const ret = { rows: [], rowCount: 0, filteredCount: 0, compRows: [] } as {
-            rows: RowType[];
+        const ret = { rows: undefined, rowCount: 0, filteredCount: 0, compRows: [] } as {
+            rows?: RowType[];
             rowCount: number;
             filteredCount: number;
             compRows: RowType[];
@@ -454,7 +454,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
                 createSendActionNameAction(updateVarName, module, {
                     action: onEdit,
                     value: value,
-                    index: getRowIndex(rows[rowIndex], rowIndex, startIndex),
+                    index: rows ? getRowIndex(rows[rowIndex], rowIndex, startIndex) : startIndex,
                     col: colName,
                     user_value: userValue,
                     tz: tz,
@@ -469,7 +469,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
             dispatch(
                 createSendActionNameAction(updateVarName, module, {
                     action: onDelete,
-                    index: getRowIndex(rows[rowIndex], rowIndex, startIndex),
+                    index: rows ? getRowIndex(rows[rowIndex], rowIndex, startIndex): startIndex,
                     user_data: userData,
                 })
             ),
@@ -481,7 +481,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
             dispatch(
                 createSendActionNameAction(updateVarName, module, {
                     action: onAction,
-                    index: getRowIndex(rows[rowIndex], rowIndex, startIndex),
+                    index: rows ? getRowIndex(rows[rowIndex], rowIndex, startIndex): startIndex,
                     col: colName === undefined ? null : colName,
                     value,
                     reason: value === undefined ? "click" : "button",
@@ -614,7 +614,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
                                 </TableRow>
                             </TableHead>
                             <TableBody>
-                                {rows.map((row, index) => {
+                                {rows?.map((row, index) => {
                                     const sel = selected.indexOf(index + startIndex);
                                     if (sel == 0) {
                                         Promise.resolve().then(
@@ -664,7 +664,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
                                         </TableRow>
                                     );
                                 })}
-                                {rows.length == 0 &&
+                                {!rows &&
                                     loading &&
                                     Array.from(Array(30).keys(), (v, idx) => (
                                         <TableRow hover key={"rowSkel" + idx}>


### PR DESCRIPTION
resolves #2275

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix empty table flicker on refresh

## Related Tickets & Documents
- Closes #2275 

## How to reproduce the issue
```py
import numpy as np

import taipy.gui.builder as tgb
from taipy.gui import Gui

n_rows = 5
base_df = np.random.random((100, 10)).tolist()
df = base_df[:n_rows]

with tgb.Page() as page:
    tgb.toggle(theme=True)
    tgb.text("# Flickering table", mode="md")
    tgb.slider(value="{n_rows}")
    tgb.button("Refresh", on_action=lambda state: state.assign("df", base_df[:state.n_rows]))
    tgb.table("{df}")

    for _ in range(5):
        with tgb.part():
            tgb.text("# Example text", mode="md")

Gui(page).run(title="2275 [🐛 BUG] Table flickers and occupies a lot of space when updating to no rows")

```
