### PR TITLE
Fix - setting width/height with CSS units for metrics

### DIFF
--- a/doc/gui/examples/controls/css_bug.py
+++ b/doc/gui/examples/controls/css_bug.py
@@ -1,0 +1,45 @@
+# Copyright 2021-2024 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from taipy.gui import Gui
+
+value = 50
+
+page = """
+<|{value}|metric|>
+
+## Works (numbers)
+<|{value}|metric|width=150|height=150|>
+<|{value}|metric|width=300|height=300|>
+
+## Height/width not working (px)
+<|{value}|metric|width=150px|height=150px|>
+<|{value}|metric|width=300px|height=300px|>
+
+## Height/width not working (rem)
+<|{value}|metric|width=150rem|height=150rem|>
+<|{value}|metric|width=300rem|height=150rem|>
+
+
+## Buttons (numbers)
+<|Foo|button|width=150|>
+<|Foo|button|width=300|>
+
+## Buttons (px)
+<|Foo-px|button|width=150px|>
+<|Foo-px|button|width=300px|>
+
+## Buttons (rem)
+<|Foo-rem|button|width=150rem|>
+<|Foo-rem|button|width=300rem|>
+"""
+
+Gui(page).run()

--- a/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.spec.tsx
@@ -359,4 +359,45 @@ describe("Metric Component", () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Error while parsing Metric.template"));
         consoleSpy.mockRestore();
     });
+
+    // Test cases for normalizeSize
+    it("correctly normalizes size when width is provided as a number", async () => {
+        const { container } = render(<Metric width={700} />);
+        await waitFor(() => {
+            const elt = container.querySelector(".svg-container");
+            expect(elt).toHaveStyle({
+                width: "700px",
+            });
+        });
+    });
+
+    it("correctly normalizes size when width is provided as a string", async () => {
+        const { container } = render(<Metric width="700px" />);
+        await waitFor(() => {
+            const elt = container.querySelector(".svg-container");
+            expect(elt).toHaveStyle({
+                width: "700px",
+            });
+        });
+    });
+
+    it("correctly normalizes size when height is provided as a number", async () => {
+        const { container } = render(<Metric height={400} />);
+        await waitFor(() => {
+            const elt = container.querySelector(".svg-container");
+            expect(elt).toHaveStyle({
+                height: "400px",
+            });
+        });
+    });
+
+    it("correctly normalizes size when height is provided as a string", async () => {
+        const { container } = render(<Metric height="450px" />);
+        await waitFor(() => {
+            const elt = container.querySelector(".svg-container");
+            expect(elt).toHaveStyle({
+                height: "450px",
+            });
+        });
+    });
 });

--- a/frontend/taipy-gui/src/components/Taipy/Metric.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Metric.tsx
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 import React, { CSSProperties, lazy, Suspense, useMemo } from "react";
 import { Data, Delta, Layout } from "plotly.js";
 import Box from "@mui/material/Box";
@@ -21,7 +22,9 @@ import { extractPrefix, extractSuffix, sprintfToD3Converter } from "../../utils/
 import { TaipyBaseProps, TaipyHoverProps } from "./utils";
 import { darkThemeTemplate } from "../../themes/darkThemeTemplate";
 import { getComponentClassName } from "./TaipyStyle";
+
 const Plot = lazy(() => import("react-plotly.js"));
