### PR TITLE
Refactor config so nested class to serialize are registered (scope and frequency)

### DIFF
--- a/taipy/common/_repr_enum.py
+++ b/taipy/common/_repr_enum.py
@@ -18,3 +18,25 @@ class _ReprEnum(Enum):
     @functools.lru_cache
     def _from_repr(cls, repr_: str):
         return next(filter(lambda e: repr(e) == repr_, cls))  # type: ignore
+
+
+class _OrderedEnum(_ReprEnum):
+    def __ge__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+        return NotImplemented
+
+    def __gt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+        return NotImplemented
+
+    def __le__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented

--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -112,6 +112,7 @@ def _inject_section(
     add_to_unconflicted_sections: bool = False,
 ):
     Config._register_default(default)
+    
     if issubclass(section_clazz, UniqueSection):
         setattr(Config, attribute_name, Config.unique_sections[section_clazz.name])
     elif issubclass(section_clazz, Section):

--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -50,8 +50,6 @@ from inspect import signature
 from typing import List
 
 from ._init import Config
-from .common.frequency import Frequency
-from .common.scope import Scope
 from .global_app.global_app_config import GlobalAppConfig
 from .section import Section
 from .unique_section import UniqueSection
@@ -114,7 +112,6 @@ def _inject_section(
     add_to_unconflicted_sections: bool = False,
 ):
     Config._register_default(default)
-
     if issubclass(section_clazz, UniqueSection):
         setattr(Config, attribute_name, Config.unique_sections[section_clazz.name])
     elif issubclass(section_clazz, Section):

--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -112,7 +112,6 @@ def _inject_section(
     add_to_unconflicted_sections: bool = False,
 ):
     Config._register_default(default)
-    
     if issubclass(section_clazz, UniqueSection):
         setattr(Config, attribute_name, Config.unique_sections[section_clazz.name])
     elif issubclass(section_clazz, Section):

--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -112,6 +112,7 @@ def _inject_section(
     add_to_unconflicted_sections: bool = False,
 ):
     Config._register_default(default)
+
     if issubclass(section_clazz, UniqueSection):
         setattr(Config, attribute_name, Config.unique_sections[section_clazz.name])
     elif issubclass(section_clazz, Section):

--- a/taipy/common/config/_config.py
+++ b/taipy/common/config/_config.py
@@ -75,7 +75,6 @@ class _Config:
 
     def __point_nested_section_to_self(self, section) -> None:
         """Loop through attributes of a Section to find if any attribute has a list of Section as value.
-
         If there is, update each nested Section by the corresponding instance in self.
 
         Arguments:

--- a/taipy/common/config/_config.py
+++ b/taipy/common/config/_config.py
@@ -75,6 +75,7 @@ class _Config:
 
     def __point_nested_section_to_self(self, section) -> None:
         """Loop through attributes of a Section to find if any attribute has a list of Section as value.
+
         If there is, update each nested Section by the corresponding instance in self.
 
         Arguments:

--- a/taipy/common/config/_init.py
+++ b/taipy/common/config/_init.py
@@ -9,6 +9,4 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from .common.frequency import Frequency
-from .common.scope import Scope
 from .config import Config

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -111,8 +111,7 @@ class _BaseSerializer(object):
         res = {}
         for key, value in config_as_dict.get(node, {}).items():  # my_task, {input=[], output=[my_data_node], ...}
             key = _validate_id(key)
-            res[key] = cls_config._from_dict(value, key, config)  # if config is None else cls_config._from_dict(key,
-            # value, config)
+            res[key] = cls_config._from_dict(value, key, config)
         return res
 
     @classmethod

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -19,9 +19,7 @@ from typing import Any, Dict, Optional
 from .._config import _Config
 from ..common._template_handler import _TemplateHandler
 from ..common._validate_id import _validate_id
-from ..common.frequency import Frequency
-from ..common.scope import Scope
-from ..exceptions.exceptions import LoadingError
+from ..exceptions.exceptions import InvalidConfigurationType, LoadingError
 from ..global_app.global_app_config import GlobalAppConfig
 from ..section import Section
 from ..unique_section import UniqueSection
@@ -32,6 +30,19 @@ class _BaseSerializer(object):
 
     _GLOBAL_NODE_NAME = "TAIPY"
     _section_class = {_GLOBAL_NODE_NAME: GlobalAppConfig}
+    _registered_types = {}
+
+    @classmethod
+    def _register(cls, section: Section):
+        cls._section_class[section.name] = section.__class__
+        for clazz in section._types_to_register():
+            if not hasattr(clazz, "_type_identifier"):
+                raise InvalidConfigurationType(f"Type {clazz.__name__} must have a `_type_identifier` method.")
+            if not hasattr(clazz, "_stringify"):
+                raise InvalidConfigurationType(f"Type {clazz.__name__} must have a `_stringify` method.")
+            if not hasattr(clazz, "_pythonify"):
+                raise InvalidConfigurationType(f"Type {clazz.__name__} must have a `_pythonify` method.")
+            cls._registered_types[clazz._type_identifier()] = clazz
 
     @classmethod
     @abstractmethod
@@ -44,23 +55,19 @@ class _BaseSerializer(object):
         for u_sect_name, u_sect in configuration._unique_sections.items():
             config_as_dict[u_sect_name] = u_sect._to_dict()
         for sect_name, sections in configuration._sections.items():
-            config_as_dict[sect_name] = cls._to_dict(sections)
-        return cls._stringify(config_as_dict)
+            config_as_dict[sect_name] = cls.__to_dict(sections)
+        return cls.__stringify(config_as_dict)
 
     @classmethod
-    def _to_dict(cls, sections: Dict[str, Any]):
+    def __to_dict(cls, sections: Dict[str, Any]):
         return {section_id: section._to_dict() for section_id, section in sections.items()}
 
     @classmethod
-    def _stringify(cls, as_dict):
+    def __stringify(cls, as_dict):
         if as_dict is None:
             return None
-        if isinstance(as_dict, Section):
-            return f"{as_dict.id}:SECTION"
-        if isinstance(as_dict, Scope):
-            return f"{as_dict.name}:SCOPE"
-        if isinstance(as_dict, Frequency):
-            return f"{as_dict.name}:FREQUENCY"
+        if hasattr(as_dict, '_stringify') and callable(as_dict._stringify):
+            return as_dict._stringify()
         if isinstance(as_dict, bool):
             return f"{str(as_dict)}:bool"
         if isinstance(as_dict, int):
@@ -76,23 +83,14 @@ class _BaseSerializer(object):
         if inspect.isclass(as_dict):
             return f"{as_dict.__module__}.{as_dict.__qualname__}:class"
         if isinstance(as_dict, dict):
-            return {str(key): cls._stringify(val) for key, val in as_dict.items()}
+            return {str(key): cls.__stringify(val) for key, val in as_dict.items()}
         if isinstance(as_dict, list):
-            return [cls._stringify(val) for val in as_dict]
+            return [cls.__stringify(val) for val in as_dict]
         if isinstance(as_dict, tuple):
-            return [cls._stringify(val) for val in as_dict]
+            return [cls.__stringify(val) for val in as_dict]
         if isinstance(as_dict, set):
-            return [cls._stringify(val) for val in as_dict]
+            return [cls.__stringify(val) for val in as_dict]
         return as_dict
-
-    @staticmethod
-    def _extract_node(config_as_dict, cls_config, node, config: Optional[Any]) -> Dict[str, Section]:
-        res = {}
-        for key, value in config_as_dict.get(node, {}).items():  # my_task, {input=[], output=[my_data_node], ...}
-            key = _validate_id(key)
-            res[key] = cls_config._from_dict(value, key, config)  # if config is None else cls_config._from_dict(key,
-            # value, config)
-        return res
 
     @classmethod
     def _from_dict(cls, as_dict) -> _Config:
