### PR TITLE
lighten warnings

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1655,10 +1655,10 @@ class Gui:
                 except Exception:
                     args = [id, payload]
                 self._call_function_with_state(t.cast(t.Callable, action_function), args)
-                return True
             except Exception as e:  # pragma: no cover
                 if not self._call_on_exception(action_function, e):
                     _warn(f"on_action(): Exception raised in '{_function_name(action_function)}()'", e)
+            return True
         return False
 
     def _call_function_with_state(self, user_function: t.Callable, args: t.Optional[t.List[t.Any]] = None) -> t.Any:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
less warnings is good warnings

## Related Tickets & Documents
- Closes #2481 

## How to reproduce the issue
```py
import warnings

import taipy.gui.builder as tgb
from taipy.gui import Gui

warnings.simplefilter('always', UserWarning) # force python to show every warnings

def button1_pressed(state):
    print("Raise an exception btn 1...")
    raise Exception("Button pressed exception")


def button2_pressed(state):
    print("Raise an exception btn 2...")
    raise Exception("Button pressed exception")



# def on_exception(state, function_name: str, exception):
#     print(f"Exception in {function_name}: {exception}")
#     traceback.print_exc()


with tgb.Page() as page:
    tgb.button("1. Click me", on_action=button1_pressed)
    tgb.button("2. Click me", on_action=button2_pressed)

if __name__ == "__main__":
    gui = Gui(page=page)
    gui.run(title="2481 Exception reporting", debug=True)

```
