### PR TITLE
Bug/#1767 favicon not displayed

### DIFF
--- a/taipy/gui/server.py
+++ b/taipy/gui/server.py
@@ -28,7 +28,9 @@ from flask import (
     Flask,
     json,
     jsonify,
+    redirect,
     render_template,
+    send_file,
     send_from_directory,
 )
 from flask_cors import CORS
@@ -157,7 +159,14 @@ class _Server:
     ) -> Blueprint:
         taipy_bp = Blueprint("Taipy", __name__, static_folder=static_folder, template_folder=template_folder)
         # Serve static react build
-
+        @taipy_bp.route("/favicon.png")
+        def serve_favicon():
+            if pathlib.Path(favicon).is_file():  # if user provided favicon conflicts with default taipy favicon
+                return send_file(favicon)
+            elif favicon.startswith("http"):  # default favicon
+                return redirect(favicon)
+            else:
+                return "", 404
         @taipy_bp.route("/", defaults={"path": ""})
         @taipy_bp.route("/<path:path>")
         def my_index(path):

--- a/tests/gui/gui_specific/test_favicon.py
+++ b/tests/gui/gui_specific/test_favicon.py
@@ -36,13 +36,13 @@ def test_favicon(gui: Gui, helpers):
 
 
 def test_root_favicon_is_served(tmp_path, gui: Gui):
-    # Create a dummy favicon.png in the root (simulated by tmp_path)
+    
     favicon_path = tmp_path / "favicon.png"
     dummy_favicon_content = b"\x89PNG\r\n\x1a\nDummyIcon"
     with open(favicon_path, "wb") as f:
         f.write(dummy_favicon_content)
 
-    # Change working dir temporarily to simulate root directory containing favicon
+    
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
 
@@ -53,10 +53,10 @@ def test_root_favicon_is_served(tmp_path, gui: Gui):
             gui.run(favicon="favicon.png", run_server=False)
             client = gui._server.test_client()
 
-            # Request the favicon
+            
             response = client.get("/favicon.png")
             assert response.status_code == 200
             assert response.data == dummy_favicon_content
             assert response.mimetype == "image/png"
     finally:
-        os.chdir(old_cwd)  # Restore original working dir
+        os.chdir(old_cwd)  

--- a/tests/gui/gui_specific/test_favicon.py
+++ b/tests/gui/gui_specific/test_favicon.py
@@ -10,13 +10,13 @@
 # specific language governing permissions and limitations under the License.
 
 import inspect
+import os
 import warnings
 
 from taipy.gui import Gui, Markdown
 
 
 def test_favicon(gui: Gui, helpers):
-
     with warnings.catch_warnings(record=True):
         gui._set_frame(inspect.currentframe())
         gui.add_page("test", Markdown("#This is a page"))
@@ -33,3 +33,30 @@ def test_favicon(gui: Gui, helpers):
         assert msgs
         assert msgs[0].get("args", {}).get("type", None) == "FV"
         assert msgs[0].get("args", {}).get("payload", {}).get("value", None) == "https://newfavicon.com/favicon.png"
+
+
+def test_root_favicon_is_served(tmp_path, gui: Gui):
+    # Create a dummy favicon.png in the root (simulated by tmp_path)
+    favicon_path = tmp_path / "favicon.png"
+    dummy_favicon_content = b"\x89PNG\r\n\x1a\nDummyIcon"
+    with open(favicon_path, "wb") as f:
+        f.write(dummy_favicon_content)
+
+    # Change working dir temporarily to simulate root directory containing favicon
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        with warnings.catch_warnings(record=True):
+            gui._set_frame(inspect.currentframe())
+            gui.add_page("test", Markdown("# Page"))
+            gui.run(favicon="favicon.png", run_server=False)
+            client = gui._server.test_client()
+
+            # Request the favicon
+            response = client.get("/favicon.png")
+            assert response.status_code == 200
+            assert response.data == dummy_favicon_content
+            assert response.mimetype == "image/png"
+    finally:
+        os.chdir(old_cwd)  # Restore original working dir

--- a/tests/gui/gui_specific/test_favicon.py
+++ b/tests/gui/gui_specific/test_favicon.py
@@ -36,27 +36,24 @@ def test_favicon(gui: Gui, helpers):
 
 
 def test_root_favicon_is_served(tmp_path, gui: Gui):
-    
     favicon_path = tmp_path / "favicon.png"
     dummy_favicon_content = b"\x89PNG\r\n\x1a\nDummyIcon"
+    #Creating a dummy favicon.png file
     with open(favicon_path, "wb") as f:
         f.write(dummy_favicon_content)
-
-    
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
-
     try:
         with warnings.catch_warnings(record=True):
             gui._set_frame(inspect.currentframe())
             gui.add_page("test", Markdown("# Page"))
             gui.run(favicon="favicon.png", run_server=False)
             client = gui._server.test_client()
-
-            
+            #assert for received file. 
             response = client.get("/favicon.png")
             assert response.status_code == 200
             assert response.data == dummy_favicon_content
             assert response.mimetype == "image/png"
+    #fallback to original directory
     finally:
-        os.chdir(old_cwd)  
+        os.chdir(old_cwd)


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
This PR fixes the issue where a user-defined favicon.png passed via `Gui.run(favicon="favicon.png")` was not being correctly served from the root directory. 
Previously, if user named custom favicon as `favicon.png` and saved it into root , the custom favicon won't be displayed. Instead the default taipy favicon would be rendered.

Now, if the passed favicon is a valid file path (like "favicon.png" in the root directory), it will correctly be used and returned when `/favicon.png` is requested.

## Related Tickets & Documents

- Related Issue #1767
- Closes #1767

## How to reproduce the issue

1- Place a `favicon.png` in root and run

```
from taipy.gui import builder as tgb
from taipy.gui import Gui
from pathlib import Path
favicon_path = Path("favicon.png")
with tgb.Page() as page:
    if favicon_path.exists():
        tgb.text("The favicon exists ")
    tgb.text("Where is my favicon?")
    
Gui(page,).run(debug=True, use_reloader=True, port=5111, favicon=str(favicon_path))
```
2- Expected: The custom favicon.png is served.
3- Previously: The default Taipy favicon was served instead.

## Backporting

- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [x] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:  
     No need for documentation updation. 
    Minor bug fix.
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
    Minor bug fix.