@@ -105,8 +103,17 @@ class _BaseSerializer(object):
                         sect_as_dict, None, None
                     )
                 elif issubclass(section_class, Section):
-                    config._sections[section_name] = cls._extract_node(as_dict, section_class, section_name, config)
+                    config._sections[section_name] = cls.__extract_node(as_dict, section_class, section_name, config)
         return config
+
+    @staticmethod
+    def __extract_node(config_as_dict, cls_config, node, config: Optional[Any]) -> Dict[str, Section]:
+        res = {}
+        for key, value in config_as_dict.get(node, {}).items():  # my_task, {input=[], output=[my_data_node], ...}
+            key = _validate_id(key)
+            res[key] = cls_config._from_dict(value, key, config)  # if config is None else cls_config._from_dict(key,
+            # value, config)
+        return res
 
     @classmethod
     def _pythonify(cls, val):
@@ -122,10 +129,8 @@ class _BaseSerializer(object):
                     dynamic_type = match.group(2)
                     if dynamic_type == "SECTION":
                         return actual_val
-                    if dynamic_type == "FREQUENCY":
-                        return Frequency[actual_val]
-                    if dynamic_type == "SCOPE":
-                        return Scope[actual_val]
+                    if dynamic_type in cls._registered_types.keys():
+                        return cls._registered_types[dynamic_type]._pythonify(actual_val)
                     if dynamic_type == "bool":
                         return _TemplateHandler._to_bool(actual_val)
                     elif dynamic_type == "int":

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -30,7 +30,7 @@ class _BaseSerializer(object):
 
     _GLOBAL_NODE_NAME = "TAIPY"
     _section_class = {_GLOBAL_NODE_NAME: GlobalAppConfig}
-    _registered_types = {}
+    _registered_types: Dict[str, type] = {}
 
     @classmethod
     def _register(cls, section: Section):

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -33,7 +33,7 @@ class _BaseSerializer(object):
     _registered_types: Dict[str, type] = {}
 
     @classmethod
-    def _register(cls, section: Section):
+    def _register(cls, section):
         cls._section_class[section.name] = section.__class__
         for clazz in section._types_to_register():
             if not hasattr(clazz, "_type_identifier"):

--- a/taipy/common/config/common/__init__.py
+++ b/taipy/common/config/common/__init__.py
@@ -8,4 +8,3 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-from .scope import Scope

--- a/taipy/common/config/common/_template_handler.py
+++ b/taipy/common/config/common/_template_handler.py
@@ -18,8 +18,6 @@ from operator import attrgetter
 from pydoc import locate
 
 from ..exceptions.exceptions import InconsistentEnvVariableError, MissingEnvVariableError
-from .frequency import Frequency
-from .scope import Scope
 
 
 class _TemplateHandler:
@@ -57,10 +55,6 @@ class _TemplateHandler:
                 return cls._to_int(val)
             elif type is float:
                 return cls._to_float(val)
-            elif type is Scope:
-                return cls._to_scope(val)
-            elif type is Frequency:
-                return cls._to_frequency(val)
             else:
                 if dynamic_type == "bool":
                     return cls._to_bool(val)
@@ -75,7 +69,7 @@ class _TemplateHandler:
     def _to_bool(val: str) -> bool:
         possible_values = ["true", "false"]
         if str.lower(val) not in possible_values:
-            raise InconsistentEnvVariableError("{val} is not a Boolean.")
+            raise InconsistentEnvVariableError(f"{val} is not a Boolean.")
         return str.lower(val) == "true" or str.lower(val) != "false"
 
     @staticmethod
@@ -118,20 +112,6 @@ class _TemplateHandler:
             raise InconsistentEnvVariableError(f"{val} is not a valid timedelta.")
         time_params = {name: float(param) for name, param in parts.groupdict().items() if param}
         return timedelta(**time_params)  # type: ignore
-
-    @staticmethod
-    def _to_scope(val: str) -> Scope:
-        try:
-            return Scope[str.upper(val)]
-        except Exception:
-            raise InconsistentEnvVariableError(f"{val} is not a valid scope.") from None
-
-    @staticmethod
-    def _to_frequency(val: str) -> Frequency:
-        try:
-            return Frequency[str.upper(val)]
-        except Exception:
-            raise InconsistentEnvVariableError(f"{val} is not a valid frequency.") from None
 
     @staticmethod
     def _to_function(val: str):

--- a/taipy/common/config/config.py
+++ b/taipy/common/config/config.py
@@ -266,6 +266,8 @@ class Config:
             cls._default_config._sections[default_section.name] = {default_section.id: default_section}
         cls._serializer._section_class[default_section.name] = default_section.__class__  # type: ignore
         cls.__json_serializer._section_class[default_section.name] = default_section.__class__  # type: ignore
+        cls._serializer._register(default_section)
+        cls.__json_serializer._register(default_section)
         cls._compile_configs()
 
     @classmethod
@@ -283,8 +285,8 @@ class Config:
                 sections[section.id] = section
         else:
             cls._python_config._sections[section.name] = {section.id: section}
-        cls._serializer._section_class[section.name] = section.__class__
-        cls.__json_serializer._section_class[section.name] = section.__class__
+        cls._serializer._register(section)
+        cls.__json_serializer._register(section)
         cls._compile_configs()
 
     @classmethod

--- a/taipy/common/config/config.pyi
+++ b/taipy/common/config/config.pyi
@@ -18,8 +18,6 @@ from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioCo
 from .checker.issue_collector import IssueCollector
 from .common._classproperty import _Classproperty
 from .common._config_blocker import _ConfigBlocker
-from .common.frequency import Frequency
-from .common.scope import Scope
 from .global_app.global_app_config import GlobalAppConfig
 from .section import Section
 from .unique_section import UniqueSection

--- a/taipy/common/config/config.pyi
+++ b/taipy/common/config/config.pyi
@@ -13,6 +13,8 @@ from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from taipy.common.config._config import _Config
+from taipy.core.common.scope import Scope
+from taipy.core.common.frequency import Frequency
 from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioConfig, TaskConfig
 
 from .checker.issue_collector import IssueCollector

--- a/taipy/common/config/config.pyi
+++ b/taipy/common/config/config.pyi
@@ -13,8 +13,8 @@ from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from taipy.common.config._config import _Config
-from taipy.core.common.scope import Scope
 from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioConfig, TaskConfig
 
 from .checker.issue_collector import IssueCollector

--- a/taipy/common/config/exceptions/exceptions.py
+++ b/taipy/common/config/exceptions/exceptions.py
@@ -25,6 +25,8 @@ class MissingEnvVariableError(Exception):
 class InvalidConfigurationId(Exception):
     """Configuration id is not valid."""
 
+class InvalidConfigurationType(Exception):
+    """Configuration attribute has an invalid type."""
 
 class ConfigurationUpdateBlocked(Exception):
     """The configuration is being blocked from update by other Taipy services."""

--- a/taipy/common/config/section.py
+++ b/taipy/common/config/section.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from abc import abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .common._config_blocker import _ConfigBlocker
 from .common._template_handler import _TemplateHandler as _tpl
@@ -53,6 +53,14 @@ class Section:
     def __init__(self, id, **properties):
         self.id = _validate_id(id)
         self._properties = properties or {}
+
+    def _stringify(self):
+        return f"{self.id}:SECTION"
+
+    @staticmethod
+    def _types_to_register() -> List[type]:
+        """Return a list of types to register for serialization."""
+        return []
 
     @abstractmethod
     def __copy__(self):

