### PR TITLE
table column width should be set as minWidth to be noticed

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
@@ -524,7 +524,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
                                             sortDirection={orderBy === columns[col].dfid && order}
                                             sx={
                                                 columns[col].width
-                                                    ? { width: columns[col].width }
+                                                    ? { minWidth: columns[col].width }
                                                     : nbWidth
                                                     ? { minWidth: `${100 / nbWidth}%` }
                                                     : undefined


### PR DESCRIPTION
resolves #2286

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
 when specifying one column width, the style is applied but not taken into account by the table
 We need to set it as min-width so that it has an impact on the table layout.

## Related Tickets & Documents

- Closes #2286 

## How to reproduce the issue

```py
import pandas as pd

import taipy.gui.builder as tgb
from taipy.gui import Gui

data = pd.DataFrame({"A C": [1, 2, 3], "B C": [4, 5, 6], "C C": [7, 8, 9]})

properties_table = {"width[B C]": "1000px"}

with tgb.Page() as page:
    tgb.table(data="{data}", properties="{properties_table}")

Gui(page=page).run(title="2286 [🐛 BUG] Applying width to a specific column (named with spaces) in a tgb.table does not work")

```
