### PR TITLE
chat image support False by default

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -232,7 +232,7 @@ const Chat = (props: ChatProps) => {
         maxFileSize = 0.8 * 1024 * 1024, // 0.8 MB
         pageSize = 50,
         showSender = false,
-        allowSendImages = true,
+        allowSendImages = false,
     } = props;
     const dispatch = useDispatch();
     const module = useModule();
@@ -279,6 +279,21 @@ const Chat = (props: ChatProps) => {
     const sendAction = useCallback(
         (elt: HTMLInputElement | null | undefined, reason: string) => {
             if (elt && (elt?.value || imagePreview)) {
+                if (!allowSendImages) {
+                        dispatch(
+                            createSendActionNameAction(
+                                id,
+                                module,
+                                onAction,
+                                reason,
+                                updateVarName,
+                                elt?.value,
+                                senderId,
+                            )
+                        );
+                        elt.value = "";
+                    return;
+                }
                 toDataUrl(imagePreview)
                     .then((dataUrl) => {
                         dispatch(
@@ -304,7 +319,7 @@ const Chat = (props: ChatProps) => {
                     .catch(console.log);
             }
         },
-        [imagePreview, updateVarName, onAction, senderId, id, dispatch, module]
+        [allowSendImages, imagePreview, updateVarName, onAction, senderId, id, dispatch, module]
     );
 
     const handleAction = useCallback(

--- a/taipy/core/data/_file_datanode_mixin.py
+++ b/taipy/core/data/_file_datanode_mixin.py
@@ -14,7 +14,7 @@ import pathlib
 import shutil
 from datetime import datetime
 from os.path import isfile
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, cast
 
 from taipy.common.config import Config
 from taipy.common.logger._taipy_logger import _TaipyLogger
@@ -39,7 +39,7 @@ class _FileDataNodeMixin(object):
     __logger = _TaipyLogger._get_logger()
 
     def __init__(self, properties: Dict) -> None:
-        self._path: str = properties.get(self._PATH_KEY, properties.get(self._DEFAULT_PATH_KEY))
+        self._path: str = cast(str, properties.get(self._PATH_KEY, properties.get(self._DEFAULT_PATH_KEY)))
         self._is_generated: bool = properties.get(self._IS_GENERATED_KEY, self._path is None)
         self._last_edit_date: Optional[datetime] = None
 

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -223,7 +223,7 @@ class ExcelDataNode(DataNode, _FileDataNodeMixin, _TabularDataNodeMixin):
             excel_file.close()
 
         if len(user_provided_sheet_names) == 1:
-            return work_books[user_provided_sheet_names[0]]
+            return work_books[cast(list, user_provided_sheet_names)[0]]
 
         return work_books
 

--- a/taipy/gui/page.py
+++ b/taipy/gui/page.py
@@ -74,7 +74,7 @@ class Page:
         # Special variables only use for page reloading in notebook context
         self._notebook_gui: t.Optional["Gui"] = None
         self._notebook_page: t.Optional["_Page"] = None
-        self.set_style(kwargs.get("style", None))
+        self.set_style(t.cast(dict, kwargs.get("style", None)))
 
     def create_page(self) -> t.Optional[Page]:
         """Create the page content for page modules.

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1738,7 +1738,7 @@
                     {
                         "name": "allow_send_images",
                         "type": "bool",
-                        "default_value": "True",
+                        "default_value": "False",
                         "doc": "TODO if True, an upload image icon is shown."
                     }
                 ]


### PR DESCRIPTION
 resolves #2671

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
chat image support False by default

## Related Tickets & Documents
- Closes #2671 

## How to reproduce the issue
```py
from math import cos, pi, sin, sqrt, tan  # noqa: F401

from taipy.gui import Gui

# The user interacts with the Python interpreter
users = ["human", "Result"]
messages: list[tuple[str, str, str]] = []


def evaluate(state, var_name: str, payload: dict):
    # Retrieve the callback parameters
    (_, _, expression, sender_id) = payload.get("args", [])
    # Add the input content as a sent message
    messages.append((f"{len(messages)}", expression, sender_id))
    # Default message used if evaluation fails
    result = "Invalid expression"
    try:
        # Evaluate the expression and store the result
        result = f"= {eval(expression)}"
    except Exception:
        pass
    # Add the result as an incoming message
    messages.append((f"{len(messages)}", result, users[1]))
    state.messages = messages


page = """
<|{messages}|chat|users={users}|sender_id={users[0]}|on_action=evaluate|don't allow_send_images|>
"""

Gui(page).run(title="2671 - Chat - Calculator")

```
