### PR TITLE
Refactor - Move config/stubs to tools

### DIFF
--- a/.github/workflows/partial-tests.yml
+++ b/.github/workflows/partial-tests.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           mypy_flags:  "--ignore-missing-imports --implicit-optional --disable-error-code attr-defined --no-namespace-packages --exclude (taipy/templates/|tools/|doc/gui/examples/.*/builder.py|taipy/common/config/config.pyi) --follow-imports skip --disable-error-code import-untyped"
 
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.6.4"
 
   tests:
     needs: linter

--- a/.github/workflows/update-config-pyi.yml
+++ b/.github/workflows/update-config-pyi.yml
@@ -13,11 +13,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Update config.pyi
-        run: python taipy/common/config/stubs/generate_pyi.py
-      - uses: stefanzweifel/git-auto-commit-action@v5
+        run: python tools/config/generate_pyi.py
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Update config.pyi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ unfixable = []
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]  # unused import
 "_init.py" = ["F401", "F403"]  # unused import
-"taipy/common/config/stubs/pyi_header.py" = ["F401", "F403"]  # unused import
+"tools/config/pyi_header.py" = ["F401", "F403"]  # unused import
 "taipy/templates/*" = ["F401", "F403", "T201"]  # unused import, `print` found
 "taipy/gui/utils/types.py" = ["B024"] # abstract base class with no abstract methods
 

--- a/taipy/common/README.md
+++ b/taipy/common/README.md
@@ -54,7 +54,6 @@ Want to be part of the *Taipy Common* community? Check out our [`CODE_OF_CONDUCT
       - `common/`: Shared data structures, types, and functions.
       - `exceptions/`: *taipy-common* exceptions.
       - `global_app/`: `GlobalAppConfig` implementation.
-      - `stubs/`: Helper functions to create the `config.pyi` file.
       - `INSTALLATION.md`: Instructions to install *taipy-common*.
       - `LICENSE`: The Apache 2.0 License.
       - `README.md`: Current file.

--- a/taipy/common/config/config.pyi
+++ b/taipy/common/config/config.pyi
@@ -8,6 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
 import json
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union

--- a/tools/config/generate_pyi.py
+++ b/tools/config/generate_pyi.py
@@ -141,7 +141,7 @@ def _build_header(filename) -> str:
 
 
 if __name__ == "__main__":
-    header_file = "taipy/common/config/stubs/pyi_header.py"
+    header_file = "tools/config/pyi_header.py"
     base_config = "taipy/common/config/config.py"
     config_init = [Path("taipy/core/config/__init__.py"), Path("taipy/rest/config/__init__.py")]
 

--- a/tools/config/pyi_header.py
+++ b/tools/config/pyi_header.py
@@ -8,6 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
 import json
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Union


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- 🛠 Refactor
- ⚡ Optimization

## Description

- Move the scripts that generate `config.pyi` to `tools/config`
- Use the official `astral-sh/ruff-action` instead of the unsupported `chartboost/ruff-action`