### PR TITLE
tree does not support mode

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Selector.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Selector.tsx
@@ -125,7 +125,12 @@ const renderBoxSx = {
     width: "100%",
 } as CSSProperties;
 
-const Selector = (props: SelTreeProps) => {
+interface SelectorProps extends SelTreeProps {
+    dropdown?: boolean;
+    mode?: string;
+}
+
+const Selector = (props: SelectorProps) => {
     const {
         id,
         defaultValue = "",

--- a/frontend/taipy-gui/src/components/Taipy/lovUtils.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/lovUtils.tsx
@@ -30,8 +30,6 @@ export interface SelTreeProps extends LovProps, TaipyLabelProps {
     filter?: boolean;
     multiple?: boolean;
     width?: string | number;
-    dropdown?: boolean;
-    mode?: string;
 }
 
 export interface LovProps<T = string | string[], U = string> extends TaipyActiveProps, TaipyChangeProps {

--- a/frontend/taipy-gui/src/themes/darkThemeTemplate.ts
+++ b/frontend/taipy-gui/src/themes/darkThemeTemplate.ts
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2021-2024 Avaiga Private Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 export const darkThemeTemplate = {
     data: {
         barpolar: [

--- a/taipy/gui/builder/_api_generator.py
+++ b/taipy/gui/builder/_api_generator.py
@@ -39,7 +39,7 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
 
     @staticmethod
     def get_properties_dict(property_list: t.List[VisElementProperties]) -> t.Dict[str, t.Any]:
-        return {prop["name"]: prop.get("type", "str") for prop in property_list}
+        return {prop["name"]: prop.get("type", "str") for prop in property_list if not prop.get("hide", False)}
 
     def add_default(self):
         if self.__module is not None:

--- a/taipy/gui/utils/viselements.py
+++ b/taipy/gui/utils/viselements.py
@@ -19,6 +19,7 @@ class VisElementProperties(t.TypedDict):
     doc: str
     default_value: t.Any
     default_property: t.Any
+    hide: t.Optional[bool]
 
 
 class VisElementDetail(t.TypedDict):
@@ -40,6 +41,7 @@ def _resolve_inherit_property(element: VisElement, viselements: VisElements) -> 
     properties = deepcopy(element_detail["properties"])
     if "inherits" not in element_detail:
         return properties
+    hidden_property_names = [p.get("name") for p in properties if p.get("hide", False)]
     for inherit in element_detail["inherits"]:
         inherit_element = None
         for element_type in "blocks", "controls", "undocumented":
@@ -48,7 +50,8 @@ def _resolve_inherit_property(element: VisElement, viselements: VisElements) -> 
                 break
         if inherit_element is None:
             raise RuntimeError(f"Error resolving inherit element with name {inherit} in viselements.json")
-        properties = properties + _resolve_inherit_property(inherit_element, viselements)
+        inherited_props = _resolve_inherit_property(inherit_element, viselements)
+        properties = properties + [p for p in inherited_props if p.get("name") not in hidden_property_names]
     return properties
 
 

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -53,8 +53,9 @@
                         "type": "dynamic(Union[str,Icon])",
                         "default_value": "\"\"",
                         "doc": "The label displayed in the button."
-                    },                                        {
-                    "name": "size",
+                    },
+                    {
+                        "name": "size",
                         "type": "str",
                         "default_value": "\"medium\"",
                         "doc": "The size of the button. Valid values: \"small\", \"medium\", or \"large\"."
@@ -1639,7 +1640,9 @@
         [
             "alert",
             {
-                "inherits": ["shared"],
+                "inherits": [
+                    "shared"
+                ],
                 "properties": [
                     {
                         "name": "message",
@@ -1850,6 +1853,14 @@
                         "name": "row_height",
                         "type": "str",
                         "doc": "The height of each row of this tree, in CSS units."
+                    },
+                    {
+                        "name": "mode",
+                        "hide": true
+                    },
+                    {
+                        "name": "dropdown",
+                        "hide": true
                     }
                 ]
             }


### PR DESCRIPTION
resolves #2278

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Tree does not support property `mode`

## Related Tickets & Documents
- Closes #2278 

## How to reproduce the issue

```py
import taipy.gui.builder as tgb
from taipy.gui import Gui

x = ""
lov = [
    {
        "id": "1",
        "label": "P",
        "children": [{"id": "2", "label": "C1", "children": []}, {"id": "3", "label": "C2", "children": []}],
    }
]

with tgb.Page() as root:
    tgb.text("Here's a Tree:")
    tgb.tree("{x}", mode="check", lov="{lov}")
    tgb.text("Here's a Selector:")
    tgb.selector("{x}", mode="check", lov="{lov}")

if __name__ == "__main__":
    Gui(root).run(title="2278 [🐛 BUG] The checkbox / radio mode does not work in tree view")

```
