### PR TITLE
Fix Force latest 'taipy' production release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -290,6 +290,7 @@ jobs:
 
       # Ensure the latest 'taipy' production release, if there is one, is marked as *latest* no matter what
       - name: Force latest 'taipy' production release
+        if: ${{ github.event.inputs.release_type == 'dev' }}
         run: |
           if [ "${{ needs.setup-versions.outputs.LATEST_TAIPY_VERSION }}" != "0.0.0" ]; then
             gh release edit ${{ needs.setup-versions.outputs.LATEST_TAIPY_VERSION }} --latest


### PR DESCRIPTION
When building a dev version we need to re set the latest package.
When building a production version, it is wrong and not necessary