### PR TITLE
Refactor: route DataNode.read() and write() to _DataNodeManager

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -38,6 +38,7 @@ charset-normalizer = "==3.3.2"
 numpy = "<2.0.0"
 
 [dev-packages]
+fastparquet = "*"
 freezegun = "*"
 ipython = "*"
 ipykernel = "*"

--- a/taipy/core/_orchestrator/_dispatcher/_task_function_wrapper.py
+++ b/taipy/core/_orchestrator/_dispatcher/_task_function_wrapper.py
@@ -54,7 +54,7 @@ class _TaskFunctionWrapper:
 
     def _read_inputs(self, inputs: List[DataNode]) -> List[Any]:
         data_manager = _DataManagerFactory._build_manager()
-        return [data_manager._get(dn.id).read_or_raise() for dn in inputs]
+        return [data_manager._read(data_manager._get(dn.id)) for dn in inputs]
 
     def _write_data(self, outputs: List[DataNode], results, job_id: JobId):
         data_manager = _DataManagerFactory._build_manager()

--- a/taipy/core/data/_data_manager.py
+++ b/taipy/core/data/_data_manager.py
@@ -10,10 +10,11 @@
 # specific language governing permissions and limitations under the License.
 
 import os
-from typing import Dict, Iterable, List, Optional, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 from taipy.common.config import Config
 from taipy.common.config._config import _Config
+from taipy.core.job.job_id import JobId
 
 from .._manager._manager import _Manager
 from .._repository._abstract_repository import _AbstractRepository
@@ -21,7 +22,7 @@ from .._version._version_mixin import _VersionMixin
 from ..common.scope import Scope
 from ..config.data_node_config import DataNodeConfig
 from ..cycle.cycle_id import CycleId
-from ..exceptions.exceptions import InvalidDataNodeType
+from ..exceptions.exceptions import InvalidDataNodeType, NoData
 from ..notification import Event, EventEntityType, EventOperation, Notifier, _make_event
 from ..reason import EntityDoesNotExist, NotGlobalScope, ReasonCollection, WrongConfigType
 from ..reason.reason import DataIsNotDuplicable
@@ -124,6 +125,45 @@ class _DataManager(_Manager[DataNode], _VersionMixin):
         """
         filters = cls._build_filters_with_version(version_number)
         return cls._repository._load_all(filters)
+
+    @classmethod
+    def _read(cls, data_node: DataNode) -> Any:
+        """Read the data referenced by this data node.
+
+        Returns:
+            The data referenced by this data node.
+
+        Raises:
+            NoData^: If the data has not been written yet.
+        """
+        if not data_node.last_edit_date:
+            raise NoData(f"Data node {data_node.id} from config {data_node.config_id} has not been written yet.")
+
+        return data_node._read()
+
+    @classmethod
+    def _append(
+        cls, data_node: DataNode, data, editor_id: Optional[str] = None, comment: Optional[str] = None, **kwargs: Any
+    ):
+        data_node._append(data)
+        data_node.track_edit(editor_id=editor_id, comment=comment, **kwargs)
+        data_node.unlock_edit()
+        cls._update(data_node)
+
+    @classmethod
+    def _write(
+        cls,
+        data_node: DataNode,
+        data,
+        job_id: Optional[JobId] = None,
+        editor_id: Optional[str] = None,
+        comment: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        data_node._write(data)
+        data_node.track_edit(job_id=job_id, editor_id=editor_id, comment=comment, **kwargs)
+        data_node.unlock_edit()
+        cls._update(data_node)
 
     @classmethod
     def _clean_generated_file(cls, data_node: DataNode) -> None:

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -395,27 +395,16 @@ class DataNode(_Entity, _Labeled):
         """
         raise NotImplementedError
 
