### PR TITLE
on submission change called twice with same status

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1557,7 +1557,7 @@ class Gui:
     def invoke_callback(
         self,
         state_id: str,
-        callback: t.Callable,
+        callback: t.Union[t.Callable, str],
         args: t.Optional[t.Sequence[t.Any]] = None,
         module_context: t.Optional[str] = None,
     ) -> t.Any:

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -158,55 +158,26 @@ class _GuiCoreContext(CoreEventConsumerBase):
         if not submission_id or not is_readable(t.cast(SubmissionId, submission_id)):
             return
         submission = None
-        new_status = None
+        new_status: t.Optional[SubmissionStatus] = None
         payload: t.Optional[t.Dict[str, t.Any]] = None
         client_id: t.Optional[str] = None
+        submission_name: t.Optional[str] = None
         try:
-            last_client_status = self.client_submission.get(submission_id)
-            if not last_client_status:
-                return
-
             submission = t.cast(Submission, core_get(submission_id))
             if not submission or not submission.entity_id:
                 return
-
-            payload = {}
-            new_status = t.cast(SubmissionStatus, submission.submission_status)
-
-            client_id = submission.properties.get("client_id")
-            if client_id:
-                running_tasks = {}
-                with self.gui._get_authorization(client_id):
-                    for job in submission.jobs:
-                        job = job if isinstance(job, Job) else t.cast(Job, core_get(job))
-                        running_tasks[job.task.id] = (
-                            SubmissionStatus.RUNNING.value
-                            if job.is_running()
-                            else SubmissionStatus.PENDING.value
-                            if job.is_pending()
-                            else None
-                        )
-                    payload.update(tasks=running_tasks)
-
-                    if last_client_status.submission_status is not new_status:
-                        # callback
-                        submission_name = submission.properties.get("on_submission")
-                        if submission_name:
-                            self.gui.invoke_callback(
-                                client_id,
-                                submission_name,
-                                [
-                                    core_get(submission.id),
-                                    {
-                                        "submission_status": new_status.name,
-                                        "submittable_entity": core_get(submission.entity_id),
-                                        **(event.metadata if event else {}),
-                                    },
-                                ],
-                                submission.properties.get("module_context"),
-                            )
+            new_status = submission.submission_status
 
             with self.submissions_lock:
+                last_client_status = self.client_submission.get(submission_id)
+                if not last_client_status:
+                    return
+
+                payload = {}
+                if last_client_status.submission_status is not new_status:
+                    # callback
+                    submission_name = submission.properties.get("on_submission")
+
                 if new_status in (
                     SubmissionStatus.COMPLETED,
                     SubmissionStatus.FAILED,
@@ -215,6 +186,36 @@ class _GuiCoreContext(CoreEventConsumerBase):
                     self.client_submission.pop(submission_id, None)
                 else:
                     last_client_status.submission_status = new_status
+
+            if client_id:= submission.properties.get("client_id"):
+                with self.gui._get_authorization(client_id):
+                    if payload is not None:
+                        running_tasks = {}
+                        for job in submission.jobs:
+                            job = job if isinstance(job, Job) else t.cast(Job, core_get(job))
+                            running_tasks[job.task.id] = (
+                                SubmissionStatus.RUNNING.value
+                                if job.is_running()
+                                else SubmissionStatus.PENDING.value
+                                if job.is_pending()
+                                else None
+                            )
+                        payload.update(tasks=running_tasks)
+
+                    if submission_name:
+                        self.gui.invoke_callback(
+                            client_id,
+                            submission_name,
+                            [
+                                core_get(submission.id),
+                                {
+                                    "submission_status": new_status.name if new_status else "None",
+                                    "submittable_entity": core_get(submission.entity_id),
+                                    **(event.metadata if event else {}),
+                                },
+                            ],
+                            submission.properties.get("module_context"),
+                        )
 
         except Exception as e:
             _warn(f"Submission ({submission_id}) is not available", e)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In some cases, the on_submission _change callback can be called twice with the same status

## Related Tickets & Documents
- Closes #2152 

## How to reproduce the issue
```py
import taipy as tp
from taipy import Config
from taipy.gui import Gui, notify


# Normal function used by Taipy
def double(nb):
    return nb * 2


# Configuration of Data Nodes
input_cfg = Config.configure_data_node("input_dn", default_data=21)
output_cfg = Config.configure_data_node("output_dn")


# Configuration of tasks
first_task_cfg = Config.configure_task("double",
                                       double,
                                       input_cfg,
                                       output_cfg)


# Configuration of scenario
scenario_cfg = Config.configure_scenario(id="my_scenario",
                                         task_configs=[first_task_cfg],
                                         name="my_scenario")



def notify_from_submissions(state, submittable, details):
    submission_status = details.get('submission_status')

    if submission_status == 'COMPLETED':
        print("COMPLETED")
        print(submittable)
        print(details)
        notify(state, 'success', 'Completed!')
        # Add additional actions here, like updating the GUI or logging the completion.

    elif submission_status == 'FAILED':
        print("FAILED")
        notify(state, 'error', 'FAILED!')
        # Handle failure, like sending notifications or logging the error.


if __name__=="__main__":
    tp.Orchestrator().run()
    scenario_1 = tp.create_scenario(scenario_cfg)

    scenario_md = """
<|{scenario_1}|scenario|on_submission_change=notify_from_submissions|>
"""
    Gui(scenario_md).run(title="2152 [🐛 BUG] On_submission_change - submission is completed twice")

```
