### PR TITLE
Chart: merge layout for figure

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chart.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chart.tsx
@@ -17,6 +17,7 @@ import { useTheme } from "@mui/material";
 import Box from "@mui/material/Box";
 import Skeleton from "@mui/material/Skeleton";
 import Tooltip from "@mui/material/Tooltip";
+import merge from "lodash/merge";
 import { nanoid } from "nanoid";
 import {
     Config,
@@ -300,7 +301,7 @@ const Chart = (props: ChartProp) => {
     const theme = useTheme();
     const module = useModule();
 
-    const refresh = useMemo(() => data?.__taipy_refresh !== undefined ? nanoid() : false, [data]);
+    const refresh = useMemo(() => (data?.__taipy_refresh !== undefined ? nanoid() : false), [data]);
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
     const active = useDynamicProperty(props.active, props.defaultActive, true);
     const render = useDynamicProperty(props.render, props.defaultRender, true);
@@ -394,12 +395,7 @@ const Chart = (props: ChartProp) => {
             layout.template = template;
         }
         if (props.figure) {
-            return {
-                ...(props.figure[0].layout as Partial<Layout>),
-                ...layout,
-                title: title || layout.title || (props.figure[0].layout as Partial<Layout>).title,
-                clickmode: "event+select",
-            } as Layout;
+            return merge({},props.figure[0].layout as Partial<Layout>, layout, {title: title || layout.title || (props.figure[0].layout as Partial<Layout>).title, clickmode: "event+select"});
         }
         return {
             ...layout,


### PR DESCRIPTION
resolves #2274

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Merge dark template with figure default template

## Related Tickets & Documents
- Closes #2274 

## How to reproduce the issue

```py
import pandas as pd
import plotly.express as px

import taipy.gui.builder as tgb
from taipy.gui import Gui

df = pd.DataFrame({"x": range(1000)})
df["y"] = df["x"] ** 3

fig = px.line(df, x="x", y="y", title="Chart title")

with tgb.Page() as page:
    tgb.toggle(theme=True)
    tgb.text("# Chart title in dark mode", mode="md")
    with tgb.layout(columns="1 1", gap="1em"):
        with tgb.part():
            tgb.chart(figure="{fig}")
        with tgb.part():
            tgb.chart("{df}", x="x", y="y", layout={"title": "Chart title"}, mode="lines")


Gui(page).run(title="2274 [🐛 BUG] Default go.Figure title position overridden to center by dark mode theme")

```