-    def read_or_raise(self) -> Any:
-        """Read the data referenced by this data node.
-
-        Returns:
-            The data referenced by this data node.
-
-        Raises:
-            NoData^: If the data has not been written yet.
-        """
-        if not self.last_edit_date:
-            raise NoData(f"Data node {self.id} from config {self.config_id} has not been written yet.")
-        return self._read()
-
     def read(self) -> Any:
         """Read the data referenced by this data node.
 
         Returns:
             The data referenced by this data node. None if the data has not been written yet.
         """
+        from ._data_manager_factory import _DataManagerFactory
+
         try:
-            return self.read_or_raise()
+            return _DataManagerFactory._build_manager()._read(self)
         except NoData:
             self._logger.warning(
                 f"Data node {self.id} from config {self.config_id} is being read but has never been written."
@@ -432,8 +421,6 @@ class DataNode(_Entity, _Labeled):
             **kwargs (Any): Extra information to attach to the edit document
                 corresponding to this write.
         """
-        from ._data_manager_factory import _DataManagerFactory
-
         if (
             editor_id
             and self.edit_in_progress
@@ -441,10 +428,10 @@ class DataNode(_Entity, _Labeled):
             and (not self.editor_expiration_date or self.editor_expiration_date > datetime.now())
         ):
             raise DataNodeIsBeingEdited(self.id, self.editor_id)
-        self._append(data)
-        self.track_edit(editor_id=editor_id, comment=comment, **kwargs)
-        self.unlock_edit()
-        _DataManagerFactory._build_manager()._update(self)
+
+        from ._data_manager_factory import _DataManagerFactory
+
+        _DataManagerFactory._build_manager()._append(self, data, editor_id, comment, **kwargs)
 
     def write(
         self,
@@ -473,12 +460,10 @@ class DataNode(_Entity, _Labeled):
             and (not self.editor_expiration_date or self.editor_expiration_date > datetime.now())
         ):
             raise DataNodeIsBeingEdited(self.id, self.editor_id)
-        self._write(data)
-        self.track_edit(job_id=job_id, editor_id=editor_id, comment=comment, **kwargs)
-        self.unlock_edit()
+
         from ._data_manager_factory import _DataManagerFactory
 
-        _DataManagerFactory._build_manager()._update(self)
+        _DataManagerFactory._build_manager()._write(self, data, job_id, editor_id, comment, **kwargs)
 
     def track_edit(
         self,

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -395,6 +395,19 @@ class DataNode(_Entity, _Labeled):
         """
         raise NotImplementedError
 
+    def read_or_raise(self) -> Any:
+        """Read the data referenced by this data node.
+
+        Returns:
+            The data referenced by this data node.
+
+        Raises:
+            NoData^: If the data has not been written yet.
+        """
+        from ._data_manager_factory import _DataManagerFactory
+
+        return _DataManagerFactory._build_manager()._read(self)
+
     def read(self) -> Any:
         """Read the data referenced by this data node.
 

--- a/taipy/core/exceptions/exceptions.py
+++ b/taipy/core/exceptions/exceptions.py
@@ -65,10 +65,7 @@ class MultipleDataNodeFromSameConfigWithSameOwner(Exception):
 
 
 class NoData(Exception):
-    """Raised if a data node is read before it has been written.
-
-    This exception can be raised by `DataNode.read_or_raise()^`.
-    """
+    """Raised if a data node is read before it has been written."""
 
 
 class UnknownDatabaseEngine(Exception):

--- a/taipy/core/exceptions/exceptions.py
+++ b/taipy/core/exceptions/exceptions.py
@@ -65,7 +65,10 @@ class MultipleDataNodeFromSameConfigWithSameOwner(Exception):
 
 
 class NoData(Exception):
-    """Raised if a data node is read before it has been written."""
+    """Raised if a data node is read before it has been written.
+
+    This exception can be raised by `DataNode.read_or_raise()^`.
+    """
 
 
 class UnknownDatabaseEngine(Exception):

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -12,7 +12,9 @@
 import os
 import pathlib
 
+import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 from taipy import Scope
 from taipy.common.config import Config
@@ -23,7 +25,7 @@ from taipy.core.data.csv import CSVDataNode
 from taipy.core.data.data_node_id import DataNodeId
 from taipy.core.data.in_memory import InMemoryDataNode
 from taipy.core.data.pickle import PickleDataNode
-from taipy.core.exceptions.exceptions import InvalidDataNodeType, ModelNotFound
+from taipy.core.exceptions.exceptions import InvalidDataNodeType, ModelNotFound, NoData
 from taipy.core.reason import EntityDoesNotExist, NotGlobalScope, WrongConfigType
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
@@ -494,6 +496,67 @@ class TestDataManager:
         assert len(dm._get_all()) == 2
 
         dm._delete_all()
+
+    @pytest.mark.parametrize(
+        "storage_type,path",
+        [
+            ("pickle", "pickle_file_path"),
+            ("csv", "csv_file"),
+            ("excel", "excel_file"),
+            ("json", "json_file"),
+            ("parquet", "parquet_file_path"),
+        ],
+    )
+    def test_read(self, storage_type, path, request):
+        path = request.getfixturevalue(path)
+
+        non_exist_dn_config = Config.configure_data_node(id="d1", storage_type=storage_type, path="non_exist_path")
+        dn_config = Config.configure_data_node(id="d2", storage_type=storage_type, path=path)
+        dn_1 = _DataManager._create(non_exist_dn_config, None, None)
+        dn_2 = _DataManager._create(dn_config, None, None)
+
+        with pytest.raises(NoData):
+            _DataManager._read(dn_1)
+
+        assert dn_2._read() is not None
+
+    @pytest.mark.parametrize(
+        "storage_type,path",
+        [
+            ("pickle", "pickle_file_path"),
+            ("csv", "csv_file"),
+            ("parquet", "parquet_file_path"),
+        ],
+    )
+    def test_write(self, storage_type, path, request):
+        path = request.getfixturevalue(path)
+
+        dn_config = Config.configure_data_node(id="d2", storage_type=storage_type, path=path)
+        dn = _DataManager._create(dn_config, None, None)
+
+        new_data = pd.DataFrame([{"a": 11, "b": 12, "c": 13}, {"a": 14, "b": 15, "c": 16}])
+
+        _DataManager._write(dn, new_data)
+        assert_frame_equal(dn._read(), new_data)
+
+    @pytest.mark.parametrize(
+        "storage_type,path",
+        [
+            ("csv", "csv_file"),
+            ("parquet", "parquet_file_path"),
+        ],
+    )
+    def test_append(self, storage_type, path, request):
+        path = request.getfixturevalue(path)
+
+        dn_config = Config.configure_data_node(id="d2", storage_type=storage_type, path=path)
+        dn = _DataManager._create(dn_config, None, None)
+
+        old_data = _DataManager._read(dn)
+        new_data = pd.DataFrame([{"a": 11, "b": 12, "c": 13}, {"a": 14, "b": 15, "c": 16}])
+
+        _DataManager._append(dn, new_data)
+        assert_frame_equal(dn._read(), pd.concat([old_data, new_data], ignore_index=True))
 
     @pytest.mark.parametrize(
         "storage_type,path",

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -150,9 +150,9 @@ class TestDataNode:
     def test_read_write(self):
         dn = FakeDataNode("foo_bar")
         _DataManagerFactory._build_manager()._repository._save(dn)
+        assert dn.read() is None
         with pytest.raises(NoData):
-            assert dn.read() is None
-            dn.read_or_raise()
+            _DataManagerFactory._build_manager()._read(dn)
         assert dn.write_has_been_called == 0
         assert dn.read_has_been_called == 0
         assert not dn.is_ready_for_reading

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -153,6 +153,8 @@ class TestDataNode:
         assert dn.read() is None
         with pytest.raises(NoData):
             _DataManagerFactory._build_manager()._read(dn)
+        with pytest.raises(NoData):
+            dn.read_or_raise()
         assert dn.write_has_been_called == 0
         assert dn.read_has_been_called == 0
         assert not dn.is_ready_for_reading

--- a/tests/core/data/test_in_memory_data_node.py
+++ b/tests/core/data/test_in_memory_data_node.py
@@ -52,9 +52,9 @@ class TestInMemoryDataNodeEntity:
     def test_read_and_write(self):
         no_data_dn = InMemoryDataNode("foo", Scope.SCENARIO, DataNodeId("dn_id"))
         _DataManagerFactory._build_manager()._repository._save(no_data_dn)
+        assert no_data_dn.read() is None
         with pytest.raises(NoData):
-            assert no_data_dn.read() is None
-            no_data_dn.read_or_raise()
+            _DataManagerFactory._build_manager()._read(no_data_dn)
         in_mem_dn = InMemoryDataNode("foo", Scope.SCENARIO, properties={"default_data": "bar"})
         _DataManagerFactory._build_manager()._repository._save(in_mem_dn)
         assert isinstance(in_mem_dn.read(), str)

--- a/tests/core/data/test_in_memory_data_node.py
+++ b/tests/core/data/test_in_memory_data_node.py
@@ -55,6 +55,8 @@ class TestInMemoryDataNodeEntity:
         assert no_data_dn.read() is None
         with pytest.raises(NoData):
             _DataManagerFactory._build_manager()._read(no_data_dn)
+        with pytest.raises(NoData):
+            no_data_dn.read_or_raise()
         in_mem_dn = InMemoryDataNode("foo", Scope.SCENARIO, properties={"default_data": "bar"})
         _DataManagerFactory._build_manager()._repository._save(in_mem_dn)
         assert isinstance(in_mem_dn.read(), str)

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -162,9 +162,9 @@ class TestJSONDataNode:
 
     def test_read_non_existing_json(self):
         not_existing_json = JSONDataNode("foo", Scope.SCENARIO, properties={"default_path": "WRONG.json"})
+        assert not_existing_json.read() is None
         with pytest.raises(NoData):
-            assert not_existing_json.read() is None
-            not_existing_json.read_or_raise()
+            _DataManagerFactory._build_manager()._read(not_existing_json)
 
     def test_read(self):
         path_1 = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/json/example_list.json")

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -165,6 +165,8 @@ class TestJSONDataNode:
         assert not_existing_json.read() is None
         with pytest.raises(NoData):
             _DataManagerFactory._build_manager()._read(not_existing_json)
+        with pytest.raises(NoData):
+            not_existing_json.read_or_raise()
 
     def test_read(self):
         path_1 = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/json/example_list.json")

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -117,9 +117,9 @@ class TestPickleDataNodeEntity:
     def test_read_and_write(self):
         no_data_dn = PickleDataNode("foo", Scope.SCENARIO)
         _DataManagerFactory._build_manager()._repository._save(no_data_dn)
+        assert no_data_dn.read() is None
         with pytest.raises(NoData):
-            assert no_data_dn.read() is None
-            no_data_dn.read_or_raise()
+            _DataManagerFactory._build_manager()._read(no_data_dn)
         pickle_str = PickleDataNode("foo", Scope.SCENARIO, properties={"default_data": "bar"})
         _DataManagerFactory._build_manager()._repository._save(pickle_str)
         assert isinstance(pickle_str.read(), str)

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -120,6 +120,8 @@ class TestPickleDataNodeEntity:
         assert no_data_dn.read() is None
         with pytest.raises(NoData):
             _DataManagerFactory._build_manager()._read(no_data_dn)
+        with pytest.raises(NoData):
+            no_data_dn.read_or_raise()
         pickle_str = PickleDataNode("foo", Scope.SCENARIO, properties={"default_data": "bar"})
         _DataManagerFactory._build_manager()._repository._save(pickle_str)
         assert isinstance(pickle_str.read(), str)

--- a/tests/core/data/test_read_csv_data_node.py
+++ b/tests/core/data/test_read_csv_data_node.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pytest
 
 from taipy import Scope
+from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.csv import CSVDataNode
 from taipy.core.exceptions.exceptions import NoData
 
@@ -33,9 +34,9 @@ class MyCustomObject:
 
 def test_raise_no_data_with_header():
     not_existing_csv = CSVDataNode("foo", Scope.SCENARIO, properties={"path": "WRONG.csv", "has_header": True})
+    assert not_existing_csv.read() is None
     with pytest.raises(NoData):
-        assert not_existing_csv.read() is None
-        not_existing_csv.read_or_raise()
+        _DataManagerFactory._build_manager()._read(not_existing_csv)
 
 
 def test_read_with_header_pandas():
@@ -75,9 +76,9 @@ def test_read_with_header_custom_exposed_type():
 
 def test_raise_no_data_without_header():
     not_existing_csv = CSVDataNode("foo", Scope.SCENARIO, properties={"path": "WRONG.csv", "has_header": False})
+    assert not_existing_csv.read() is None
     with pytest.raises(NoData):
-        assert not_existing_csv.read() is None
-        not_existing_csv.read_or_raise()
+        _DataManagerFactory._build_manager()._read(not_existing_csv)
 
 
 def test_read_without_header_pandas():

--- a/tests/core/data/test_read_csv_data_node.py
+++ b/tests/core/data/test_read_csv_data_node.py
@@ -37,6 +37,8 @@ def test_raise_no_data_with_header():
     assert not_existing_csv.read() is None
     with pytest.raises(NoData):
         _DataManagerFactory._build_manager()._read(not_existing_csv)
+    with pytest.raises(NoData):
+        not_existing_csv.read_or_raise()
 
 
 def test_read_with_header_pandas():

--- a/tests/core/data/test_read_excel_data_node.py
+++ b/tests/core/data/test_read_excel_data_node.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pytest
 
 from taipy import Scope
+from taipy.core.data._data_manager_factory import _DataManagerFactory
 from taipy.core.data.excel import ExcelDataNode
 from taipy.core.exceptions.exceptions import (
     ExposedTypeLengthMismatch,
@@ -62,10 +63,10 @@ custom_pandas_numpy_exposed_type_dict = {"Sheet1": "pandas", "Sheet2": "numpy"}
 
 
 def test_raise_no_data_with_header():
+    not_existing_excel = ExcelDataNode("foo", Scope.SCENARIO, properties={"path": "WRONG.xlsx"})
+    assert not_existing_excel.read() is None
     with pytest.raises(NoData):
-        not_existing_excel = ExcelDataNode("foo", Scope.SCENARIO, properties={"path": "WRONG.xlsx"})
-        assert not_existing_excel.read() is None
-        not_existing_excel.read_or_raise()
+        _DataManagerFactory._build_manager()._read(not_existing_excel)
 
 
 def test_read_empty_excel_with_header():
@@ -79,12 +80,10 @@ def test_read_empty_excel_with_header():
 
 
 def test_raise_no_data_without_header():
+    not_existing_excel = ExcelDataNode("foo", Scope.SCENARIO, properties={"path": "WRONG.xlsx", "has_header": False})
+    assert not_existing_excel.read() is None
     with pytest.raises(NoData):
-        not_existing_excel = ExcelDataNode(
-            "foo", Scope.SCENARIO, properties={"path": "WRONG.xlsx", "has_header": False}
-        )
-        assert not_existing_excel.read() is None
-        not_existing_excel.read_or_raise()
+        _DataManagerFactory._build_manager()._read(not_existing_excel)
 
 
 def test_read_empty_excel_without_header():
@@ -103,9 +102,9 @@ def test_read_multi_sheet_with_header_no_data():
         Scope.SCENARIO,
         properties={"path": "WRONG.xlsx", "sheet_name": ["sheet_name_1", "sheet_name_2"]},
     )
+    assert not_existing_excel.read() is None
     with pytest.raises(NoData):
-        assert not_existing_excel.read() is None
-        not_existing_excel.read_or_raise()
+        _DataManagerFactory._build_manager()._read(not_existing_excel)
 
 
 def test_read_multi_sheet_without_header_no_data():
@@ -114,9 +113,9 @@ def test_read_multi_sheet_without_header_no_data():
         Scope.SCENARIO,
         properties={"path": "WRONG.xlsx", "has_header": False, "sheet_name": ["sheet_name_1", "sheet_name_2"]},
     )
+    assert not_existing_excel.read() is None
     with pytest.raises(NoData):
-        assert not_existing_excel.read() is None
-        not_existing_excel.read_or_raise()
+        _DataManagerFactory._build_manager()._read(not_existing_excel)
 
 
 ########################## SINGLE SHEET ##########################

--- a/tests/core/data/test_read_excel_data_node.py
+++ b/tests/core/data/test_read_excel_data_node.py
@@ -67,6 +67,8 @@ def test_raise_no_data_with_header():
     assert not_existing_excel.read() is None
     with pytest.raises(NoData):
         _DataManagerFactory._build_manager()._read(not_existing_excel)
+    with pytest.raises(NoData):
+        not_existing_excel.read_or_raise()
 
 
 def test_read_empty_excel_with_header():

--- a/tests/core/data/test_read_parquet_data_node.py
+++ b/tests/core/data/test_read_parquet_data_node.py
@@ -68,9 +68,9 @@ class TestReadParquetDataNode:
         not_existing_parquet = ParquetDataNode(
             "foo", Scope.SCENARIO, properties={"path": "nonexistent.parquet", "engine": engine}
         )
+        assert not_existing_parquet.read() is None
         with pytest.raises(NoData):
-            assert not_existing_parquet.read() is None
-            not_existing_parquet.read_or_raise()
+            _DataManagerFactory._build_manager()._read(not_existing_parquet)
 
     @pytest.mark.parametrize("engine", __engine)
     def test_read_parquet_file_pandas(self, engine, parquet_file_path):

--- a/tests/core/data/test_read_parquet_data_node.py
+++ b/tests/core/data/test_read_parquet_data_node.py
@@ -71,6 +71,8 @@ class TestReadParquetDataNode:
         assert not_existing_parquet.read() is None
         with pytest.raises(NoData):
             _DataManagerFactory._build_manager()._read(not_existing_parquet)
+        with pytest.raises(NoData):
+            not_existing_parquet.read_or_raise()
 
     @pytest.mark.parametrize("engine", __engine)
     def test_read_parquet_file_pandas(self, engine, parquet_file_path):

--- a/tools/packages/pipfiles/Pipfile3.10.max
+++ b/tools/packages/pipfiles/Pipfile3.10.max
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+fastparquet = "*"
 freezegun = "*"
 ipython = "*"
 ipykernel = "*"

--- a/tools/packages/pipfiles/Pipfile3.11.max
+++ b/tools/packages/pipfiles/Pipfile3.11.max
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+fastparquet = "*"
 freezegun = "*"
 ipython = "*"
 ipykernel = "*"

--- a/tools/packages/pipfiles/Pipfile3.12.max
+++ b/tools/packages/pipfiles/Pipfile3.12.max
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+fastparquet = "*"
 freezegun = "*"
 ipython = "*"
 ipykernel = "*"

--- a/tools/packages/pipfiles/Pipfile3.9.max
+++ b/tools/packages/pipfiles/Pipfile3.9.max
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+fastparquet = "*"
 freezegun = "*"
 ipython = "*"
 ipykernel = "*"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Refactor
- Feature

## Description

This PR reroutes the DataNode.read() and write() methods to call to the manager methods.

## Related Tickets & Documents

- Related Issue https://github.com/Avaiga/taipy-enterprise/issues/651