### PR TITLE
Fix URL encoding in content accessor by replacing quote_plus with quote for file URLs

### DIFF
--- a/taipy/gui/data/content_accessor.py
+++ b/taipy/gui/data/content_accessor.py
@@ -113,7 +113,7 @@ class _ContentAccessor:
             self.__content_paths[url_path] = dir_path
             file_url = f"{url_path}/{path.name}"
             self.__url_is_image[file_url] = image
-            return (urllib.parse.quote_plus(file_url, safe="/"),)
+            return (urllib.parse.quote(file_url, safe="/"),)
         elif _has_magic_module:
             try:
                 mime = magic.from_buffer(value, mime=True)

--- a/tests/gui/control/test_file_download.py
+++ b/tests/gui/control/test_file_download.py
@@ -62,8 +62,7 @@ def test_file_download_with_spaces_path_md(gui: Gui, test_client, helpers):
         md_string = "<|{content}|file_download|>"
         expected_list = [
             "<FileDownload",
-            'defaultContent="/taipy-content/taipyStatic',
-            'test%20file%20with%20spaces.txt"',
+            'defaultContent="/taipy-content/taipyStatic0/test%20file%20with%20spaces.txt"',
         ]
         helpers.test_control_md(gui, md_string, expected_list)
     finally:

--- a/tests/gui/control/test_file_download.py
+++ b/tests/gui/control/test_file_download.py
@@ -50,6 +50,27 @@ def test_file_download_path_md(gui: Gui, test_client, helpers):
     helpers.test_control_md(gui, md_string, expected_list)
 
 
+def test_file_download_with_spaces_path_md(gui: Gui, test_client, helpers):
+    resources_dir = pathlib.Path(__file__).parent.parent / "resources"
+    test_file_path = resources_dir / "test file with spaces.txt"
+
+    try:
+        with open(test_file_path, "w") as f:
+            f.write("Test content")
+
+        gui._bind_var_val("content", str(test_file_path.resolve()))
+        md_string = "<|{content}|file_download|>"
+        expected_list = [
+            "<FileDownload",
+            'defaultContent="/taipy-content/taipyStatic',
+            'test%20file%20with%20spaces.txt"',
+        ]
+        helpers.test_control_md(gui, md_string, expected_list)
+    finally:
+        if test_file_path.exists():
+            test_file_path.unlink()
+
+
 def test_file_download_any_file_md(gui: Gui, test_client, helpers):
     with open(os.path.abspath(__file__), "rb") as content:
         gui._bind_var_val("content", content.read())


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
This PR fixes an issue with the file_download control when file names contain spaces. Previously, spaces in filenames were encoded as **`+`** characters (using **`urllib.parse.quote_plus`**), which caused browsers to fail to locate the files. This PR changes the URL encoding to use **`urllib.parse.quote`** instead, which properly encodes spaces as **`%20`** in URLs, allowing files with spaces in their names to be downloaded correctly.

## Related Tickets & Documents

- Closes #2523 

## How to reproduce the issue

1. Create two text files in the same directory: sample_file.txt and sample file.txt (with a space)
2. Create a Taipy app with: 
```
 import taipy.gui.builder as tgb
   from taipy import Gui

   with tgb.Page() as test_page:
       tgb.text("# Test Download button", mode="md")
       tgb.file_download(
           content="sample file.txt",  # Use file with space in name
           label="Download File",
       )

   if __name__ == "__main__":
       gui = Gui(page=test_page)
       gui.run(
           title="Test download",
           use_reloader=True,
       )
```

3. Run the app and click the download button
4. Before the fix: A .htm file is downloaded with a 404 error message
5. After the fix: The text file is properly downloaded

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [ ] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._
- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [ ] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
