### PR TITLE
Selector in table width

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/tableUtils.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/tableUtils.tsx
@@ -193,6 +193,8 @@ export const iconsWrapperSx = { gridColumnStart: 2, display: "flex", alignItems:
 const CellBoxSx = { display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center" } as CSSProperties;
 const TableFontSx = { fontSize: "body2.fontSize" };
 const ButtonSx = { minHeight: "unset", mb: "unset", padding: "unset", lineHeight: "unset" };
+const Width100pSx = { width: "100%" };
+const CellBox100pSx = {...CellBoxSx, ...Width100pSx};
 export interface OnCellValidation {
     (value: RowValue, rowIndex: number, colName: string, userValue: string, tz?: string): void;
 }
@@ -606,7 +608,12 @@ export const EditableCell = (props: EditableCellProps) => {
             component={colDesc.multi !== undefined ? "th" : undefined}
             rowSpan={rowSpan}
         >
-            <Badge color="primary" variant="dot" invisible={comp === undefined || comp === null}>
+            <Badge
+                color="primary"
+                variant="dot"
+                invisible={comp === undefined || comp === null}
+                sx={edit && colDesc.lov ? Width100pSx : undefined}
+            >
                 {edit ? (
                     colDesc.type?.startsWith("bool") ? (
                         <Box sx={CellBoxSx}>
@@ -671,7 +678,7 @@ export const EditableCell = (props: EditableCellProps) => {
                             </Box>
                         </Box>
                     ) : colDesc.lov ? (
-                        <Box sx={CellBoxSx}>
+                        <Box sx={CellBox100pSx}>
                             <Autocomplete
                                 autoComplete={true}
                                 fullWidth

--- a/tools/frontend/bundle_build.py
+++ b/tools/frontend/bundle_build.py
@@ -9,6 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import os
 import platform
 import subprocess
 import sys
@@ -23,9 +24,19 @@ def build_gui(root_path: Path):
     if already_exists:
         print(f'Found taipy-gui frontend bundle in {root_path  / "taipy" / "gui" / "webapp"}.')  # noqa: T201
     else:
-        subprocess.run(["npm", "ci"], cwd=root_path / "frontend" / "taipy-gui" / "dom", check=True, shell=with_shell)
-        subprocess.run(["npm", "ci"], cwd=root_path / "frontend" / "taipy-gui", check=True, shell=with_shell)
-        subprocess.run(["npm", "run", "build"], cwd=root_path / "frontend" / "taipy-gui", check=True, shell=with_shell)
+        my_env = os.environ.copy()
+        if my_env.get("NODE_OPTIONS") is None:
+            print("Setting NODE_OPTIONS to --max-old-space-size=16384")  # noqa: T201
+            my_env["NODE_OPTIONS"] = "--max-old-space-size=16384"
+        subprocess.run(
+            ["npm", "ci"], cwd=root_path / "frontend" / "taipy-gui" / "dom", check=True, shell=with_shell, env=my_env
+        )
+        subprocess.run(
+            ["npm", "ci"], cwd=root_path / "frontend" / "taipy-gui", check=True, shell=with_shell, env=my_env
+        )
+        subprocess.run(
+            ["npm", "run", "build"], cwd=root_path / "frontend" / "taipy-gui", check=True, shell=with_shell, env=my_env
+        )
 
 
 def build_taipy(root_path: Path):
@@ -39,8 +50,14 @@ def build_taipy(root_path: Path):
         if not env_file_path.exists():
             with open(env_file_path, "w") as env_file:
                 env_file.write(f"TAIPY_DIR={root_path}\n")
-        subprocess.run(["npm", "ci"], cwd=root_path / "frontend" / "taipy", check=True, shell=with_shell)
-        subprocess.run(["npm", "run", "build"], cwd=root_path / "frontend" / "taipy", check=True, shell=with_shell)
+        my_env = os.environ.copy()
+        if my_env.get("NODE_OPTIONS") is None:
+            print("Setting NODE_OPTIONS to --max-old-space-size=16384") # noqa: T201
+            my_env["NODE_OPTIONS"] = "--max-old-space-size=16384"
+        subprocess.run(["npm", "ci"], cwd=root_path / "frontend" / "taipy", check=True, shell=with_shell, env=my_env)
+        subprocess.run(
+            ["npm", "run", "build"], cwd=root_path / "frontend" / "taipy", check=True, shell=with_shell, env=my_env
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
resolves #2685

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
Give Selector in table the maximum available width in the column
And give node.js more heap to build if not defined

## Related Tickets & Documents
- Closes #2685 

## How to reproduce the issue
Equivalent to css rule 
```css
.tpc-editing: {.MuiBadge-root: {width: 100%}, .MuiBox-root: {width: 100%}}
```

```py
import pandas as pd

from taipy.gui import Gui, State

series_1 = pd.Series(["value a", "value b", "value c"], name="LoV free value")
series_2 = pd.Series(["value 1", "value 2", "value 3"], name="LoV closed values")
data = pd.concat([series_1, series_2], axis=1)

col1_lov = [None, "value 1", "value 2", "Another value"]
col2_lov = ["value 1", "value 2", "value 3"]

md_string = """
<|{data}|table|lov[LoV free value]={col1_lov}|lov[LoV closed values]={col2_lov}|editable|>

"""

def on_edit(state: State, var: str, payload: dict):
    print(f"on_edit(state: State, var={var}, payload={payload})")

if __name__ == "__main__":
    gui = Gui()
    gui.add_page("demo", md_string) 
    gui.run(title="2685 Table selector width")

```