--- a/taipy/common/config/stubs/pyi_header.py
+++ b/taipy/common/config/stubs/pyi_header.py
@@ -18,8 +18,6 @@ from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioCo
 from .checker.issue_collector import IssueCollector
 from .common._classproperty import _Classproperty
 from .common._config_blocker import _ConfigBlocker
-from .common.frequency import Frequency
-from .common.scope import Scope
 from .global_app.global_app_config import GlobalAppConfig
 from .section import Section
 from .unique_section import UniqueSection

--- a/taipy/common/config/stubs/pyi_header.py
+++ b/taipy/common/config/stubs/pyi_header.py
@@ -13,6 +13,8 @@ from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from taipy.common.config._config import _Config
+from taipy.core.common.scope import Scope
+from taipy.core.common.frequency import Frequency
 from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioConfig, TaskConfig
 
 from .checker.issue_collector import IssueCollector

--- a/taipy/common/config/stubs/pyi_header.py
+++ b/taipy/common/config/stubs/pyi_header.py
@@ -13,8 +13,8 @@ from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from taipy.common.config._config import _Config
-from taipy.core.common.scope import Scope
 from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioConfig, TaskConfig
 
 from .checker.issue_collector import IssueCollector

--- a/taipy/core/_init.py
+++ b/taipy/core/_init.py
@@ -11,6 +11,8 @@
 
 from ._core import Core
 from ._entity.submittable import Submittable
+from .common.frequency import Frequency
+from .common.scope import Scope
 from .cycle.cycle import Cycle
 from .cycle.cycle_id import CycleId
 from .data.data_node import DataNode

--- a/taipy/core/common/__init__.py
+++ b/taipy/core/common/__init__.py
@@ -9,4 +9,6 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from .frequency import Frequency
 from .mongo_default_document import MongoDefaultDocument
+from .scope import Scope

--- a/taipy/core/common/frequency.py
+++ b/taipy/core/common/frequency.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from ..common._repr_enum import _ReprEnum
+from taipy.common._repr_enum import _ReprEnum
 
 
 class Frequency(_ReprEnum):
@@ -39,3 +39,26 @@ class Frequency(_ReprEnum):
     MONTHLY = 3
     QUARTERLY = 4
     YEARLY = 5
+
+    @staticmethod
+    def _type_identifier():
+        """Return a string to identify the object type.
+
+        The type identifier is used to identify the type of the value when serializing
+        and deserializing the configuration. As a consequence, the identifier must be
+        a unique string and must not change over time to ensure backward compatibility.
+        """
+        return "FREQUENCY"
+
+    def _stringify(self) -> str:
+        """Return a string representation of the object.
+
+        The string representation is used to serialize the object. It must be a unique string
+        that can be used to deserialize the object. The string representation must not change
+        over time to ensure backward compatibility.
+        """
+        return f"{self.name}:{self._type_identifier()}"
+
+    @classmethod
+    def _pythonify(cls, value: str):
+        return Frequency[str.upper(value)]

--- a/taipy/core/common/scope.py
+++ b/taipy/core/common/scope.py
@@ -1,37 +1,4 @@
-# Copyright 2021-2025 Avaiga Private Limited
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
-# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations under the License.
-
-from ..common._repr_enum import _ReprEnum
-
-
-class _OrderedEnum(_ReprEnum):
-    def __ge__(self, other):
-        if self.__class__ is other.__class__:
-            return self.value >= other.value
-        return NotImplemented
-
-    def __gt__(self, other):
-        if self.__class__ is other.__class__:
-            return self.value > other.value
-        return NotImplemented
-
-    def __le__(self, other):
-        if self.__class__ is other.__class__:
-            return self.value <= other.value
-        return NotImplemented
-
-    def __lt__(self, other):
-        if self.__class__ is other.__class__:
-            return self.value < other.value
-        return NotImplemented
+from taipy.common._repr_enum import _OrderedEnum
 
 
 class Scope(_OrderedEnum):
@@ -96,3 +63,26 @@ class Scope(_OrderedEnum):
     GLOBAL = 3
     CYCLE = 2
     SCENARIO = 1
+
+    @staticmethod
+    def _type_identifier() -> str:
+        """Return a string to identify the object type.
+
+        The type identifier is used to identify the type of the value when serializing
+        and deserializing the configuration. As a consequence, the identifier must be
+        a unique string and must not change over time to ensure backward compatibility.
+        """
+        return "SCOPE"
+
+    def _stringify(self) -> str:
+        """Return a string representation of the object.
+
+        The string representation is used to serialize the object. It must be a unique string
+        that can be used to deserialize the object. The string representation must not change
+        over time to ensure backward compatibility.
+        """
+        return f"{self.name}:{self._type_identifier()}"
+
+    @classmethod
+    def _pythonify(cls, value: str):
+        return Scope[str.upper(value)]

--- a/taipy/core/config/__init__.py
+++ b/taipy/core/config/__init__.py
@@ -10,13 +10,8 @@
 # specific language governing permissions and limitations under the License.
 """Configuration of the core package functionalities."""
 
-from taipy.common.config import (
-    Config,  # type: ignore
-    _inject_section,
-)
+from taipy.common.config import _inject_section
 from taipy.common.config.checker._checker import _Checker
-from taipy.common.config.common.frequency import Frequency  # type: ignore
-from taipy.common.config.common.scope import Scope  # type: ignore
 from taipy.common.config.global_app.global_app_config import GlobalAppConfig  # type: ignore
 
 from .checkers._config_id_checker import _ConfigIdChecker

--- a/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/taipy/core/config/checkers/_data_node_config_checker.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, List, cast
 from taipy.common.config._config import _Config
 from taipy.common.config.checker._checkers._config_checker import _ConfigChecker
 from taipy.common.config.checker.issue_collector import IssueCollector
-from taipy.common.config.common.scope import Scope
+from taipy.core.common.scope import Scope
 
 from ...scenario.scenario import Scenario
 from ...task.task import Task

--- a/taipy/core/config/checkers/_scenario_config_checker.py
+++ b/taipy/core/config/checkers/_scenario_config_checker.py
@@ -15,8 +15,8 @@ from taipy.common.config import Config
 from taipy.common.config._config import _Config
 from taipy.common.config.checker._checkers._config_checker import _ConfigChecker
 from taipy.common.config.checker.issue_collector import IssueCollector
-from taipy.common.config.common.frequency import Frequency
 
+from ...common.frequency import Frequency
 from ..data_node_config import DataNodeConfig
 from ..scenario_config import ScenarioConfig
 from ..task_config import TaskConfig

--- a/taipy/core/config/data_node_config.py
+++ b/taipy/core/config/data_node_config.py
@@ -21,12 +21,12 @@ from taipy.common.config import Config
 from taipy.common.config._config import _Config
 from taipy.common.config.common._config_blocker import _ConfigBlocker
 from taipy.common.config.common._template_handler import _TemplateHandler as _tpl
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.section import Section
 
 from ..common._utils import _normalize_path
 from ..common._warnings import _warn_deprecated
 from ..common.mongo_default_document import MongoDefaultDocument
+from ..common.scope import Scope
 
 
 class DataNodeConfig(Section):
@@ -504,6 +504,10 @@ class DataNodeConfig(Section):
             for optional_property, default_value in self._OPTIONAL_PROPERTIES[self._storage_type].items():
                 if default_value is not None and self._properties.get(optional_property) is None:
                     self._properties[optional_property] = default_value
