### PR TITLE
Refactor - Allow expanding the TYPE_PATTERN by the _BaseSerializer._SERIALIZABLE_TYPES list

### DIFF
--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -111,6 +111,8 @@ def _inject_section(
     configuration_methods: List[tuple],
     add_to_unconflicted_sections: bool = False,
 ):
+    from ._serializer._base_serializer import _BaseSerializer
+
     Config._register_default(default)
 
     if issubclass(section_clazz, UniqueSection):
@@ -125,6 +127,10 @@ def _inject_section(
 
     for exposed_configuration_method, configuration_method in configuration_methods:
         setattr(Config, exposed_configuration_method, configuration_method)
+
+    for type_to_register in section_clazz._types_to_register():
+        if type_to_register._type_identifier() not in _BaseSerializer._SERIALIZABLE_TYPES:
+            _BaseSerializer._SERIALIZABLE_TYPES.append(type_to_register._type_identifier())
 
 
 @_config_doc_for_method

--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -46,7 +46,6 @@ and attributes to configure the Taipy application and retrieve the configuration
 """
 
 import os
-from inspect import signature
 from typing import List
 
 from ._init import Config
@@ -127,10 +126,6 @@ def _inject_section(
 
     for exposed_configuration_method, configuration_method in configuration_methods:
         setattr(Config, exposed_configuration_method, configuration_method)
-
-    for type_to_register in section_clazz._types_to_register():
-        if type_to_register._type_identifier() not in _BaseSerializer._SERIALIZABLE_TYPES:
-            _BaseSerializer._SERIALIZABLE_TYPES.append(type_to_register._type_identifier())
 
 
 @_config_doc_for_method

--- a/taipy/common/config/__init__.py
+++ b/taipy/common/config/__init__.py
@@ -54,7 +54,7 @@ from .section import Section
 from .unique_section import UniqueSection
 
 
-def __write_method_to_doc(configuration_methods):
+def __write_method_to_doc(configuration_methods):  # pragma: no cover
     if os.environ.get("GENERATING_TAIPY_DOC", None) and os.environ["GENERATING_TAIPY_DOC"] == "true":
         with open("config_doc.txt", "a") as f:
             from inspect import signature
@@ -68,7 +68,7 @@ def __write_method_to_doc(configuration_methods):
                 f.write(annotation + sign + doc + content)
 
 
-def __write_section_to_doc(section, attr_name):
+def __write_section_to_doc(section, attr_name):  # pragma: no cover
     if os.environ.get("GENERATING_TAIPY_DOC", None) and os.environ["GENERATING_TAIPY_DOC"] == "true":
         with open("config_doc.txt", "a") as f:
             # Add the documentation for the attribute
@@ -85,7 +85,7 @@ def __write_section_to_doc(section, attr_name):
             f.write(annotation + sign + doc + content)
 
 
-def _config_doc_for_section(func):
+def _config_doc_for_section(func):  # pragma: no cover
     def func_with_doc(section, attribute_name, default, configuration_methods, add_to_unconflicted_sections=False):
         __write_section_to_doc(section, attribute_name)
         __write_method_to_doc(configuration_methods)
@@ -94,7 +94,7 @@ def _config_doc_for_section(func):
     return func_with_doc
 
 
-def _config_doc_for_method(func):
+def _config_doc_for_method(func):  # pragma: no cover
     def func_with_doc(configuration_methods):
         __write_method_to_doc(configuration_methods)
         return func(configuration_methods)

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -29,6 +29,19 @@ class _BaseSerializer(object):
     """Base serializer class for taipy configuration."""
 
     _GLOBAL_NODE_NAME = "TAIPY"
+    _SERIALIZABLE_TYPES = [
+        "bool",
+        "str",
+        "int",
+        "float",
+        "datetime",
+        "timedelta",
+        "function",
+        "class",
+        "SCOPE",
+        "FREQUENCY",
+        "SECTION",
+    ]
     _section_class = {_GLOBAL_NODE_NAME: GlobalAppConfig}
     _registered_types: Dict[str, type] = {}
 
@@ -66,7 +79,7 @@ class _BaseSerializer(object):
     def __stringify(cls, as_dict):
         if as_dict is None:
             return None
-        if hasattr(as_dict, '_stringify') and callable(as_dict._stringify):
+        if hasattr(as_dict, "_stringify") and callable(as_dict._stringify):
             return as_dict._stringify()
         if isinstance(as_dict, bool):
             return f"{str(as_dict)}:bool"
@@ -119,10 +132,7 @@ class _BaseSerializer(object):
         match = re.fullmatch(_TemplateHandler._PATTERN, str(val))
         if not match:
             if isinstance(val, str):
-                TYPE_PATTERN = (
-                    r"^(.+):(\bbool\b|\bstr\b|\bint\b|\bfloat\b|\bdatetime\b||\btimedelta\b|"
-                    r"\bfunction\b|\bclass\b|\bSCOPE\b|\bFREQUENCY\b|\bSECTION\b)?$"
-                )
+                TYPE_PATTERN = r"^(.+):(" + r"\b|\b".join(cls._SERIALIZABLE_TYPES) + r")?$"
                 if match := re.fullmatch(TYPE_PATTERN, str(val)):
                     actual_val = match.group(1)
                     dynamic_type = match.group(2)

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -38,8 +38,6 @@ class _BaseSerializer(object):
         "timedelta",
         "function",
         "class",
-        "SCOPE",
-        "FREQUENCY",
         "SECTION",
     ]
     _section_class = {_GLOBAL_NODE_NAME: GlobalAppConfig}

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -130,7 +130,7 @@ class _BaseSerializer(object):
         match = re.fullmatch(_TemplateHandler._PATTERN, str(val))
         if not match:
             if isinstance(val, str):
-                TYPE_PATTERN = r"^(.+):(" + r"\b|\b".join(cls._SERIALIZABLE_TYPES) + r")?$"
+                TYPE_PATTERN = r"^(.+):(\b" + r"\b|\b".join(cls._SERIALIZABLE_TYPES) + r"\b)?$"
                 if match := re.fullmatch(TYPE_PATTERN, str(val)):
                     actual_val = match.group(1)
                     dynamic_type = match.group(2)

--- a/taipy/common/config/_serializer/_base_serializer.py
+++ b/taipy/common/config/_serializer/_base_serializer.py
@@ -55,6 +55,9 @@ class _BaseSerializer(object):
                 raise InvalidConfigurationType(f"Type {clazz.__name__} must have a `_pythonify` method.")
             cls._registered_types[clazz._type_identifier()] = clazz
 
+            if clazz._type_identifier() not in cls._SERIALIZABLE_TYPES:
+                cls._SERIALIZABLE_TYPES.append(clazz._type_identifier())
+
     @classmethod
     @abstractmethod
     def _write(cls, configuration: _Config, filename: str):

--- a/tests/common/config/test_inject_section.py
+++ b/tests/common/config/test_inject_section.py
@@ -1,0 +1,30 @@
+# Copyright 2021-2025 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from taipy.common.config import Config, _inject_section
+from taipy.common.config._serializer._base_serializer import _BaseSerializer
+from tests.common.config.utils.section_for_tests import SectionForTest
+from tests.common.config.utils.serializable_object_for_test import SerializableObjectForTest
+
+
+def test_inject_section():
+    assert not hasattr(Config, "sectionfortest")
+    assert SerializableObjectForTest._type_identifier() not in _BaseSerializer._SERIALIZABLE_TYPES
+
+    _inject_section(
+        SectionForTest,
+        "sectionfortest",
+        SectionForTest("default"),
+        [("configure_scenario", SectionForTest._configure)],
+    )
+
+    assert hasattr(Config, "sectionfortest")
+    assert SerializableObjectForTest._type_identifier() in _BaseSerializer._SERIALIZABLE_TYPES

--- a/tests/common/config/test_inject_section.py
+++ b/tests/common/config/test_inject_section.py
@@ -9,10 +9,19 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import pytest
+
 from taipy.common.config import Config, _inject_section
 from taipy.common.config._serializer._base_serializer import _BaseSerializer
 from tests.common.config.utils.section_for_tests import SectionForTest
 from tests.common.config.utils.serializable_object_for_test import SerializableObjectForTest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset(reset_configuration_singleton):
+    reset_configuration_singleton()
+
+    yield
 
 
 def test_inject_section():

--- a/tests/common/config/test_section_serialization.py
+++ b/tests/common/config/test_section_serialization.py
@@ -16,8 +16,6 @@ from unittest import mock
 
 from taipy.common.config import Config
 from taipy.common.config._serializer._json_serializer import _JsonSerializer
-from taipy.core.common.frequency import Frequency
-from taipy.core.common.scope import Scope
 from tests.common.config.utils.named_temporary_file import NamedTemporaryFile
 from tests.common.config.utils.section_for_tests import SectionForTest
 from tests.common.config.utils.unique_section_for_tests import UniqueSectionForTest
@@ -62,8 +60,6 @@ prop = "my_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
 prop_list = [ "p1", "1991-01-01T00:00:00:datetime", "1d0h0m0s:timedelta",]
-prop_scope = "SCENARIO:SCOPE"
-prop_freq = "QUARTERLY:FREQUENCY"
 baz = "ENV[QUX]"
 quux = "ENV[QUUZ]:bool"
 corge = [ "grault", "ENV[GARPLY]", "ENV[WALDO]:int", "3.0:float",]
@@ -79,7 +75,6 @@ prop = "default_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
 prop_list = [ "unique_section_name:SECTION",]
-prop_scope = "SCENARIO"
 baz = "ENV[QUX]"
     """.strip()
     tf = NamedTemporaryFile()
@@ -92,8 +87,6 @@ baz = "ENV[QUX]"
             prop_int=1,
             prop_bool=False,
             prop_list=["p1", datetime.datetime(1991, 1, 1), datetime.timedelta(days=1)],
-            prop_scope=Scope.SCENARIO,
-            prop_freq=Frequency.QUARTERLY,
             baz="ENV[QUX]",
             quux="ENV[QUUZ]:bool",
             corge=("grault", "ENV[GARPLY]", "ENV[WALDO]:int", 3.0),
@@ -104,7 +97,6 @@ baz = "ENV[QUX]"
             prop_int=1,
             prop_bool=False,
             prop_list=[unique_section],
-            prop_scope="SCENARIO",
             baz="ENV[QUX]",
         )
 
