### PR TITLE
Navbar: do not select the first value on unknown id

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/NavBar.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/NavBar.spec.tsx
@@ -53,18 +53,18 @@ describe("NavBar Component", () => {
     });
     it("is disabled", async () => {
         const { getAllByRole } = render(<BrowserRouter><NavBar lov={lov} active={false} /></BrowserRouter>);
-        const elts = getAllByRole("tab");
-        elts.forEach(elt => expect(elt).toBeDisabled());
+        const tabElements = getAllByRole("tab");
+        tabElements.forEach(elt => expect(elt).toBeDisabled());
     });
     it("is enabled by default", async () => {
         const { getAllByRole } = render(<BrowserRouter><NavBar lov={lov} /></BrowserRouter>);
-        const elts = getAllByRole("tab");
-        elts.forEach(elt => expect(elt).not.toBeDisabled());
+        const tabElements = getAllByRole("tab");
+        tabElements.forEach(elt => expect(elt).not.toBeDisabled());
     });
     it("is enabled by active", async () => {
         const { getAllByRole } = render(<BrowserRouter><NavBar lov={lov} active={true} /></BrowserRouter>);
-        const elts = getAllByRole("tab");
-        elts.forEach(elt => expect(elt).not.toBeDisabled());
+        const tabElements = getAllByRole("tab");
+        tabElements.forEach(elt => expect(elt).not.toBeDisabled());
     });
     it("dispatch a well formed message", async () => {
         const focusSpy = jest.fn()

--- a/frontend/taipy-gui/src/components/Taipy/NavBar.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/NavBar.tsx
@@ -66,9 +66,7 @@ const NavBar = (props: LovProps) => {
         [state.locations, navigate]
     );
 
-    const selectedVal =
-        lov.find((it) => getBaseURL() + it.id.substring(1) === location.pathname)?.id ||
-        (lov.length ? lov[0].id : false);
+    const selectedVal = lov.find((it) => getBaseURL() + it.id.substring(1) === location.pathname)?.id || "";
 
     return isMobile ? (
         <Tooltip title={hover || ""}>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Do not select the first page if the location is not in the list

## Related Tickets & Documents

- Closes #2401

## How to reproduce the issue
```py
import taipy.gui.builder as tgb
from taipy.gui import Gui, navigate

page_list = [(f"page{i+1}", f"Page {i+1}", tgb.Page(tgb.text(f"# Page {i+1}", mode="md"))) for i in range(3)]
navbar_lov = [(f"/{page_name}", page_label) for page_name, page_label, _ in page_list]

config_page = tgb.Page(tgb.text("# Config Page", mode="md"))

with tgb.Page() as root_page:
    with tgb.layout(columns="max-content max-content"):
        tgb.navbar(lov="{navbar_lov}")
        tgb.button("Go to config", on_action=lambda state: navigate(state, "config", tab="_self"))


pages = {"/": root_page, "config": config_page}
pages.update({page_name: page for page_name, _, page in page_list})


def on_change(state, var_name, var_value):
    print(var_name, type(var_value), var_value)


if __name__ == "__main__":
    Gui(pages=pages).run(title="2401 navbar selection")

```