+
+    @staticmethod
+    def _types_to_register() -> List[type]:
+        return [Scope]
 
     @staticmethod
     def _set_default_configuration(

--- a/taipy/core/config/scenario_config.py
+++ b/taipy/core/config/scenario_config.py
@@ -19,9 +19,9 @@ from taipy.common.config import Config
 from taipy.common.config._config import _Config
 from taipy.common.config.common._template_handler import _TemplateHandler as _tpl
 from taipy.common.config.common._validate_id import _validate_id
-from taipy.common.config.common.frequency import Frequency
 from taipy.common.config.section import Section
 
+from ..common.frequency import Frequency
 from .data_node_config import DataNodeConfig
 from .task_config import TaskConfig
 
@@ -300,6 +300,10 @@ class ScenarioConfig(Section):
         self._properties.update(as_dict)
         if default_section:
             self._properties = {**default_section.properties, **self._properties}
+
+    @staticmethod
+    def _types_to_register() -> List[type]:
+        return [Frequency]
 
     @staticmethod
     def _configure(

--- a/taipy/core/cycle/_cycle_manager.py
+++ b/taipy/core/cycle/_cycle_manager.py
@@ -13,11 +13,10 @@ import calendar
 from datetime import datetime, time, timedelta
 from typing import Callable, List, Optional
 
-from taipy.common.config.common.frequency import Frequency
-
 from .._entity._entity_ids import _EntityIds
 from .._manager._manager import _Manager
 from .._repository._abstract_repository import _AbstractRepository
+from ..common.frequency import Frequency
 from ..job._job_manager_factory import _JobManagerFactory
 from ..notification import EventEntityType, EventOperation, _publish_event
 from ..submission._submission_manager_factory import _SubmissionManagerFactory

--- a/taipy/core/cycle/_cycle_model.py
+++ b/taipy/core/cycle/_cycle_model.py
@@ -12,9 +12,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict
 
-from taipy.common.config.common.frequency import Frequency
-
 from .._repository._base_taipy_model import _BaseModel
+from ..common.frequency import Frequency
 from .cycle_id import CycleId
 
 

--- a/taipy/core/cycle/cycle.py
+++ b/taipy/core/cycle/cycle.py
@@ -14,12 +14,11 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from taipy.common.config.common.frequency import Frequency
-
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties
 from .._entity._reload import _Reloader, _self_reload, _self_setter
+from ..common.frequency import Frequency
 from ..exceptions.exceptions import _SuspiciousFileOperation
 from ..notification.event import Event, EventEntityType, EventOperation, _make_event
 from .cycle_id import CycleId

--- a/taipy/core/data/_abstract_sql.py
+++ b/taipy/core/data/_abstract_sql.py
@@ -20,9 +20,8 @@ import numpy as np
 import pandas as pd
 from sqlalchemy import create_engine, text
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..data.operator import JoinOperator, Operator
 from ..exceptions.exceptions import MissingRequiredProperty, UnknownDatabaseEngine
 from ._tabular_datanode_mixin import _TabularDataNodeMixin

--- a/taipy/core/data/_data_manager.py
+++ b/taipy/core/data/_data_manager.py
@@ -14,10 +14,10 @@ from typing import Dict, Iterable, List, Optional, Set, Union
 
 from taipy.common.config import Config
 from taipy.common.config._config import _Config
-from taipy.common.config.common.scope import Scope
 
 from .._manager._manager import _Manager
 from .._version._version_mixin import _VersionMixin
+from ..common.scope import Scope
 from ..config.data_node_config import DataNodeConfig
 from ..cycle.cycle_id import CycleId
 from ..exceptions.exceptions import InvalidDataNodeType

--- a/taipy/core/data/_data_model.py
+++ b/taipy/core/data/_data_model.py
@@ -12,9 +12,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from taipy.common.config.common.scope import Scope
-
 from .._repository._base_taipy_model import _BaseModel
+from ..common.scope import Scope
 from .data_node_id import Edit
 
 

--- a/taipy/core/data/aws_s3.py
+++ b/taipy/core/data/aws_s3.py
@@ -18,9 +18,8 @@ from ..common._check_dependencies import _check_dependency_is_installed
 if util.find_spec("boto3"):
     import boto3
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import MissingRequiredProperty
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit

--- a/taipy/core/data/csv.py
+++ b/taipy/core/data/csv.py
@@ -16,10 +16,9 @@ from typing import Any, Dict, List, Optional, Set
 import numpy as np
 import pandas as pd
 
-from taipy.common.config.common.scope import Scope
-
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ._file_datanode_mixin import _FileDataNodeMixin
 from ._tabular_datanode_mixin import _TabularDataNodeMixin
 from .data_node import DataNode

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -21,7 +21,6 @@ import networkx as nx
 
 from taipy.common.config import Config
 from taipy.common.config.common._validate_id import _validate_id
-from taipy.common.config.common.scope import Scope
 from taipy.common.logger._taipy_logger import _TaipyLogger
 
 from .._entity._entity import _Entity
@@ -30,6 +29,7 @@ from .._entity._properties import _Properties
 from .._entity._ready_to_run_property import _ReadyToRunProperty
 from .._entity._reload import _Reloader, _self_reload, _self_setter
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import DataNodeIsBeingEdited, NoData
 from ..job.job_id import JobId
 from ..notification.event import Event, EventEntityType, EventOperation, _make_event

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -16,10 +16,9 @@ import numpy as np
 import pandas as pd
 from openpyxl import load_workbook
 
-from taipy.common.config.common.scope import Scope
-
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import ExposedTypeLengthMismatch, NonExistingExcelSheet, SheetNameLengthMismatch
 from ._file_datanode_mixin import _FileDataNodeMixin
 from ._tabular_datanode_mixin import _TabularDataNodeMixin

--- a/taipy/core/data/generic.py
+++ b/taipy/core/data/generic.py
@@ -12,9 +12,8 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import MissingReadFunction, MissingRequiredProperty, MissingWriteFunction
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit

--- a/taipy/core/data/in_memory.py
+++ b/taipy/core/data/in_memory.py
@@ -12,9 +12,8 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit
 

--- a/taipy/core/data/json.py
+++ b/taipy/core/data/json.py
@@ -16,10 +16,9 @@ from enum import Enum
 from pydoc import locate
 from typing import Any, Dict, List, Optional, Set
 
-from taipy.common.config.common.scope import Scope
-
 from .._entity._reload import _Reloader, _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ._file_datanode_mixin import _FileDataNodeMixin
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit

--- a/taipy/core/data/mongo.py
+++ b/taipy/core/data/mongo.py
@@ -14,10 +14,9 @@ from importlib import util
 from inspect import isclass
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..common._check_dependencies import _check_dependency_is_installed
+from ..common.scope import Scope
 
 if util.find_spec("pymongo"):
     from ..common._mongo_connector import _connect_mongodb

--- a/taipy/core/data/parquet.py
+++ b/taipy/core/data/parquet.py
@@ -16,10 +16,9 @@ from typing import Any, Dict, List, Optional, Set
 import numpy as np
 import pandas as pd
 
-from taipy.common.config.common.scope import Scope
-
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import UnknownCompressionAlgorithm, UnknownParquetEngine
 from ._file_datanode_mixin import _FileDataNodeMixin
 from ._tabular_datanode_mixin import _TabularDataNodeMixin

--- a/taipy/core/data/pickle.py
+++ b/taipy/core/data/pickle.py
@@ -13,10 +13,9 @@ import pickle
 from datetime import datetime, timedelta
 from typing import Any, List, Optional, Set
 
-from taipy.common.config.common.scope import Scope
-
 from .._entity._reload import _Reloader
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ._file_datanode_mixin import _FileDataNodeMixin
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit

--- a/taipy/core/data/sql.py
+++ b/taipy/core/data/sql.py
@@ -14,9 +14,8 @@ from typing import Dict, List, Optional, Set
 
 from sqlalchemy import text
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import MissingAppendQueryBuilder, MissingRequiredProperty
 from ._abstract_sql import _AbstractSQLDataNode
 from .data_node_id import DataNodeId, Edit

--- a/taipy/core/data/sql_table.py
+++ b/taipy/core/data/sql_table.py
@@ -15,9 +15,8 @@ from typing import Any, Dict, List, Optional, Set, Union
 import pandas as pd
 from sqlalchemy import MetaData, Table
 
-from taipy.common.config.common.scope import Scope
-
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..exceptions.exceptions import MissingRequiredProperty
 from ._abstract_sql import _AbstractSQLDataNode
 from .data_node_id import DataNodeId, Edit

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -12,7 +12,6 @@
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Union, overload
 
-from taipy.common.config import Scope
 from taipy.common.logger._taipy_logger import _TaipyLogger
 
 from ._entity._entity import _Entity
@@ -27,6 +26,7 @@ from .common._check_instance import (
     _is_task,
 )
 from .common._warnings import _warn_no_orchestrator_service
+from .common.scope import Scope
 from .config.data_node_config import DataNodeConfig
 from .config.scenario_config import ScenarioConfig
 from .cycle._cycle_manager_factory import _CycleManagerFactory

--- a/taipy/core/task/_task_manager.py
+++ b/taipy/core/task/_task_manager.py
@@ -12,7 +12,6 @@
 from typing import Callable, List, Optional, Type, Union, cast
 
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 
 from .._entity._entity_ids import _EntityIds
 from .._manager._manager import _Manager
@@ -20,6 +19,7 @@ from .._orchestrator._abstract_orchestrator import _AbstractOrchestrator
 from .._repository._abstract_repository import _AbstractRepository
 from .._version._version_manager_factory import _VersionManagerFactory
 from .._version._version_mixin import _VersionMixin
+from ..common.scope import Scope
 from ..common.warn_if_inputs_not_ready import _warn_if_inputs_not_ready
 from ..config.task_config import TaskConfig
 from ..cycle.cycle_id import CycleId

--- a/taipy/core/task/task.py
+++ b/taipy/core/task/task.py
@@ -13,13 +13,13 @@ import uuid
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Union
 
 from taipy.common.config.common._validate_id import _validate_id
-from taipy.common.config.common.scope import Scope
 
 from .._entity._entity import _Entity
 from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties
 from .._entity._reload import _Reloader, _self_reload, _self_setter
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common.scope import Scope
 from ..data.data_node import DataNode
 from ..exceptions import AttributeKeyAlreadyExisted
 from ..notification.event import Event, EventEntityType, EventOperation, _make_event

--- a/taipy/gui_core/_adapters.py
+++ b/taipy/gui_core/_adapters.py
@@ -23,6 +23,7 @@ from operator import attrgetter, contains, eq, ge, gt, le, lt, ne
 
 import pandas as pd
 
+from taipy.common.config import Config
 from taipy.core import (
     Cycle,
     DataNode,
@@ -35,7 +36,6 @@ from taipy.core import (
     is_submittable,
 )
 from taipy.core import get as core_get
-from taipy.core.config import Config
 from taipy.core.data import JSONDataNode
 from taipy.core.data._file_datanode_mixin import _FileDataNodeMixin
 from taipy.core.data._tabular_datanode_mixin import _TabularDataNodeMixin

--- a/taipy/rest/api/resources/cycle.py
+++ b/taipy/rest/api/resources/cycle.py
@@ -14,8 +14,8 @@ from datetime import datetime
 from flask import request
 from flask_restful import Resource
 
-from taipy.common.config.common.frequency import Frequency
 from taipy.core import Cycle
+from taipy.core.common.frequency import Frequency
 from taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
 from taipy.core.exceptions.exceptions import NonExistingCycle
 

--- a/taipy/templates/sdm/{{cookiecutter.__root_folder}}/config/config.py
+++ b/taipy/templates/sdm/{{cookiecutter.__root_folder}}/config/config.py
@@ -11,7 +11,7 @@
 
 from algos import clean_data
 
-from taipy.common.config import Config, Frequency, Scope
+from taipy import Config, Frequency, Scope
 
 
 def configure():

--- a/tests/common/config/common/test_scope.py
+++ b/tests/common/config/common/test_scope.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 
 
 def test_scope():

--- a/tests/common/config/common/test_template_handler.py
+++ b/tests/common/config/common/test_template_handler.py
@@ -16,8 +16,6 @@ from unittest import mock
 import pytest
 
 from taipy.common.config.common._template_handler import _TemplateHandler
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InconsistentEnvVariableError
 
 
@@ -169,31 +167,3 @@ def test_to_float():
     assert 0.0 == _TemplateHandler._to_float("0")
     assert -2.1 == _TemplateHandler._to_float("-2.1")
     assert 156165.3 == _TemplateHandler._to_float("156165.3")
-
-
-def test_to_scope():
-    with pytest.raises(InconsistentEnvVariableError):
-        _TemplateHandler._to_scope("okhds")
-    with pytest.raises(InconsistentEnvVariableError):
-        _TemplateHandler._to_scope("plop")
-
-    assert Scope.GLOBAL == _TemplateHandler._to_scope("global")
-    assert Scope.GLOBAL == _TemplateHandler._to_scope("GLOBAL")
-    assert Scope.SCENARIO == _TemplateHandler._to_scope("SCENARIO")
-    assert Scope.CYCLE == _TemplateHandler._to_scope("cycle")
-
-
-def test_to_frequency():
-    with pytest.raises(InconsistentEnvVariableError):
-        _TemplateHandler._to_frequency("okhds")
-    with pytest.raises(InconsistentEnvVariableError):
-        _TemplateHandler._to_frequency("plop")
-
-    assert Frequency.DAILY == _TemplateHandler._to_frequency("DAILY")
-    assert Frequency.DAILY == _TemplateHandler._to_frequency("Daily")
-    assert Frequency.WEEKLY == _TemplateHandler._to_frequency("weekly")
-    assert Frequency.WEEKLY == _TemplateHandler._to_frequency("WEEKLY")
-    assert Frequency.MONTHLY == _TemplateHandler._to_frequency("Monthly")
-    assert Frequency.MONTHLY == _TemplateHandler._to_frequency("MONThLY")
-    assert Frequency.QUARTERLY == _TemplateHandler._to_frequency("QuaRtERlY")
-    assert Frequency.YEARLY == _TemplateHandler._to_frequency("Yearly")

--- a/tests/common/config/test_section_serialization.py
+++ b/tests/common/config/test_section_serialization.py
@@ -16,8 +16,8 @@ from unittest import mock
 
 from taipy.common.config import Config
 from taipy.common.config._serializer._json_serializer import _JsonSerializer
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from tests.common.config.utils.named_temporary_file import NamedTemporaryFile
 from tests.common.config.utils.section_for_tests import SectionForTest
 from tests.common.config.utils.unique_section_for_tests import UniqueSectionForTest

--- a/tests/core/_entity/test_dag.py
+++ b/tests/core/_entity/test_dag.py
@@ -10,9 +10,9 @@
 # specific language governing permissions and limitations under the License.
 from typing import List
 
-from taipy.common.config.common.scope import Scope
 from taipy.core import DataNode, Sequence, SequenceId, Task, TaskId
 from taipy.core._entity._dag import _DAG
+from taipy.core.common.scope import Scope
 
 
 def assert_x(x: int, *nodes):

--- a/tests/core/_entity/test_labelled.py
+++ b/tests/core/_entity/test_labelled.py
@@ -13,9 +13,11 @@ from unittest import mock
 
 import pytest
 
-from taipy.common.config import Config, Frequency, Scope
+from taipy.common.config import Config
 from taipy.core import taipy
 from taipy.core._entity._labeled import _Labeled
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 
 
 class MockOwner:

--- a/tests/core/_entity/test_ready_to_run_property.py
+++ b/tests/core/_entity/test_ready_to_run_property.py
@@ -12,8 +12,8 @@
 
 from taipy import ScenarioId, SequenceId, TaskId
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
 from taipy.core._entity._ready_to_run_property import _ReadyToRunProperty
+from taipy.core.common.frequency import Frequency
 from taipy.core.reason import DataNodeEditInProgress, DataNodeIsNotWritten, ReasonCollection
 from taipy.core.scenario._scenario_manager_factory import _ScenarioManagerFactory
 from taipy.core.sequence._sequence_manager_factory import _SequenceManagerFactory

--- a/tests/core/_orchestrator/_dispatcher/test_task_function_wrapper.py
+++ b/tests/core/_orchestrator/_dispatcher/test_task_function_wrapper.py
@@ -12,9 +12,9 @@
 import random
 import string
 
+from taipy import Scope
 from taipy.common.config import Config
 from taipy.common.config._serializer._toml_serializer import _TomlSerializer
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions import ConfigurationUpdateBlocked
 from taipy.core._orchestrator._dispatcher._task_function_wrapper import _TaskFunctionWrapper
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/_orchestrator/test_orchestrator.py
+++ b/tests/core/_orchestrator/test_orchestrator.py
@@ -19,10 +19,10 @@ from typing import cast
 import pytest
 
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core._orchestrator._dispatcher import _StandaloneJobDispatcher
 from taipy.core._orchestrator._orchestrator import _Orchestrator
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
+from taipy.core.common.scope import Scope
 from taipy.core.config.job_config import JobConfig
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.scenario.scenario import Scenario

--- a/tests/core/_orchestrator/test_orchestrator__submit.py
+++ b/tests/core/_orchestrator/test_orchestrator__submit.py
@@ -16,10 +16,8 @@ from unittest import mock
 import freezegun
 import pytest
 
-from taipy import Scenario, Task
 from taipy.common.config import Config
-from taipy.common.config.common import Scope
-from taipy.core import Orchestrator, taipy
+from taipy.core import Orchestrator, Scenario, Scope, Task, taipy
 from taipy.core._orchestrator._orchestrator import _Orchestrator
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.config import JobConfig

--- a/tests/core/_version/test_version_cli.py
+++ b/tests/core/_version/test_version_cli.py
@@ -16,11 +16,11 @@ import pytest
 
 from taipy._entrypoint import _entrypoint
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.core import Orchestrator
 from taipy.core._version._cli._version_cli_factory import _VersionCLIFactory
 from taipy.core._version._version_manager import _VersionManager
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.job._job_manager import _JobManager
 from taipy.core.scenario._scenario_manager import _ScenarioManager

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -14,9 +14,9 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
 from taipy.common.config.checker.issue_collector import IssueCollector
-from taipy.common.config.common.scope import Scope
 from taipy.core.config.data_node_config import DataNodeConfig
 
 

--- a/tests/core/config/checkers/test_scenario_config_checker.py
+++ b/tests/core/config/checkers/test_scenario_config_checker.py
@@ -15,7 +15,7 @@ import pytest
 
 from taipy.common.config import Config
 from taipy.common.config.checker.issue_collector import IssueCollector
-from taipy.common.config.common.frequency import Frequency
+from taipy.core.common.frequency import Frequency
 from taipy.core.config import ScenarioConfig
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.config.task_config import TaskConfig

--- a/tests/core/config/test_config.py
+++ b/tests/core/config/test_config.py
@@ -11,8 +11,8 @@
 
 from datetime import timedelta
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 
 
 class TestConfig:

--- a/tests/core/config/test_config_serialization.py
+++ b/tests/core/config/test_config_serialization.py
@@ -14,8 +14,8 @@ import json
 
 from taipy.common.config import Config
 from taipy.common.config._serializer._json_serializer import _JsonSerializer
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config import CoreSection, DataNodeConfig, JobConfig, ScenarioConfig, TaskConfig
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -12,8 +12,8 @@
 import json
 from datetime import timedelta
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core.common.mongo_default_document import MongoDefaultDocument
 
 

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -15,8 +15,8 @@ from unittest import mock
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from taipy.core import MongoDefaultDocument
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory

--- a/tests/core/config/test_default_config.py
+++ b/tests/core/config/test_default_config.py
@@ -8,9 +8,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+from taipy import Scope
 from taipy.common.config import Config
 from taipy.common.config._config import _Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.global_app.global_app_config import GlobalAppConfig
 from taipy.core.config import CoreSection
 from taipy.core.config.data_node_config import DataNodeConfig

--- a/tests/core/config/test_file_config.py
+++ b/tests/core/config/test_file_config.py
@@ -14,8 +14,8 @@ from datetime import timedelta
 from unittest import mock
 
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config import DataNodeConfig, ScenarioConfig, TaskConfig
 from taipy.core.config.core_section import CoreSection
 from tests.core.utils.named_temporary_file import NamedTemporaryFile

--- a/tests/core/config/test_scenario_config.py
+++ b/tests/core/config/test_scenario_config.py
@@ -15,7 +15,7 @@ from unittest import mock
 import pytest
 
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
+from taipy.core.common.frequency import Frequency
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -23,11 +23,11 @@ from sqlalchemy.orm import close_all_sessions
 
 from taipy.common.config import Config
 from taipy.common.config.checker._checker import _Checker
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core._version._version import _Version
 from taipy.core._version._version_manager_factory import _VersionManagerFactory
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config import (
     _ConfigIdChecker,
     _CoreSectionChecker,

--- a/tests/core/cycle/test_cycle.py
+++ b/tests/core/cycle/test_cycle.py
@@ -12,11 +12,11 @@
 import datetime
 from datetime import timedelta
 
-from taipy.common.config.common.frequency import Frequency
-from taipy.core import CycleId
+from taipy.core.common.frequency import Frequency
 from taipy.core.cycle._cycle_manager import _CycleManager
 from taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
 from taipy.core.cycle.cycle import Cycle
+from taipy.core.cycle.cycle_id import CycleId
 from taipy.core.task.task import Task
 
 

--- a/tests/core/cycle/test_cycle_manager.py
+++ b/tests/core/cycle/test_cycle_manager.py
@@ -12,8 +12,8 @@
 from datetime import datetime
 
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.cycle._cycle_manager import _CycleManager
 from taipy.core.cycle.cycle import Cycle
 from taipy.core.cycle.cycle_id import CycleId

--- a/tests/core/data/test_aws_s3_data_node.py
+++ b/tests/core/data/test_aws_s3_data_node.py
@@ -20,8 +20,8 @@ import pytest
 from moto import mock_s3
 from pandas.testing import assert_frame_equal
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.aws_s3 import S3ObjectDataNode
 

--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -23,8 +23,8 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -14,8 +14,8 @@ import pathlib
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core._version._version_manager import _VersionManager
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -19,8 +19,8 @@ import pandas as pd
 import pytest
 
 import taipy.core as tp
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data._data_manager_factory import _DataManagerFactory

--- a/tests/core/data/test_excel_data_node.py
+++ b/tests/core/data/test_excel_data_node.py
@@ -23,8 +23,8 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data._data_manager_factory import _DataManagerFactory

--- a/tests/core/data/test_filter_csv_data_node.py
+++ b/tests/core/data/test_filter_csv_data_node.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.csv import CSVDataNode
 from taipy.core.data.operator import JoinOperator, Operator
 

--- a/tests/core/data/test_filter_excel_data_node.py
+++ b/tests/core/data/test_filter_excel_data_node.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.excel import ExcelDataNode
 from taipy.core.data.operator import JoinOperator, Operator
 

--- a/tests/core/data/test_filter_parquet_data_node.py
+++ b/tests/core/data/test_filter_parquet_data_node.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.operator import JoinOperator, Operator
 from taipy.core.data.parquet import ParquetDataNode
 

--- a/tests/core/data/test_filter_sql_table_data_node.py
+++ b/tests/core/data/test_filter_sql_table_data_node.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.operator import JoinOperator, Operator
 from taipy.core.data.sql_table import SQLTableDataNode
 

--- a/tests/core/data/test_generic_data_node.py
+++ b/tests/core/data/test_generic_data_node.py
@@ -11,8 +11,8 @@
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node import DataNode

--- a/tests/core/data/test_in_memory_data_node.py
+++ b/tests/core/data/test_in_memory_data_node.py
@@ -11,8 +11,8 @@
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node_id import DataNodeId

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -24,8 +24,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/data/test_mongo_data_node.py
+++ b/tests/core/data/test_mongo_data_node.py
@@ -20,8 +20,8 @@ import pytest
 from bson import ObjectId
 from bson.errors import InvalidDocument
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core import MongoDefaultDocument
 from taipy.core.common._mongo_connector import _connect_mongodb
 from taipy.core.data._data_manager_factory import _DataManagerFactory

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -23,8 +23,8 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -21,8 +21,8 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.common._utils import _normalize_path
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/data/test_read_csv_data_node.py
+++ b/tests/core/data/test_read_csv_data_node.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.csv import CSVDataNode
 from taipy.core.exceptions.exceptions import NoData
 

--- a/tests/core/data/test_read_excel_data_node.py
+++ b/tests/core/data/test_read_excel_data_node.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.excel import ExcelDataNode
 from taipy.core.exceptions.exceptions import (
     ExposedTypeLengthMismatch,

--- a/tests/core/data/test_read_parquet_data_node.py
+++ b/tests/core/data/test_read_parquet_data_node.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.parquet import ParquetDataNode
 from taipy.core.exceptions.exceptions import NoData
 

--- a/tests/core/data/test_read_sql_table_data_node.py
+++ b/tests/core/data/test_read_sql_table_data_node.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.operator import JoinOperator, Operator
 from taipy.core.data.sql_table import SQLTableDataNode
 

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -17,8 +17,8 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node_id import DataNodeId
 from taipy.core.data.operator import JoinOperator, Operator

--- a/tests/core/data/test_sql_table_data_node.py
+++ b/tests/core/data/test_sql_table_data_node.py
@@ -14,8 +14,8 @@ from unittest.mock import patch
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node_id import DataNodeId
 from taipy.core.data.sql_table import SQLTableDataNode

--- a/tests/core/data/test_write_csv_data_node.py
+++ b/tests/core/data/test_write_csv_data_node.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.csv import CSVDataNode
 
 

--- a/tests/core/data/test_write_multiple_sheet_excel_data_node.py
+++ b/tests/core/data/test_write_multiple_sheet_excel_data_node.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.excel import ExcelDataNode
 from taipy.core.exceptions.exceptions import SheetNameLengthMismatch
 

--- a/tests/core/data/test_write_parquet_data_node.py
+++ b/tests/core/data/test_write_parquet_data_node.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.parquet import ParquetDataNode
 
 

--- a/tests/core/data/test_write_single_sheet_excel_data_node.py
+++ b/tests/core/data/test_write_single_sheet_excel_data_node.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.excel import ExcelDataNode
 from taipy.core.exceptions.exceptions import SheetNameLengthMismatch
 

--- a/tests/core/data/test_write_sql_table_data_node.py
+++ b/tests/core/data/test_write_sql_table_data_node.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.sql_table import SQLTableDataNode
 
 

--- a/tests/core/data/utils.py
+++ b/tests/core/data/utils.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.data_node import DataNode
 from taipy.core.data.in_memory import InMemoryDataNode
 

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -18,8 +18,8 @@ from unittest.mock import MagicMock
 import freezegun
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core import JobId, TaskId
 from taipy.core._orchestrator._abstract_orchestrator import _AbstractOrchestrator
 from taipy.core._orchestrator._dispatcher._development_job_dispatcher import _DevelopmentJobDispatcher

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -19,8 +19,8 @@ from unittest import mock
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core._orchestrator._dispatcher import _StandaloneJobDispatcher
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core.config.job_config import JobConfig

--- a/tests/core/notification/test_core_event_consumer.py
+++ b/tests/core/notification/test_core_event_consumer.py
@@ -11,8 +11,9 @@
 
 from queue import SimpleQueue
 
-from taipy.common.config import Config, Frequency
+from taipy.common.config import Config
 from taipy.core import taipy as tp
+from taipy.core.common.frequency import Frequency
 from taipy.core.notification.core_event_consumer import CoreEventConsumerBase
 from taipy.core.notification.event import Event, EventEntityType, EventOperation
 from taipy.core.notification.notifier import Notifier

--- a/tests/core/notification/test_event.py
+++ b/tests/core/notification/test_event.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from taipy.common.config.common.frequency import Frequency
+from taipy.core.common.frequency import Frequency
 from taipy.core.exceptions.exceptions import InvalidEventAttributeName, InvalidEventOperation
 from taipy.core.notification.event import Event, EventEntityType, EventOperation, _make_event
 from taipy.core.submission.submission import Submission

--- a/tests/core/notification/test_events_published.py
+++ b/tests/core/notification/test_events_published.py
@@ -15,8 +15,9 @@ from typing import Any, Dict, List
 import pytest
 
 from taipy import Orchestrator
-from taipy.common.config import Config, Frequency
+from taipy.common.config import Config
 from taipy.core import taipy as tp
+from taipy.core.common.frequency import Frequency
 from taipy.core.job.status import Status
 from taipy.core.notification.core_event_consumer import CoreEventConsumerBase
 from taipy.core.notification.event import Event, EventEntityType, EventOperation

--- a/tests/core/notification/test_notifier.py
+++ b/tests/core/notification/test_notifier.py
@@ -11,9 +11,10 @@
 
 from queue import SimpleQueue
 
-from taipy.common.config import Config, Frequency
+from taipy.common.config import Config
 from taipy.core import taipy as tp
 from taipy.core._version._version_manager_factory import _VersionManagerFactory
+from taipy.core.common.frequency import Frequency
 from taipy.core.notification import EventEntityType, EventOperation
 from taipy.core.notification._topic import _Topic
 from taipy.core.notification.event import Event

--- a/tests/core/repository/test_encoding.py
+++ b/tests/core/repository/test_encoding.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import taipy.core.taipy as tp
-from taipy.core.config import Config
+from taipy.common.config import Config
 
 
 def test_no_special_characters():

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -13,11 +13,12 @@ from unittest import mock
 
 import pytest
 
-from taipy.common.config import Config, Frequency
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
+from taipy.common.config import Config
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core import create_scenario
 from taipy.core.common._utils import _Subscriber
+from taipy.core.common.frequency import Frequency
 from taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
 from taipy.core.cycle.cycle import Cycle, CycleId
 from taipy.core.data._data_manager_factory import _DataManagerFactory

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -17,14 +17,14 @@ import freezegun
 import pytest
 
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.core import Job
 from taipy.core import taipy as tp
 from taipy.core._orchestrator._orchestrator import _Orchestrator
 from taipy.core._version._version_manager import _VersionManager
 from taipy.core.common import _utils
 from taipy.core.common._utils import _Subscriber
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config.scenario_config import ScenarioConfig
 from taipy.core.cycle._cycle_manager import _CycleManager
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/sequence/test_sequence.py
+++ b/tests/core/sequence/test_sequence.py
@@ -13,8 +13,8 @@ from unittest import mock
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core.common._utils import _Subscriber
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.data_node import DataNode

--- a/tests/core/sequence/test_sequence_manager.py
+++ b/tests/core/sequence/test_sequence_manager.py
@@ -15,8 +15,8 @@ from unittest.mock import ANY
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core._orchestrator._orchestrator import _Orchestrator
 from taipy.core._version._version_manager import _VersionManager
 from taipy.core.common import _utils

--- a/tests/core/task/test_task.py
+++ b/tests/core/task/test_task.py
@@ -13,8 +13,8 @@ from unittest import mock
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import InvalidConfigurationId
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.data._data_manager import _DataManager

--- a/tests/core/task/test_task_manager.py
+++ b/tests/core/task/test_task_manager.py
@@ -14,8 +14,8 @@ from unittest import mock
 
 import pytest
 
+from taipy import Scope
 from taipy.common.config import Config
-from taipy.common.config.common.scope import Scope
 from taipy.core import taipy
 from taipy.core._orchestrator._orchestrator import _Orchestrator
 from taipy.core._version._version_manager import _VersionManager

--- a/tests/core/task/test_task_model.py
+++ b/tests/core/task/test_task_model.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data import InMemoryDataNode
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.task._task_model import _TaskModel

--- a/tests/core/test_core_cli.py
+++ b/tests/core/test_core_cli.py
@@ -14,12 +14,12 @@ from unittest.mock import patch
 import pytest
 
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.core import Orchestrator, taipy
 from taipy.core._version._version_manager import _VersionManager
 from taipy.core._version._version_manager_factory import _VersionManagerFactory
 from taipy.core.common._utils import _load_fct
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.cycle._cycle_manager import _CycleManager
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.exceptions.exceptions import NonExistingVersion

--- a/tests/core/test_taipy.py
+++ b/tests/core/test_taipy.py
@@ -16,8 +16,6 @@ import pytest
 
 import taipy.core.taipy as tp
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.common.config.exceptions.exceptions import ConfigurationUpdateBlocked
 from taipy.core import (
     Cycle,
@@ -36,6 +34,8 @@ from taipy.core import (
 )
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
 from taipy.core._version._version_manager import _VersionManager
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.config.scenario_config import ScenarioConfig
 from taipy.core.cycle._cycle_manager import _CycleManager

--- a/tests/gui_core/test_context_crud_scenario.py
+++ b/tests/gui_core/test_context_crud_scenario.py
@@ -12,7 +12,7 @@
 import typing as t
 from unittest.mock import Mock, patch
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core import DataNode, Scenario
 from taipy.core.data.pickle import PickleDataNode
 from taipy.gui.mock.mock_state import MockState

--- a/tests/gui_core/test_context_dn_properties.py
+++ b/tests/gui_core/test_context_dn_properties.py
@@ -12,7 +12,7 @@
 import typing as t
 from unittest.mock import Mock, patch
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core.data.pickle import PickleDataNode
 from taipy.gui_core._context import _GuiCoreContext
 

--- a/tests/gui_core/test_context_filter.py
+++ b/tests/gui_core/test_context_filter.py
@@ -12,7 +12,7 @@
 import typing as t
 from unittest.mock import Mock, patch
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core import DataNode, Scenario
 from taipy.core.data.pickle import PickleDataNode
 from taipy.gui_core._context import _GuiCoreContext

--- a/tests/gui_core/test_context_is_deletable.py
+++ b/tests/gui_core/test_context_is_deletable.py
@@ -11,7 +11,7 @@
 
 from unittest.mock import Mock, patch
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core import Job, JobId, Scenario, Task
 from taipy.core.data.pickle import PickleDataNode
 from taipy.gui_core._context import _GuiCoreContext

--- a/tests/gui_core/test_context_is_editable.py
+++ b/tests/gui_core/test_context_is_editable.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core import Job, JobId, Scenario, Task
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.pickle import PickleDataNode

--- a/tests/gui_core/test_context_is_promotable.py
+++ b/tests/gui_core/test_context_is_promotable.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core import Job, JobId, Scenario, Task
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.pickle import PickleDataNode

--- a/tests/gui_core/test_context_is_readable.py
+++ b/tests/gui_core/test_context_is_readable.py
@@ -16,9 +16,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.core import Cycle, CycleId, Job, JobId, Scenario, Task
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.pickle import PickleDataNode

--- a/tests/gui_core/test_context_is_submitable.py
+++ b/tests/gui_core/test_context_is_submitable.py
@@ -11,7 +11,7 @@
 
 from unittest.mock import Mock, patch
 
-from taipy.common.config.common.scope import Scope
+from taipy import Scope
 from taipy.core import Job, JobId, Scenario, Task
 from taipy.core.data.pickle import PickleDataNode
 from taipy.core.reason import ReasonCollection

--- a/tests/gui_core/test_context_tabular_data_edit.py
+++ b/tests/gui_core/test_context_tabular_data_edit.py
@@ -13,8 +13,7 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 
-from taipy import DataNode, Gui
-from taipy.common.config.common.scope import Scope
+from taipy import DataNode, Gui, Scope
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.pickle import PickleDataNode
 from taipy.core.reason import Reason, ReasonCollection

--- a/tests/gui_core/test_context_update_data.py
+++ b/tests/gui_core/test_context_update_data.py
@@ -13,8 +13,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from taipy import DataNode, Gui
-from taipy.common.config.common.scope import Scope
+from taipy import DataNode, Gui, Scope
 from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.pickle import PickleDataNode
 from taipy.core.reason import Reason, ReasonCollection

--- a/tests/rest/conftest.py
+++ b/tests/rest/conftest.py
@@ -20,10 +20,10 @@ import pytest
 from dotenv import load_dotenv
 
 from taipy.common.config import Config
-from taipy.common.config.common.frequency import Frequency
-from taipy.common.config.common.scope import Scope
 from taipy.core import Cycle, DataNodeId, Job, JobId, Scenario, Sequence, Task
 from taipy.core._orchestrator._orchestrator_factory import _OrchestratorFactory
+from taipy.core.common.frequency import Frequency
+from taipy.core.common.scope import Scope
 from taipy.core.cycle._cycle_manager import _CycleManager
 from taipy.core.data.pickle import PickleDataNode
 from taipy.core.job._job_manager import _JobManager


### PR DESCRIPTION
### WARNING
Wait for PRs on taipy-enterprise, benchmark, and integration testing before merging.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Implement a mechanism to register the nested classes used by config section attributes that must be serialized and deserialized (Scope and Frequency).

## Related Tickets & Documents

- Related Issue https://github.com/Avaiga/taipy-enterprise/issues/624
- Closes #

## Checklist
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] This solution meets the acceptance criteria of the related issue.
- [x] The related issue checklist is completed.
- [x] This PR adds unit tests for the developed code. If not, why?
- [ ] End-to-End tests have been added or updated. If not, why? 
No need
- [ ] The documentation has been updated, or a dedicated issue created. (If applicable) 
No need as it is transparent for users
- [ ] The release notes have been updated? (If applicable)
No need as it is transparent for users
