### PR TITLE
Feature/#2322 - Log error when sequence or scenario is not consistent

### DIFF
--- a/taipy/core/sequence/sequence.py
+++ b/taipy/core/sequence/sequence.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Union
 import networkx as nx
 
 from taipy.common.config.common._validate_id import _validate_id
+from taipy.common.logger._taipy_logger import _TaipyLogger
 
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
@@ -117,6 +118,8 @@ class Sequence(_Entity, Submittable, _Labeled):
     _SEPARATOR = "_"
     _MANAGER_NAME = "sequence"
     __CHECK_INIT_DONE_ATTR_NAME = "_init_done"
+
+    _logger = _TaipyLogger._get_logger()
 
     id: SequenceId
     """The unique identifier of the sequence."""
@@ -343,15 +346,37 @@ class Sequence(_Entity, Submittable, _Labeled):
         if dag.number_of_nodes() == 0:
             return True
         if not nx.is_directed_acyclic_graph(dag):
+            self._logger.error(f'The DAG of sequence "{self.id}" is not a directed acyclic graph')
             return False
         if not nx.is_weakly_connected(dag):
+            self._logger.error(f'The DAG of sequence "{self.id}" is not weakly connected')
             return False
         for left_node, right_node in dag.edges:
             if (isinstance(left_node, DataNode) and isinstance(right_node, Task)) or (
                 isinstance(left_node, Task) and isinstance(right_node, DataNode)
             ):
                 continue
+
+            left_node_desc = (
+                f'{left_node.__class__.__name__} "{left_node.get_label()}"'
+                if isinstance(left_node, _Labeled)
+                else left_node.__class__.__name__
+                if left_node
+                else "None"
+            )
+            right_node_desc = (
+                f'{right_node.__class__.__name__} "{right_node.get_label()}"'
+                if isinstance(right_node, _Labeled)
+                else right_node.__class__.__name__
+                if right_node
+                else "None"
+            )
+            self._logger.error(
+                f'Invalid edge detected in sequence "{self.id}": left node {left_node_desc} and right node '
+                f"{right_node_desc} must connect a Task and a DataNode"
+            )
             return False
+
         return True
 
     def _get_tasks(self) -> Dict[str, Task]:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- Feature

## Description

In this PR, when a `Sequence` or `Scenario` is not consistent (the DAG is not valid), an error message is now log to better explain the error to the user.

## Related Tickets & Documents

- Closes #2322

## Checklist
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] This solution meets the acceptance criteria of the related issue.
- [x] The related issue checklist is completed.
- [x] This PR adds unit tests for the developed code. If not, why?
- [x] End-to-End tests have been added or updated. If not, why?
- [x] The documentation has been updated, or a dedicated issue created. (If applicable)
- [x] The release notes have been updated? (If applicable)