+
 interface MetricProps extends TaipyBaseProps, TaipyHoverProps {
     value?: number;
     defaultValue?: number;
@@ -48,10 +51,12 @@ interface MetricProps extends TaipyBaseProps, TaipyHoverProps {
     template_Dark_?: string;
     template_Light_?: string;
 }
+
 const emptyLayout = {} as Partial<Layout>;
 const defaultStyle = { position: "relative", display: "inline-block", width: "100%" } as CSSProperties;
 const skeletonStyle = { ...defaultStyle, minHeight: "7em" };
 const plotConfig = { displaylogo: false };
+
 const Metric = (props: MetricProps) => {
     const { showValue = true } = props;
     const value = useDynamicProperty(props.value, props.defaultValue, 0);
@@ -61,6 +66,7 @@ const Metric = (props: MetricProps) => {
     const baseLayout = useDynamicJsonProperty(props.layout, props.defaultLayout || "", emptyLayout);
     const hover = useDynamicProperty(props.hoverText, props.defaultHoverText, undefined);
     const theme = useTheme();
+
     const colorMap = useMemo(() => {
         try {
             const obj = props.colorMap ? JSON.parse(props.colorMap) : null;
@@ -79,6 +85,7 @@ const Metric = (props: MetricProps) => {
         }
         return undefined;
     }, [props.colorMap, props.max]);
+
     const data = useMemo(() => {
         const mode = typeof props.type === "string" && props.type.toLowerCase() === "none" ? [] : ["gauge"];
         showValue && mode.push("number");
@@ -147,6 +154,7 @@ const Metric = (props: MetricProps) => {
         showValue,
         colorMap,
     ]);
+
     /* React-plotly-js only accepts numerical widths/heights, but our Metric component
      * accepts numbers or strings. To use react-plotly-js, we need to convert our
      * potential string width/height into a number of pixels */
@@ -193,9 +201,11 @@ const Metric = (props: MetricProps) => {
         if (template) {
             layout.template = template;
         }
+
         if (props.title) {
             layout.title = props.title;
         }
+
         return layout as Partial<Layout>;
     }, [
         props.title,
@@ -207,6 +217,7 @@ const Metric = (props: MetricProps) => {
         theme.palette.mode,
         baseLayout,
     ]);
+
     return (
         <Tooltip title={hover || ""}>
             <Box className={`${className} ${getComponentClassName(props.children)}`}>
@@ -218,7 +229,9 @@ const Metric = (props: MetricProps) => {
         </Tooltip>
     );
 };
+
 export default Metric;
+
 const { colorscale, colorway, font } = darkThemeTemplate.layout;
 const darkTemplate = {
     layout: {

--- a/tests/gui/e2e/test_metric_css_units.py
+++ b/tests/gui/e2e/test_metric_css_units.py
@@ -1,0 +1,60 @@
+import inspect
+from importlib import util
+
+import pytest
+
+if util.find_spec("playwright"):
+    from playwright._impl._page import Page
+
+from taipy.gui import Gui
+
+
+@pytest.mark.extension
+def test_metric_basic_width(page: Page, gui: Gui, helpers):
+    page_md = """
+<|100|metric|>
+"""
+    gui._set_frame(inspect.currentframe())
+    gui.add_page(name="test", page=page_md)
+    helpers.run_e2e(gui)
+    page.goto("./test")
+    page.wait_for_selector(".plot-container")
+    events_list = page.locator("//*[@class='js-plotly-plot']//*[name()='svg'][2]//*[local-name()='text']")
+    gauge_value = events_list.nth(0).text_content()
+    assert gauge_value == "100"
+
+@pytest.mark.extension
+def test_metric_numeric_width(page: Page, gui: Gui, helpers):
+    """Test that documents the bug with numeric width/height values"""
+    page_md = """
+<|100|metric|width=300|height=300|>
+"""
+    gui._set_frame(inspect.currentframe())
+    gui.add_page(name="test", page=page_md)
+    helpers.run_e2e(gui)
+    page.goto("./test")
+    page.wait_for_selector(".plot-container")
+    
+    plot = page.locator("//*[@class='js-plotly-plot']")
+    width = plot.evaluate("el => el.style.width")
+    
+    # This assertion documents the current buggy behavior
+    assert width == "100%", "Width is defaulting to 100% instead of using specified width"
+    
+@pytest.mark.extension
+def test_metric_px_units(page: Page, gui: Gui, helpers):
+    """Test that documents the bug with px width/height values"""
+    page_md = """
+<|100|metric|width=150px|height=300px|>
+"""
+    gui._set_frame(inspect.currentframe())
+    gui.add_page(name="test", page=page_md)
+    helpers.run_e2e(gui)
+    page.goto("./test")
+    page.wait_for_selector(".plot-container")
+    
+    plot = page.locator("//*[@class='js-plotly-plot']")
+    width = plot.evaluate("el => el.style.width")
+    
+    # This assertion documents the current buggy behavior
+    assert width == "100%", "Width is defaulting to 100% instead of using specified px units"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The Metric component was not responding to size style values with units such as `width='100px'` or `height='100%'` because it uses an external `Plot` library that only accepts numerical sizes. This change adds a function that converts any size dimensions into a number of pixels, which can then be interpreted by the `Plot` properly.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #2141 

## How to reproduce the issue

The file [doc/gui/examples/controls/css_bug.py](https://github.com/Avaiga/taipy/pull/2309/files#diff-ac3f2bbf07a3ba29304b1c8036ddc4b47561e7873f4d87112556910c13d391cb) has example components and styles that previously did not respond to variable width/height Metric components. Running this file now should show the Metric component properly working.

## Checklist
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Does this solution meet the acceptance criteria of the related issue?
- [x] Is the related issue checklist completed?
- [x] Does this PR adds unit tests for the developed code? If not, why?
- [x] End-to-End tests have been added or updated?
- [ ] Was the documentation updated, or a dedicated issue for documentation created? (If applicable)
- [ ] Is the release notes updated? (If applicable)