@@ -124,8 +116,6 @@ prop = "my_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
 prop_list = [ "p1", "1991-01-01T00:00:00:datetime", "1d0h0m0s:timedelta",]
-prop_scope = "SCENARIO:SCOPE"
-prop_freq = "QUARTERLY:FREQUENCY"
 baz = "ENV[QUX]"
 quux = "ENV[QUUZ]:bool"
 corge = [ "grault", "ENV[GARPLY]", "ENV[WALDO]:int", "3.0:float",]
@@ -144,7 +134,6 @@ prop = "default_prop"
 prop_int = "1:int"
 prop_bool = "False:bool"
 prop_list = [ "unique_section_name", "section_name.my_id",]
-prop_scope = "SCENARIO:SCOPE"
 baz = "ENV[QUX]"
     """.strip()
     tf = NamedTemporaryFile(toml_config)
@@ -167,8 +156,6 @@ baz = "ENV[QUX]"
             datetime.datetime(1991, 1, 1),
             datetime.timedelta(days=1),
         ]
-        assert Config.unique_sections[UniqueSectionForTest.name].prop_scope == Scope.SCENARIO
-        assert Config.unique_sections[UniqueSectionForTest.name].prop_freq == Frequency.QUARTERLY
         assert Config.unique_sections[UniqueSectionForTest.name].baz == "qux"
         assert Config.unique_sections[UniqueSectionForTest.name].quux is True
         assert Config.unique_sections[UniqueSectionForTest.name].corge == [
@@ -192,7 +179,6 @@ baz = "ENV[QUX]"
         assert Config.sections[SectionForTest.name]["my_id"].prop_int == 1
         assert Config.sections[SectionForTest.name]["my_id"].prop_bool is False
         assert Config.sections[SectionForTest.name]["my_id"].prop_list == ["unique_section_name", "section_name.my_id"]
-        assert Config.sections[SectionForTest.name]["my_id"].prop_scope == Scope.SCENARIO
         assert Config.sections[SectionForTest.name]["my_id"].baz == "qux"
 
         tf2 = NamedTemporaryFile()
@@ -274,9 +260,7 @@ def test_write_json_configuration_file():
 "p1",
 "1991-01-01T00:00:00:datetime",
 "1d0h0m0s:timedelta"
-],
-"prop_scope": "SCENARIO:SCOPE",
-"prop_freq": "QUARTERLY:FREQUENCY"
+]
 },
 "section_name": {
 "default": {
@@ -292,7 +276,6 @@ def test_write_json_configuration_file():
 "prop_list": [
 "unique_section_name:SECTION"
 ],
-"prop_scope": "SCENARIO",
 "baz": "ENV[QUX]"
 }
 }
@@ -307,8 +290,6 @@ def test_write_json_configuration_file():
         prop_int=1,
         prop_bool=False,
         prop_list=["p1", datetime.datetime(1991, 1, 1), datetime.timedelta(days=1)],
-        prop_scope=Scope.SCENARIO,
-        prop_freq=Frequency.QUARTERLY,
     )
     Config.configure_section_for_tests(
         "my_id",
@@ -316,7 +297,6 @@ def test_write_json_configuration_file():
         prop_int=1,
         prop_bool=False,
         prop_list=[unique_section],
-        prop_scope="SCENARIO",
         baz="ENV[QUX]",
     )
     Config.backup(tf.filename)
@@ -341,9 +321,7 @@ def test_read_json_configuration_file():
 "p1",
 "1991-01-01T00:00:00:datetime",
 "1d0h0m0s:timedelta"
-],
-"prop_scope": "SCENARIO:SCOPE",
-"prop_freq": "QUARTERLY:FREQUENCY"
+]
 },
 "section_name": {
 "default": {
@@ -358,8 +336,7 @@ def test_read_json_configuration_file():
 "prop_bool": "False:bool",
 "prop_list": [
 "unique_section_name"
-],
-"prop_scope": "SCENARIO"
+]
 }
 }
 }
@@ -380,8 +357,6 @@ def test_read_json_configuration_file():
         datetime.datetime(1991, 1, 1),
         datetime.timedelta(days=1),
     ]
-    assert Config.unique_sections[UniqueSectionForTest.name].prop_scope == Scope.SCENARIO
-    assert Config.unique_sections[UniqueSectionForTest.name].prop_freq == Frequency.QUARTERLY
 
     assert Config.sections is not None
     assert len(Config.sections) == 1

--- a/tests/common/config/utils/section_for_tests.py
+++ b/tests/common/config/utils/section_for_tests.py
@@ -10,11 +10,12 @@
 # specific language governing permissions and limitations under the License.
 
 from copy import copy
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from taipy.common.config import Config, Section
 from taipy.common.config._config import _Config
 from taipy.common.config.common._config_blocker import _ConfigBlocker
+from tests.common.config.utils.serializable_object_for_test import SerializableObjectForTest
 
 
 class SectionForTest(Section):
@@ -61,6 +62,10 @@ class SectionForTest(Section):
         self._properties.update(as_dict)
         if default_section:
             self._properties = {**default_section.properties, **self._properties}
+
+    @staticmethod
+    def _types_to_register() -> List[type]:
+        return [SerializableObjectForTest]
 
     @staticmethod
     def _configure(id: str, attribute: str, **properties):

--- a/tests/common/config/utils/serializable_object_for_test.py
+++ b/tests/common/config/utils/serializable_object_for_test.py
@@ -1,0 +1,28 @@
+# Copyright 2021-2025 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from taipy.common._repr_enum import _OrderedEnum
+
+
+class SerializableObjectForTest(_OrderedEnum):
+    FOO = 1
+    BAR = 2
+
+    @staticmethod
+    def _type_identifier() -> str:
+        return "SERIALIZABLE_OBJECT_FOR_TEST"
+
+    def _stringify(self) -> str:
+        return f"{self.name}:{self._type_identifier()}"
+
+    @classmethod
+    def _pythonify(cls, value: str):
+        return SerializableObjectForTest[str.upper(value)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from taipy.common._cli._base_cli._taipy_parser import _TaipyParser
 from taipy.common.config import Config, _inject_section
 from taipy.common.config._config import _Config
 from taipy.common.config._config_comparator._config_comparator import _ConfigComparator
+from taipy.common.config._serializer._base_serializer import _BaseSerializer
 from taipy.common.config._serializer._toml_serializer import _TomlSerializer
 from taipy.common.config.checker._checker import _Checker
 from taipy.common.config.checker.issue_collector import IssueCollector
@@ -57,6 +58,7 @@ def remove_subparser(name: str) -> None:
 @pytest.fixture
 def clean_argparser() -> t.Callable:
     """Fixture to clean the argument parser."""
+
     def _clean_argparser() -> None:
         _TaipyParser._parser = argparse.ArgumentParser(conflict_handler="resolve")
         _TaipyParser._subparser_action = None
@@ -71,6 +73,7 @@ def clean_argparser() -> t.Callable:
 @pytest.fixture
 def reset_configuration_singleton() -> t.Callable:
     """Fixture to reset the configuration singleton."""
+
     def _reset_configuration_singleton() -> None:
         Config.unblock_update()
 
@@ -82,6 +85,17 @@ def reset_configuration_singleton() -> t.Callable:
         Config._collector = IssueCollector()
         Config._serializer = _TomlSerializer()
         Config._comparator = _ConfigComparator()
+        _BaseSerializer._SERIALIZABLE_TYPES = [
+            "bool",
+            "str",
+            "int",
+            "float",
+            "datetime",
+            "timedelta",
+            "function",
+            "class",
+            "SECTION",
+        ]
         _Checker._checkers = []
 
     return _reset_configuration_singleton
@@ -90,6 +104,7 @@ def reset_configuration_singleton() -> t.Callable:
 @pytest.fixture
 def inject_core_sections() -> t.Callable:
     """Fixture to inject core sections into the configuration."""
+
     def _inject_core_sections() -> None:
         _inject_section(
             JobConfig,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description

This PR creates the `_BaseSerializer._SERIALIZABLE_TYPES` to allow expanding the serializable types when stringify and pythonify the Config.
