### PR TITLE
Feature/#2292 allow menu to be expanded by default (Redo)

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Menu.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Menu.spec.tsx
@@ -86,14 +86,14 @@ describe("Menu Component", () => {
         });
     });
 
-    it("starts folded unless 'unfolded' is true", () => {
+    it("starts folded unless 'expanded' is true", () => {
         const improbable_width = "277px";
         const { rerender, container } = render(
             <Menu label="Test Menu" lov={lov} width={improbable_width} />
         );
         const drawer = container.querySelector(".MuiDrawer-root");
         expect(drawer).toHaveStyle(`width: calc(72px + 1px)`); 
-        rerender(<Menu label="Test Menu" unfolded={true} lov={lov} width={improbable_width} />);
+        rerender(<Menu label="Test Menu" expanded={true} lov={lov} width={improbable_width} />);
         expect(drawer).toHaveStyle(`width: ${improbable_width}`);
     });
 

--- a/frontend/taipy-gui/src/components/Taipy/Menu.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Menu.spec.tsx
@@ -17,7 +17,7 @@ const lov: LovItem[] = [
 
 const imageItem: LovItem = { id: "ii1", item: { path: "/img/fred.png", text: "Image" } };
 
-describe("Menu Component", () => {
+describe("Menu Component", () => {   
     it("renders", async () => {
         const { getByText } = render(<Menu lov={lov} />);
         const elt = getByText("Item 1");
@@ -85,4 +85,16 @@ describe("Menu Component", () => {
             type: "SEND_ACTION_ACTION",
         });
     });
+
+    it("starts folded unless 'unfolded' is true", () => {
+        const improbable_width = "277px";
+        const { rerender, container } = render(
+            <Menu label="Test Menu" lov={lov} width={improbable_width} />
+        );
+        const drawer = container.querySelector(".MuiDrawer-root");
+        expect(drawer).toHaveStyle(`width: calc(72px + 1px)`); 
+        rerender(<Menu label="Test Menu" unfolded={true} lov={lov} width={improbable_width} />);
+        expect(drawer).toHaveStyle(`width: ${improbable_width}`);
+    });
+
 });

--- a/frontend/taipy-gui/src/components/Taipy/Menu.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Menu.tsx
@@ -36,12 +36,12 @@ const avatarSx = { bgcolor: (theme: Theme) => theme.palette.text.primary };
 const baseTitleProps = { noWrap: true, variant: "h6" } as const;
 
 const Menu = (props: MenuProps) => {
-    const { label, onAction = "", lov, width, inactiveIds = emptyArray, active = true, unfolded = false } = props;
+    const { label, onAction = "", lov, width, inactiveIds = emptyArray, active = true, expanded = false } = props;
     const [selectedValue, setSelectedValue] = useState<string>("");
-    const [opened, setOpened] = useState(unfolded);
+    const [opened, setOpened] = useState(expanded);
     useEffect(() => { 
-        setOpened(unfolded); 
-    }, [unfolded]);
+        setOpened(expanded); 
+    }, [expanded]);
     const dispatch = useDispatch();
     const theme = useTheme();
     const module = useModule();

--- a/frontend/taipy-gui/src/components/Taipy/Menu.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Menu.tsx
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import React, { useCallback, useMemo, useState, MouseEvent, CSSProperties } from "react";
+import React, { useCallback, useMemo, useState, MouseEvent, CSSProperties,useEffect } from "react";
 import MenuIco from "@mui/icons-material/Menu";
 import ListItemButton from "@mui/material/ListItemButton";
 import Drawer from "@mui/material/Drawer";
@@ -36,9 +36,12 @@ const avatarSx = { bgcolor: (theme: Theme) => theme.palette.text.primary };
 const baseTitleProps = { noWrap: true, variant: "h6" } as const;
 
 const Menu = (props: MenuProps) => {
-    const { label, onAction = "", lov, width, inactiveIds = emptyArray, active = true } = props;
+    const { label, onAction = "", lov, width, inactiveIds = emptyArray, active = true, unfolded = false } = props;
     const [selectedValue, setSelectedValue] = useState<string>("");
-    const [opened, setOpened] = useState(false);
+    const [opened, setOpened] = useState(unfolded);
+    useEffect(() => { 
+        setOpened(unfolded); 
+    }, [unfolded]);
     const dispatch = useDispatch();
     const theme = useTheme();
     const module = useModule();

--- a/frontend/taipy-gui/src/components/Taipy/MenuCtl.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/MenuCtl.tsx
@@ -34,11 +34,11 @@ interface MenuCtlProps extends LovProps<string> {
     defaultInactiveIds?: string;
     selected?: string[];
     defaultSelected?: string;
-    unfolded?: boolean;
+    expanded?: boolean;
 }
 
 const MenuCtl = (props: MenuCtlProps) => {
-    const {id, label, onAction, defaultLov = "", width = "15vw", width_Mobile_ = "85vw",unfolded} = props;
+    const {id, label, onAction, defaultLov = "", width = "15vw", width_Mobile_ = "85vw",expanded} = props;
     const dispatch = useDispatch();
     const isMobile = useIsMobile();
     const module = useModule();
@@ -87,11 +87,11 @@ const MenuCtl = (props: MenuCtlProps) => {
                 width: isMobile ? width_Mobile_ : width,
                 className: className,
                 selected: selected,
-                unfolded: unfolded,
+                expanded: expanded,
             } as MenuProps)
         );
         return () => dispatch(createSetMenuAction({}));
-    }, [label, onAction, active, lovList, inactiveIds, width, width_Mobile_, isMobile, className, dispatch, selected,unfolded]);
+    }, [label, onAction, active, lovList, inactiveIds, width, width_Mobile_, isMobile, className, dispatch, selected,expanded]);
 
     return <></>;
 };

