### PR TITLE
Fix/2420 - Only check the compatibility of the core_version when not in development mode

### DIFF
--- a/taipy/core/_version/_version_manager.py
+++ b/taipy/core/_version/_version_manager.py
@@ -136,8 +136,13 @@ class _VersionManager(_Manager[_Version]):
             return ""
 
         try:
-            if version := cls._get(version_number):
-                return version.id
+            if version_number == cls._get_development_version():
+                if cls._exists(version_number):
+                    return version_number
+            else:
+                if cls._get(version_number):
+                    return version_number
+
         except InconsistentEnvVariableError:  # The version exist but the Config is alternated
             return version_number
         except ConfigCoreVersionMismatched as e:
@@ -183,6 +188,9 @@ class _VersionManager(_Manager[_Version]):
                 cls._set_experiment_version(current_version_number, Config.core.force)
             except VersionAlreadyExistsAsDevelopment as err:
                 raise SystemExit(err.message) from None
+            except ConfigCoreVersionMismatched as e:
+                cls._logger.error(e.message)
+                raise SystemExit() from e
 
         else:
             raise SystemExit(f"Undefined execution mode: {Config.core.mode}.")

--- a/tests/core/config/test_core_version.py
+++ b/tests/core/config/test_core_version.py
@@ -14,24 +14,30 @@ from unittest import mock
 import pytest
 
 from taipy.common.config import Config
+from taipy.core import Orchestrator, taipy
 from taipy.core._init_version import _read_version
 from taipy.core.config.core_section import CoreSection
 from taipy.core.exceptions import ConfigCoreVersionMismatched
+from taipy.core.scenario._scenario_manager import _ScenarioManager
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 _MOCK_CORE_VERSION = "3.1.1"
 
 
+def patch_core_version(mock_core_version: str):
+    with mock.patch("taipy.core.config.core_section._read_version") as mock_read_version:
+        mock_read_version.return_value = mock_core_version
+
+    CoreSection._CURRENT_CORE_VERSION = mock_core_version
+    Config._default_config._unique_sections[CoreSection.name] = CoreSection.default_config()
+    Config._python_config._unique_sections[CoreSection.name] = CoreSection.default_config()
+
+
 @pytest.fixture(scope="function", autouse=True)
 def mock_core_version():
-    with mock.patch("taipy.core.config.core_section._read_version") as mock_read_version:
-        mock_read_version.return_value = _MOCK_CORE_VERSION
-        CoreSection._CURRENT_CORE_VERSION = _MOCK_CORE_VERSION
-        Config.unique_sections[CoreSection.name] = CoreSection.default_config()
-        Config._default_config._unique_sections[CoreSection.name] = CoreSection.default_config()
-        Config._python_config._unique_sections[CoreSection.name] = CoreSection.default_config()
+    patch_core_version(_MOCK_CORE_VERSION)
 
-        yield
+    yield
 
     CoreSection._CURRENT_CORE_VERSION = _read_version()
 
@@ -137,3 +143,57 @@ class TestCoreVersionInCoreSectionConfig:
         )
         Config.load(file_config.filename)
         assert Config.unique_sections[CoreSection.name]._core_version == _MOCK_CORE_VERSION
+
+    def test_run_core_app_with_different_taipy_core_version_in_development_mode(self):
+        with mock.patch("sys.argv", ["prog", "--development"]):
+            run_application()
+
+        # Run the application with a compatible version should NOT raise any error
+        patch_core_version(f"{self.major}.{self.minor}.{self.patch}.dev0")
+        with mock.patch("sys.argv", ["prog", "--development"]):
+            run_application()
+
+        # Run the application with an incompatible version in development mode should NOT raise an error
+        patch_core_version(f"{self.major}.{int(self.minor) + 1}.{self.patch}.dev0")
+        with mock.patch("sys.argv", ["prog", "--development"]):
+            run_application()
+
+    def test_run_core_app_with_different_taipy_core_version_in_experiment_mode(self, caplog):
+        with mock.patch("sys.argv", ["prog", "--experiment", "1.0"]):
+            run_application()
+
+        # Run the application with a compatible version should not raise any error
+        patch_core_version(f"{self.major}.{self.minor}.{int(self.patch) + 1}.dev0")
+        with mock.patch("sys.argv", ["prog", "--experiment", "1.0"]):
+            run_application()
+
+        # Run the application with an incompatible version in experiment mode should raise SystemExit and log the error
+        patch_core_version(f"{self.major}.{int(self.minor) + 1}.{self.patch}.dev0")
+        with mock.patch("sys.argv", ["prog", "--experiment", "1.0"]):
+            with pytest.raises(SystemExit):
+                run_application()
+        assert (
+            f"The version {self.major}.{self.minor}.{self.patch} of Taipy's entities does not match version "
+            f"of the Taipy Version management {self.major}.{int(self.minor) + 1}.{self.patch}.dev0"
+        ) in caplog.text
+
+
+def twice(a):
+    return [a * 2]
+
+
+def run_application():
+    Config.configure_data_node(id="d0")
+    data_node_1_config = Config.configure_data_node(id="d1", storage_type="pickle", default_data="abc")
+    data_node_2_config = Config.configure_data_node(id="d2", storage_type="csv")
+    task_config = Config.configure_task("my_task", twice, data_node_1_config, data_node_2_config)
+    scenario_config = Config.configure_scenario("my_scenario", [task_config])
+    scenario_config.add_sequences({"my_sequence": [task_config]})
+
+    orchestrator = Orchestrator()
+    orchestrator.run()
+
+    scenario = _ScenarioManager._create(scenario_config)
+    taipy.submit(scenario)
+
+    orchestrator.stop()


### PR DESCRIPTION
## What type of PR is this?

- Refactor
- Bug Fix

## Description

In experiment mode, when the `core_version` is incompatible, the `CoreVersionMismatched` exception is raised but not caught properly. This PR should fix it and print a pretty log message.

Also in development mode, the `core_version` should not be checked since all entities will be deleted anyway.

## Related Tickets & Documents

- Closes #2420

## Checklist
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] This solution meets the acceptance criteria of the related issue.
- [x] The related issue checklist is completed.
- [x] This PR adds unit tests for the developed code. If not, why?
- [x] End-to-End tests have been added or updated. If not, why?
- [ ] The documentation has been updated, or a dedicated issue created. (If applicable)
- [ ] The release notes have been updated? (If applicable)
