### PR TITLE
support html tag in markdown line

### DIFF
--- a/taipy/gui/_renderers/_markdown/preproc.py
+++ b/taipy/gui/_renderers/_markdown/preproc.py
@@ -61,7 +61,7 @@ class _Preprocessor(MdPreprocessor):
     __PROPERTY_RE = re.compile(r"((?:don'?t|not?)\s+)?([a-zA-Z][\.a-zA-Z_$0-9]*(?:\[(?:.*?)\])?)\s*(?:=(.*))?$")
 
     # Error syntax detection regex
-    __MISSING_LEADING_PIPE_RE = re.compile(r"^<[^|](.*?)\|>")
+    __MISSING_LEADING_PIPE_RE = re.compile(r"^<[^|]([^>]*?)\|>")
 
     _gui: "Gui"
 

--- a/tests/gui/renderers/test_md_parsing.py
+++ b/tests/gui/renderers/test_md_parsing.py
@@ -52,3 +52,9 @@ def test_md_link(gui: Gui, helpers):
     md_string = "[content](link)"
     expected_list = ["<a", 'href="link"', "content</a>"]
     helpers.test_control_md(gui, md_string, expected_list)
+
+
+def test_html_in_md(gui: Gui, helpers):
+    md_string = "<center> <|Hello|text|> </center>"
+    expected_list = ["<center>", "<div", "Hello", "</div>", "</center>"]
+    helpers.test_control_md(gui, md_string, expected_list)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
support html tag in markdown line

## Related Tickets & Documents
- Closes #2126 

## How to reproduce the issue
```py
from taipy.gui import Gui

md = """
<center> <|Hello|text|> </center>
"""

Gui(md).run(title="2126 Center Markdown")

```

## Other branches or releases that this needs to be backported
4.0 ?