--- a/frontend/taipy-gui/src/components/Taipy/MenuCtl.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/MenuCtl.tsx
@@ -34,10 +34,11 @@ interface MenuCtlProps extends LovProps<string> {
     defaultInactiveIds?: string;
     selected?: string[];
     defaultSelected?: string;
+    unfolded?: boolean;
 }
 
 const MenuCtl = (props: MenuCtlProps) => {
-    const {id, label, onAction, defaultLov = "", width = "15vw", width_Mobile_ = "85vw"} = props;
+    const {id, label, onAction, defaultLov = "", width = "15vw", width_Mobile_ = "85vw",unfolded} = props;
     const dispatch = useDispatch();
     const isMobile = useIsMobile();
     const module = useModule();
@@ -86,10 +87,11 @@ const MenuCtl = (props: MenuCtlProps) => {
                 width: isMobile ? width_Mobile_ : width,
                 className: className,
                 selected: selected,
+                unfolded: unfolded,
             } as MenuProps)
         );
         return () => dispatch(createSetMenuAction({}));
-    }, [label, onAction, active, lovList, inactiveIds, width, width_Mobile_, isMobile, className, dispatch, selected]);
+    }, [label, onAction, active, lovList, inactiveIds, width, width_Mobile_, isMobile, className, dispatch, selected,unfolded]);
 
     return <></>;
 };

--- a/frontend/taipy-gui/src/utils/lov.ts
+++ b/frontend/taipy-gui/src/utils/lov.ts
@@ -34,5 +34,5 @@ export interface MenuProps extends TaipyBaseProps {
     lov?: LovItem[];
     active?: boolean;
     selected?: string[];
-    unfolded?: boolean;
+    expanded?: boolean;
 }

--- a/frontend/taipy-gui/src/utils/lov.ts
+++ b/frontend/taipy-gui/src/utils/lov.ts
@@ -34,4 +34,5 @@ export interface MenuProps extends TaipyBaseProps {
     lov?: LovItem[];
     active?: boolean;
     selected?: string[];
+    unfolded?: boolean;
 }

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -371,7 +371,7 @@ class _Factory:
                 ("hover_text", PropertyType.dynamic_string),
                 ("width",),
                 ("width[mobile]",),
-                ("unfolded",PropertyType.boolean, False),
+                ("expanded",PropertyType.boolean, False),
             ]
         )
         ._set_propagate(),

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -371,6 +371,7 @@ class _Factory:
                 ("hover_text", PropertyType.dynamic_string),
                 ("width",),
                 ("width[mobile]",),
+                ("unfolded",PropertyType.boolean, False),
             ]
         )
         ._set_propagate(),

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1648,10 +1648,10 @@
                         "doc": "The width of the menu when unfolded, in CSS units, when running on a mobile device."
                     },
                     {
-                        "name": "unfolded",
+                        "name": "expanded",
                         "type":"bool",
                         "default_value":"False",
-                        "doc": "Defines whether the menu starts unfolded or folded"
+                        "doc": "Defines whether the menu starts expanded or folded"
                     }
                 ]
             }

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1646,6 +1646,12 @@
                         "type": "str",
                         "default_value": "\"85vw\"",
                         "doc": "The width of the menu when unfolded, in CSS units, when running on a mobile device."
+                    },
+                    {
+                        "name": "unfolded",
+                        "type":"bool",
+                        "default_value":"False",
+                        "doc": "Defines whether the menu starts unfolded or folded"
                     }
                 ]
             }


### PR DESCRIPTION
## What type of PR is this?

- [X] Feature

## Description
I added the "expanded" parameter to the Menu component. It is a boolean that, when set to true, causes the menu to start off expanded.

![Screenshot 2025-03-21 160053](https://github.com/user-attachments/assets/08ce76b4-9386-4425-99ca-c6d39367777e)

 Default value is false, which starts the menu folded.

![Screenshot 2025-03-21 160025](https://github.com/user-attachments/assets/def2cdcf-d9e3-46f1-9c93-b403da503c82)

## Related Tickets & Documents

- Related Issue #2292
- Closes #2292

## Feature description

Running this code will generate a folded menu:


from taipy.gui import Gui
import taipy.gui.builder as tgb

options = [("a", "Option A"), ("b", "Option B"), ("c", "Option C"), ("d", "Option D")]


with tgb.Page() as page:
   tgb.menu(label = "options",
            lov = options,
)


if __name__ == "__main__":
    Gui(page).run(title="Menu - Selected")

By setting the "expanded" property to "True", the menu will start expanded:

[...]

with tgb.Page() as page:
   tgb.menu(label = "options",
            lov = options,
            expanded = True,
)

[...]

## Checklist

- [X] This solution meets the acceptance criteria of the related issue.
- [X] This PR adds unit tests for the developed code. 

(This is an updated version of another fork by the same name)

