### PR TITLE
cycle datanode in viewer

### DIFF
--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -711,9 +711,17 @@ class _GuiCoreContext(CoreEventConsumerBase):
             self.__do_datanodes_tree()
         if datanodes is None:
             if scenarios is None:
-                base_list = (self.data_nodes_by_owner or {}).get(None, []) + (
-                    self.get_scenarios(None, None, None) or []
-                )
+                tree: t.List[t.Union[Cycle, Scenario]] = []
+                with self.lock:
+                    # always needed to get scenarios for a cycle in cycle_adapter
+                    if self.scenario_by_cycle is None:
+                        self.scenario_by_cycle = get_cycles_scenarios()
+                    for cycle, c_scenarios in self.scenario_by_cycle.items():
+                        if cycle is None:
+                            tree.extend(c_scenarios)
+                        else:
+                            tree.append(cycle)
+                base_list = (self.data_nodes_by_owner or {}).get(None, []) + tree
             else:
                 if isinstance(scenarios, (list, tuple)) and len(scenarios) > 1:
                     base_list = list(scenarios)

--- a/taipy/gui_core/_context.py
+++ b/taipy/gui_core/_context.py
@@ -732,7 +732,7 @@ class _GuiCoreContext(CoreEventConsumerBase):
                     else:
                         base_list = []
         else:
-            base_list = datanodes
+            base_list = t.cast(list, datanodes)
         adapted_list = self.get_sorted_datanode_list(t.cast(list, base_list), sorts)
         return self.get_filtered_datanode_list(t.cast(list, adapted_list), filters)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Show cycle datanodes in datanode selector (only on 4.0.x)

## Related Tickets & Documents
- Closes #2470 

## How to reproduce the issue

```py
import taipy as tp
import taipy.gui.builder as tgb
from taipy import Config, Frequency, Gui, Scope


def add_three(a, b, c):
    return a + b + c


a_node_config = Config.configure_data_node(id="a", default_data=1, scope=Scope.GLOBAL)

b_node_config = Config.configure_data_node(id="b", default_data=2, scope=Scope.CYCLE)

c_node_config = Config.configure_data_node(id="c", default_data=3, scope=Scope.SCENARIO)

result_node_config = Config.configure_data_node(id="result", scope=Scope.SCENARIO)

add_three_scenario_task = Config.configure_task(
    id="add_three",
    function=add_three,
    input=[a_node_config, b_node_config, c_node_config],
    output=result_node_config,
)


add_three_scenario_config = Config.configure_scenario(
    id="scenario",
    task_configs=add_three_scenario_task,
    frequency=Frequency.MONTHLY,
)


with tgb.Page() as page:
    tgb.text("# Data Node selector does not show Cycle Data Nodes", mode="md")

    tgb.data_node_selector()

if __name__ == "__main__":
    tp.Orchestrator().run()
    scenario = tp.create_scenario(add_three_scenario_config)

    scenario.submit()

    gui = Gui(page=page)
    gui.run(title="2470 test data node selector")
```

## Other branches or releases that this needs to be backported
only 4.0
