### PR TITLE
Fix - Only log the string values of the _ALL_EXPOSED_TYPES when run the _DataNodeConfigChecker

### DIFF
--- a/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/taipy/core/config/checkers/_data_node_config_checker.py
@@ -241,7 +241,9 @@ class _DataNodeConfigChecker(_ConfigChecker):
         if not isinstance(data_node_config.exposed_type, str):
             return
         if data_node_config.exposed_type not in DataNodeConfig._ALL_EXPOSED_TYPES:
-            valid_exposed_types_str = ", ".join([f'"{x}"' for x in DataNodeConfig._ALL_EXPOSED_TYPES])
+            valid_exposed_types_str = ", ".join(
+                [f'"{x}"' for x in DataNodeConfig._ALL_EXPOSED_TYPES if isinstance(x, str)]
+            )
             self._error(
                 data_node_config._EXPOSED_TYPE_KEY,
                 data_node_config.exposed_type,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PR https://github.com/Avaiga/taipy/pull/2296 introduces a failed test, where the error log of the _DataNodeConfigChecker also includes the string for `pandas.DataFrame` and `numpy.array`.

This PR updates the _DataNodeConfigChecker to only log the string values of the _ALL_EXPOSED_TYPES
