### PR TITLE
Feature/enterprise#550 - Create _CreateCLIFactory to allow expanding the taipy create command

### DIFF
--- a/taipy/_entrypoint.py
+++ b/taipy/_entrypoint.py
@@ -14,7 +14,7 @@ import sys
 from importlib.util import find_spec
 
 from taipy.common._cli._base_cli._taipy_parser import _TaipyParser
-from taipy.common._cli._create_cli import _CreateCLI
+from taipy.common._cli._create_cli_factory import _CreateCLIFactory
 from taipy.common._cli._help_cli import _HelpCLI
 from taipy.common._cli._run_cli import _RunCLI
 from taipy.core._cli._core_cli_factory import _CoreCLIFactory
@@ -42,14 +42,15 @@ def _entrypoint():
         _enterprise_entrypoint_initialize()
 
     _core_cli = _CoreCLIFactory._build_cli()
+    _create_cli = _CreateCLIFactory._build_cli()
 
     _RunCLI.create_parser()
     _GuiCLI.create_run_parser()
     _core_cli.create_run_parser()
 
     _VersionCLIFactory._build_cli().create_parser()
-    _CreateCLI.generate_template_map()
-    _CreateCLI.create_parser()
+    _create_cli.generate_template_map()
+    _create_cli.create_parser()
     _MigrateCLI.create_parser()
     _HelpCLI.create_parser()
 
@@ -67,7 +68,7 @@ def _entrypoint():
     _HelpCLI.handle_command()
     _VersionCLIFactory._build_cli().handle_command()
     _MigrateCLI.handle_command()
-    _CreateCLI.handle_command()
+    _create_cli.handle_command()
 
     _TaipyParser._remove_argument("help")
     _TaipyParser._parser.print_help()

--- a/taipy/common/_cli/_create_cli.py
+++ b/taipy/common/_cli/_create_cli.py
@@ -11,7 +11,7 @@
 
 import pathlib
 import sys
-from typing import Dict, Optional
+from typing import Dict
 
 from cookiecutter.exceptions import OutputDirExistsException
 from cookiecutter.main import cookiecutter
@@ -29,9 +29,8 @@ class _CreateCLI(_AbstractCLI):
     _ARGUMENTS = ["--application"]
 
     @classmethod
-    def generate_template_map(cls, template_path: Optional[pathlib.Path] = None):
-        if not template_path:
-            template_path = pathlib.Path(taipy.__file__).parent.resolve() / "templates"
+    def generate_template_map(cls):
+        template_path = pathlib.Path(taipy.__file__).parent.resolve() / "templates"
 
         # Update the template map with the new templates but do not override the existing ones
         cls._template_map.update(

--- a/taipy/common/_cli/_create_cli_factory.py
+++ b/taipy/common/_cli/_create_cli_factory.py
@@ -1,0 +1,31 @@
+# Copyright 2021-2025 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from importlib import import_module
+from operator import attrgetter
+from typing import Type
+
+from taipy.common._cli._base_cli._abstract_cli import _AbstractCLI
+
+from ...core.common._check_dependencies import EnterpriseEditionUtils
+from ._create_cli import _CreateCLI
+
+
+class _CreateCLIFactory:
+    @staticmethod
+    def _build_cli() -> Type[_AbstractCLI]:
+        if EnterpriseEditionUtils._using_enterprise():
+            module = import_module(EnterpriseEditionUtils._TAIPY_ENTERPRISE_MODULE + ".templates._create_cli")
+            create_cli = attrgetter("_CreateCLI")(module)
+        else:
+            create_cli = _CreateCLI
+
+        return create_cli


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR introduces the _CreateCLIFactory class to be called from the taipy `_entrypoint`.

This would allow the `taipy create` command to be expandable.

## Related Tickets & Documents

- Related Issue https://github.com/Avaiga/taipy-enterprise/issues/550
