### PR TITLE
on_submission_change called twice with the same status

### DIFF
--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -200,7 +200,10 @@ class _GuiCoreContext(CoreEventConsumerBase):
                         )
                     payload.update(tasks=running_tasks)
 
-                    if last_client_status.submission_status is not new_status:
+                    if (
+                        last_client_status.submission_status is None
+                        or last_client_status.submission_status.value < new_status.value
+                    ):
                         # callback
                         submission_name = submission.properties.get("on_submission")
                         if submission_name:
@@ -639,11 +642,10 @@ class _GuiCoreContext(CoreEventConsumerBase):
                     client_id=self.gui._get_client_id(),
                     module_context=self.gui._get_locals_context(),
                 )
-                client_status = _ClientStatus(self.gui._get_client_id(), submission_entity.submission_status)
+                client_status = _ClientStatus(self.gui._get_client_id(), None)
                 with self.submissions_lock:
                     self.client_submission[submission_entity.id] = client_status
                 if Config.core.mode == "development":
-                    client_status.submission_status = SubmissionStatus.SUBMITTED
                     self.submission_status_callback(submission_entity.id)
                 _GuiCoreContext.__assign_var(state, error_var, "")
         except Exception as e:
@@ -714,7 +716,6 @@ class _GuiCoreContext(CoreEventConsumerBase):
                 else:
                     args.append(None)
         return args
-
 
     def get_sorted_datanode_list(
         self,

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -200,10 +200,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
                         )
                     payload.update(tasks=running_tasks)
 
-                    if (
-                        last_client_status.submission_status is None
-                        or last_client_status.submission_status.value < new_status.value
-                    ):
+                    if last_client_status.submission_status is not new_status:
                         # callback
                         submission_name = submission.properties.get("on_submission")
                         if submission_name:

--- a/taipy/gui_core/_utils.py
+++ b/taipy/gui_core/_utils.py
@@ -17,4 +17,4 @@ from taipy.core.submission.submission_status import SubmissionStatus
 @dataclass
 class _ClientStatus:
     client_id: t.Optional[str]
-    submission_status: SubmissionStatus
+    submission_status: t.Optional[SubmissionStatus]

--- a/tests/gui_core/test_context_is_readable.py
+++ b/tests/gui_core/test_context_is_readable.py
@@ -204,7 +204,7 @@ class TestGuiCoreContext_is_readable:
             mockGui._get_authorization = lambda s: contextlib.nullcontext()
             gui_core_context = _GuiCoreContext(mockGui)
 
-            gui_core_context.client_submission[a_submission.id] = _ClientStatus("client_id", SubmissionStatus.UNDEFINED)
+            gui_core_context.client_submission[a_submission.id] = _ClientStatus("client_id", None)
             gui_core_context.submission_status_callback(a_submission.id)
             mockget.assert_called()
             found = False

--- a/tests/gui_core/test_context_is_readable.py
+++ b/tests/gui_core/test_context_is_readable.py
@@ -25,7 +25,7 @@ from taipy.core.data.pickle import PickleDataNode
 from taipy.core.job._job_manager_factory import _JobManagerFactory
 from taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
 from taipy.core.submission._submission_manager_factory import _SubmissionManagerFactory
-from taipy.core.submission.submission import Submission, SubmissionStatus
+from taipy.core.submission.submission import Submission
 from taipy.core.task._task_manager_factory import _TaskManagerFactory
 from taipy.gui import Gui, State
 from taipy.gui_core._context import _GuiCoreContext


### PR DESCRIPTION
resolves #2152

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
on_sumission_changed can be called twice with the same status.
fix: initiliaze the context status to None and report only increase in status

## Related Tickets & Documents
- Closes #2152 

## How to reproduce the issue
```py
import taipy as tp
from taipy import Config
from taipy.gui import Gui, notify


# Normal function used by Taipy
def double(nb):
    return nb * 2


# Configuration of Data Nodes
input_cfg = Config.configure_data_node("input_dn", default_data=21)
output_cfg = Config.configure_data_node("output_dn")


# Configuration of tasks
first_task_cfg = Config.configure_task("double",
                                       double,
                                       input_cfg,
                                       output_cfg)


# Configuration of scenario
scenario_cfg = Config.configure_scenario(id="my_scenario",
                                         task_configs=[first_task_cfg],
                                         name="my_scenario")



def notify_from_submissions(state, submittable, details):
    submission_status = details.get('submission_status')

    if submission_status == 'COMPLETED':
        print("COMPLETED")
        print(submittable)
        print(details)
        notify(state, 'success', 'Completed!')
        # Add additional actions here, like updating the GUI or logging the completion.

    elif submission_status == 'FAILED':
        print("FAILED")
        notify(state, 'error', 'FAILED!')
        # Handle failure, like sending notifications or logging the error.


if __name__=="__main__":
    tp.Orchestrator().run()
    scenario_1 = tp.create_scenario(scenario_cfg)

    scenario_md = """
<|{scenario_1}|scenario|on_submission_change=notify_from_submissions|>
"""
    Gui(scenario_md).run(title="2152 [🐛 BUG] On_submission_change - submission is completed twice")

```