### PR TITLE
scroll chat down when non user scroll action

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chat.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.spec.tsx
@@ -212,7 +212,7 @@ describe("Chat Component", () => {
         });
         jest.restoreAllMocks();
     });
-    it("Not upload image over a file size limit", async () => {
+    it("does not upload image over a file size limit", async () => {
         const dispatch = jest.fn();
         const state: TaipyState = INITIAL_STATE;
         const { getByText, getByAltText } = render(

--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -22,6 +22,7 @@ import React, {
     ReactNode,
     lazy,
     ChangeEvent,
+    UIEvent,
 } from "react";
 import { SxProps, Theme, darken, lighten } from "@mui/material/styles";
 import Avatar from "@mui/material/Avatar";
@@ -250,6 +251,7 @@ const Chat = (props: ChatProps) => {
     const [imagePreview, setImagePreview] = useState<string | null>(null);
     const [objectURLs, setObjectURLs] = useState<string[]>([]);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const userScrolled = useRef(false);
 
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
     const active = useDynamicProperty(props.active, props.defaultActive, true);
@@ -450,8 +452,9 @@ const Chat = (props: ChatProps) => {
                 }
             }
             page.current.key = getChatKey(0, pageSize);
+            !userScrolled.current && showBottom();
         }
-    }, [refresh, pageSize, props.messages]);
+    }, [refresh, pageSize, props.messages, showBottom]);
 
     useEffect(() => {
         if (showMessage && !isAnchorDivVisible) {
@@ -490,10 +493,14 @@ const Chat = (props: ChatProps) => {
         [loadMoreItems]
     );
 
+    const handleOnScroll = useCallback((evt: UIEvent) => {
+        userScrolled.current = (evt.target as HTMLDivElement).scrollHeight - (evt.target as HTMLDivElement).offsetHeight - (evt.target as HTMLDivElement).scrollTop > 1;
+    }, []);
+
     return (
         <Tooltip title={hover || ""}>
             <Paper className={`${className} ${getComponentClassName(props.children)}`} sx={boxSx} id={id}>
-                <Grid container rowSpacing={2} sx={gridSx} ref={scrollDivRef}>
+                <Grid container rowSpacing={2} sx={gridSx} ref={scrollDivRef} onScroll={handleOnScroll}>
                     {rows.length && !rows[0] ? (
                         <Grid className={getSuffixedClassNames(className, "-load")} size={12} sx={noAnchorSx}>
                             <Box sx={loadMoreSx}>

--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -426,7 +426,7 @@ const Chat = (props: ChatProps) => {
     );
 
     const showBottom = useCallback(() => {
-        anchorDivRef.current?.scrollIntoView();
+        anchorDivRef.current?.scrollIntoView && anchorDivRef.current?.scrollIntoView();
         setShowMessage(false);
     }, []);
 


### PR DESCRIPTION
resolves #2281

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
scroll down on every data change if no user scroll action

## Related Tickets & Documents
- Closes #2281 

## How to reproduce the issue
```py
import taipy.gui.builder as tgb
from taipy.gui import Gui

messages = []


def evaluate(state, var_name: str, payload: dict):
    args = payload.get("args", [])
    state.messages.append(
        [len(state.messages), args[2], args[3]]
    )
    state.messages.append(
        [len(state.messages), "The MP5 is pretty fun to shoot actually, virtually no recoil", "Robot"]
    )
    state.messages = state.messages


with tgb.Page() as page_home:
    tgb.chat(
        messages="{messages}",
        on_action=evaluate,
        height="80vh",
    )

if __name__ == "__main__":
    Gui(page=page_home).run(title="2281 [🐛 BUG] Chat control should automatically scroll down when a new message is added")

```

