### PR TITLE
support boolean value in env file config

### DIFF
--- a/taipy/core/data/_file_datanode_mixin.py
+++ b/taipy/core/data/_file_datanode_mixin.py
@@ -14,7 +14,7 @@ import pathlib
 import shutil
 from datetime import datetime
 from os.path import isfile
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, cast
 
 from taipy.common.config import Config
 from taipy.common.logger._taipy_logger import _TaipyLogger
@@ -47,7 +47,7 @@ class _FileDataNodeMixin:
     __logger = _TaipyLogger._get_logger()
 
     def __init__(self, properties: Dict) -> None:
-        self._path: str = properties.get(self._PATH_KEY, properties.get(self._DEFAULT_PATH_KEY))
+        self._path: str = cast(str, properties.get(self._PATH_KEY, properties.get(self._DEFAULT_PATH_KEY)))
         self._is_generated: bool = properties.get(self._IS_GENERATED_KEY, self._path is None)
         self._last_edit_date: Optional[datetime] = None
 
@@ -248,5 +248,5 @@ class _FileDataNodeMixin:
             else:
                 shutil.copy(self._path, new_path)
             normalize_path = _normalize_path(new_path)
-            dest._path = normalize_path
+            dest._path = normalize_path # type: ignore[attr-defined]
             dest._properties[self._PATH_KEY] = normalize_path

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -225,7 +225,7 @@ class ExcelDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             excel_file.close()
 
         if len(user_provided_sheet_names) == 1:
-            return work_books[user_provided_sheet_names[0]]
+            return work_books[cast(list, user_provided_sheet_names)[0]]
 
         return work_books
 

--- a/taipy/gui/config.py
+++ b/taipy/gui/config.py
@@ -26,7 +26,7 @@ from ._hook import _Hooks
 from ._page import _Page
 from ._warnings import _warn
 from .partial import Partial
-from .utils import _is_in_notebook
+from .utils import _is_in_notebook, _is_true
 
 ConfigParameter = t.Literal[
     "allow_unsafe_werkzeug",
@@ -266,9 +266,12 @@ class _Config(object):
                 if value is not None and key in config:
                     try:
                         if key == "port" and str(value).strip() == "auto":
-                            config["port"] = "auto"
+                            config[key] = "auto"
                         else:
-                            config[key] = value if config[key] is None else type(config[key])(value)  # type: ignore[reportCallIssue]
+                            if isinstance(config[key], bool):
+                                config[key] = _is_true(value)
+                            else:
+                                config[key] = value if config[key] is None else type(config[key])(value)  # type: ignore[reportCallIssue]
                     except Exception as e:
                         _warn(
                             f"Invalid env value in Gui.run(): {key} - {value}. Unable to parse value to the correct type",  # noqa: E501

--- a/taipy/gui/page.py
+++ b/taipy/gui/page.py
@@ -76,7 +76,7 @@ class Page:
         # Special variables only use for page reloading in notebook context
         self._notebook_gui: t.Optional["Gui"] = None
         self._notebook_page: t.Optional["_Page"] = None
-        self.set_style(kwargs.get("style", None))
+        self.set_style(t.cast(dict, kwargs.get("style", None)))
         self._script_paths(kwargs.get("script_paths", None))
 
     def create_page(self) -> t.Union[Page, str, None]:

--- a/tests/gui/config/test_filename.py
+++ b/tests/gui/config/test_filename.py
@@ -18,7 +18,7 @@ from taipy.gui import Gui
 
 def test_env_filename():
 
-    gui = Gui(env_filename=str(pathlib.Path(__file__).parent.parent / "resources" / "taipy.env"))
+    gui = Gui(env_filename=str(pathlib.Path(__file__).parent.parent / "resources" / "taipy_env"))
     gui.run(run_server=False)
     service_config = gui._config.config
     assert service_config["run_browser"] is False # type: ignore

--- a/tests/gui/config/test_filename.py
+++ b/tests/gui/config/test_filename.py
@@ -1,0 +1,26 @@
+# Copyright 2021-2025 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import pathlib
+
+import pytest
+
+from taipy.gui import Gui
+
+
+def test_env_filename():
+
+    gui = Gui(env_filename=str(pathlib.Path(__file__).parent.parent / "resources" / "taipy.env"))
+    gui.run(run_server=False)
+    service_config = gui._config.config
+    assert service_config["run_browser"] is False # type: ignore
+    gui.stop()
+

--- a/tests/gui/config/test_filename.py
+++ b/tests/gui/config/test_filename.py
@@ -22,5 +22,6 @@ def test_env_filename():
     gui.run(run_server=False)
     service_config = gui._config.config
     assert service_config["run_browser"] is False # type: ignore
+    assert service_config["port"] == 5555 # type: ignore
     gui.stop()
 

--- a/tests/gui/config/test_filename.py
+++ b/tests/gui/config/test_filename.py
@@ -11,8 +11,6 @@
 
 import pathlib
 
-import pytest
-
 from taipy.gui import Gui
 
 

--- a/tests/gui/resources/taipy_env
+++ b/tests/gui/resources/taipy_env
@@ -1,0 +1,2 @@
+run_browser = False
+port=5555


### PR DESCRIPTION
resolves #2453

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
support boolean value in env file config

## Related Tickets & Documents
- Closes #2453 

## How to reproduce the issue

```env
run_browser=False
```

```py
import taipy.gui.builder as tgb
from taipy.gui import Gui

input_value = 0
output_value = None


with tgb.Page() as update_test:
    tgb.selector(
        "{input_value}",
        lov=[0, 1, 2, 3, 4],
        label="select number to add 1",
        dropdown=True,
    )
    tgb.button(
        label="input to output",
        on_action=lambda state: state.assign("output_value", int(state.input_value) + 1),
    )
    tgb.text("Your Number plus 1 is {output_value}")


if __name__ == "__main__":
    gui = Gui(page=update_test, env_filename="demo.env")

    gui.run(
        title="2453 - Env file demo",
    )

```

