### PR TITLE
backport multiline scroll

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -349,6 +349,7 @@ const Input = (props: TaipyInputProps) => {
                 onKeyDown={handleAction}
                 multiline={multiline}
                 minRows={linesShown}
+                maxRows={linesShown}
             />
         </Tooltip>
     );


### PR DESCRIPTION
#2546

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
backport multiline scroll

## Related Tickets & Documents
- Closes #2546 

## How to reproduce the issue

```py
import taipy.gui.builder as tgb
from taipy.gui import Gui

app_title = "Testing"

textarea = "\n".join([str(i) for i in range(1, 30)])

with tgb.Page() as page:
    tgb.text(value="# {app_title}", mode="md")
    tgb.input(label="Textarea", value="{textarea}", multiline=True, lines_shown=10, id="my_textarea")

if __name__ == "__main__":
    gui = Gui(page=page, css_file="main.css")
    gui.run(title=f"2546 {app_title}")
```

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [x] 4.0
- [x] develop

