### PR TITLE
Fix - `update()` is not imported at taipy level

### DIFF
--- a/taipy/core/_init.py
+++ b/taipy/core/_init.py
@@ -68,6 +68,7 @@ from .taipy import (
     unsubscribe_scenario,
     unsubscribe_sequence,
     untag,
+    update,
 )
 from .task.task import Task
 from .task.task_id import TaskId


### PR DESCRIPTION
## What type of PR is this?

- 🐛 Bug Fix

## Description

The `update()` method was not in the `_init` at taipy level, which causes issue when trying to use the method in https://github.com/Avaiga/taipy-enterprise/pull/684.

## Related Tickets & Documents

- Related PR https://github.com/Avaiga/taipy-enterprise/pull/684

## Backporting

No backport is needed because the `update()` method is only in develop branch.

