### PR TITLE
Fix/Enterprise#664 - Initialize Orchestrator instance correctly when creates entities

### DIFF
--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -910,7 +910,7 @@ def create_scenario(
         SystemExit: If the configuration check returns some errors.
 
     """
-    Orchestrator._manage_version_and_block_config()
+    Orchestrator()._manage_version_and_block_config()
 
     return _ScenarioManagerFactory._build_manager()._create(config, creation_date, name)
 
@@ -935,7 +935,7 @@ def create_global_data_node(config: DataNodeConfig) -> DataNode:
     if config.scope is not Scope.GLOBAL:
         raise DataNodeConfigIsNotGlobal(config.id)
 
-    Orchestrator._manage_version_and_block_config()
+    Orchestrator()._manage_version_and_block_config()
 
     if dns := _DataManagerFactory._build_manager()._get_by_config_id(config.id):
         return dns[0]


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- 🐛 Bug Fix

## Description

The `taipy.enterprise.core.orchestrator._Orchestrator` inherits from `taipy.core.orchestrator.Orchestrator`.

The instance of the Orchestrator service is built in the `_init_core_enterprise()` when creating new service instance.

However, when creating entities using `create_scenario()` or `create_global_data_node()`, the Orchestrator instance is not created but the classmethod is called directly, which calls to the community Orchestrator class. It then updates the class variable of the community class, which is wrong.

## Related Tickets & Documents

- Closes https://github.com/Avaiga/taipy-enterprise/issues/664

## Backporting

_This change should be backported to?:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [ ] develop

## Checklist

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why: It relates to initializing enterprise Orchestrator instance, which is already tested in enterprise. The issue is from a mis-use of the class.
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
