### PR TITLE
Backport: Table with lists

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/tableUtils.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/tableUtils.tsx
@@ -243,7 +243,7 @@ const formatValue = (
             return getNumberString(val as number, col.format, formatConf);
         default:
             return val
-                ? lineBreak && (col.lineBreak === undefined || col.lineBreak)
+                ? lineBreak && (col.lineBreak === undefined || col.lineBreak) && typeof val === "string"
                     ? (val as string).split("\n").map((p, i) =>
                           i == 0 ? (
                               p
@@ -574,25 +574,25 @@ export const EditableCell = (props: EditableCellProps) => {
                     colDesc.type?.startsWith("bool") ? (
                         <Box sx={cellBoxSx}>
                             {useCheckbox ? (
-                            <input
-                                type="checkbox"
-                                checked={val as boolean}
-                                title={boolTitle}
-                                style={iconInRowSx}
-                                className={getSuffixedClassNames(tableClassName, "-bool")}
-                                ref={setInputFocus}
-                                onChange={onBoolChange}
-                            />
+                                <input
+                                    type="checkbox"
+                                    checked={val as boolean}
+                                    title={boolTitle}
+                                    style={iconInRowSx}
+                                    className={getSuffixedClassNames(tableClassName, "-bool")}
+                                    ref={setInputFocus}
+                                    onChange={onBoolChange}
+                                />
                             ) : (
-                            <Switch
-                                checked={val as boolean}
-                                size="small"
-                                title={boolTitle}
-                                sx={iconInRowSx}
-                                onChange={onBoolChange}
-                                inputRef={setInputFocus}
-                                className={getSuffixedClassNames(tableClassName, "-bool")}
-                            />
+                                <Switch
+                                    checked={val as boolean}
+                                    size="small"
+                                    title={boolTitle}
+                                    sx={iconInRowSx}
+                                    onChange={onBoolChange}
+                                    inputRef={setInputFocus}
+                                    className={getSuffixedClassNames(tableClassName, "-bool")}
+                                />
                             )}
                             <Box sx={iconsWrapperSx}>
                                 <IconButton onClick={onCheckClick} size="small" sx={iconInRowSx}>


### PR DESCRIPTION
resolves #2553

## What type of PR is this? (Check all that apply)

- [x] 🛠 Backport
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
Table with lists

## Related Tickets & Documents
- Closes #2553 

## How to reproduce the issue

```py
import pandas as pd

import taipy.gui.builder as tgb
from taipy import Gui

data = {
    "State": [["NY"], ["IL"], ["TX"], ["WA"]],
    "Plant Id": [101, 102, 103, 104]
}

plants = pd.DataFrame(data)

with tgb.Page() as page:
    tgb.table("{plants}",)

Gui(page).run(title="2553 Table with list")
```
