### PR TITLE
ZoneInfoNotFoundError: No time zone found with key Asia/Beijing

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -139,6 +139,7 @@ def _get_valid_timezone():
         zoneinfo.ZoneInfo(tzname)
         return tzname
     except (zoneinfo.ZoneInfoNotFoundError, AttributeError):
+        _warn('Cannot retrieve time zone, default is "UTC"', e)
         return "UTC"
 
 

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -129,10 +129,7 @@ def _get_valid_timezone():
     try:
         tzname = str(tzlocal.get_localzone())
         tzname = TIMEZONE_FALLBACKS.get(tzname, tzname)
-        try:
-            zoneinfo.ZoneInfo(tzname)
-        except zoneinfo.ZoneInfoNotFoundError:
-            tzname = "UTC"
+        zoneinfo.ZoneInfo(tzname)
         return tzname
     except (zoneinfo.ZoneInfoNotFoundError, AttributeError, KeyError):
         return "UTC"

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -122,16 +122,23 @@ def _get_valid_timezone():
     Returns:
         str: The name of the timezone, or 'UTC' if an error occurs or the timezone is not found.
 
-    This function tries to get the local timezone using `tzlocal.get_localzone()`, applies any necessary
-    fallbacks from the TIMEZONE_FALLBACKS dictionary, and checks if the timezone is valid for `zoneinfo`.
-    If the timezone is not found or an error occurs, it falls back to 'UTC'.
+     This function:
+        - Retrieves the local timezone using `tzlocal.get_localzone()`.
+        - Applies a fallback from the TIMEZONE_FALLBACKS dictionary if needed.
+        - Validates the timezone using `zoneinfo.ZoneInfo`.
+        - Falls back to 'UTC' if any error occurs.
+
+    Warning:
+        - `tzlocal.get_localzone()` may raise AttributeError if the local timezone cannot be determined.
+        - `TIMEZONE_FALLBACKS.get(tzname, tzname)` is safe and does not raise KeyError.
+        - `zoneinfo.ZoneInfo(tzname)` raises `ZoneInfoNotFoundError` if the timezone is unknown.
     """
     try:
         tzname = str(tzlocal.get_localzone())
         tzname = TIMEZONE_FALLBACKS.get(tzname, tzname)
         zoneinfo.ZoneInfo(tzname)
         return tzname
-    except (zoneinfo.ZoneInfoNotFoundError, AttributeError, KeyError):
+    except (zoneinfo.ZoneInfoNotFoundError, AttributeError):
         return "UTC"
 
 

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -31,6 +31,7 @@ from urllib.parse import unquote, urlencode, urlparse
 
 import markdown as md_lib
 import tzlocal
+import zoneinfo
 from werkzeug.utils import secure_filename
 
 import __main__  # noqa: F401
@@ -109,6 +110,34 @@ from .utils.table_col_builder import _enhance_columns
 from .utils.threads import _invoke_async_callback
 
 
+TIMEZONE_FALLBACKS = {
+    "Asia/Beijing": "Asia/Shanghai",
+}
+
+
+def _get_valid_timezone():
+    """
+    Determines a valid timezone name for the current system.
+
+    Returns:
+        str: The name of the timezone, or 'UTC' if an error occurs or the timezone is not found.
+
+    This function tries to get the local timezone using `tzlocal.get_localzone()`, applies any necessary
+    fallbacks from the TIMEZONE_FALLBACKS dictionary, and checks if the timezone is valid for `zoneinfo`.
+    If the timezone is not found or an error occurs, it falls back to 'UTC'.
+    """
+    try:
+        tzname = str(tzlocal.get_localzone())
+        tzname = TIMEZONE_FALLBACKS.get(tzname, tzname)
+        try:
+            zoneinfo.ZoneInfo(tzname)
+        except zoneinfo.ZoneInfoNotFoundError:
+            tzname = "UTC"
+        return tzname
+    except (zoneinfo.ZoneInfoNotFoundError, AttributeError, KeyError):
+        return "UTC"
+
+
 class Gui:
     """Entry point for the Graphical User Interface generation.
 
@@ -158,7 +187,7 @@ class Gui:
         _USER_CONTENT_URL,
     ]
 
-    __LOCAL_TZ = str(tzlocal.get_localzone())
+    __LOCAL_TZ = _get_valid_timezone()
 
     __extensions: t.Dict[str, t.List[ElementLibrary]] = {}
 

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -22,6 +22,7 @@ import tempfile
 import time
 import typing as t
 import warnings
+import zoneinfo
 from importlib import metadata, util
 from inspect import currentframe, getabsfile, iscoroutinefunction, ismethod, ismodule
 from pathlib import Path
@@ -31,7 +32,6 @@ from urllib.parse import unquote, urlencode, urlparse
 
 import markdown as md_lib
 import tzlocal
-import zoneinfo
 from werkzeug.utils import secure_filename
 
 import __main__  # noqa: F401
@@ -108,7 +108,6 @@ from .utils._variable_directory import _is_moduled_variable, _VariableDirectory
 from .utils.chart_config_builder import _build_chart_config
 from .utils.table_col_builder import _enhance_columns
 from .utils.threads import _invoke_async_callback
-
 
 TIMEZONE_FALLBACKS = {
     "Asia/Beijing": "Asia/Shanghai",

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -138,7 +138,7 @@ def _get_valid_timezone():
         tzname = TIMEZONE_FALLBACKS.get(tzname, tzname)
         zoneinfo.ZoneInfo(tzname)
         return tzname
-    except (zoneinfo.ZoneInfoNotFoundError, AttributeError):
+    except (zoneinfo.ZoneInfoNotFoundError, AttributeError) as e:
         _warn('Cannot retrieve time zone, default is "UTC"', e)
         return "UTC"
 


### PR DESCRIPTION
create _get_valid_timezone

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description

This PR introduces a new helper function `_get_valid_timezone()` that ensures the application can gracefully handle unsupported or legacy timezone names returned by the system. It adds a fallback mechanism (currently mapping `"Asia/Beijing"` to `"Asia/Shanghai"`) to avoid crashes when the detected timezone is not present in the tzdata database.  
If the timezone is still invalid or an error occurs, the system falls back to `"UTC"`.

## Related Tickets & Documents

- Closes #2696 ([🐛 BUG] ZoneInfoNotFoundError: No time zone found with key Asia/Beijing)
- Related to #1894 (Gui fails to start if system timezone is not supported)

## How to reproduce the issue

1. Install Taipy:  
   `pip install taipy`
2. On a system with the `"Asia/Beijing"` timezone (e.g., some Linux distributions), create and run a file:
   ```python
   from taipy import Gui
   data = {"x": [1,2,3,4],"y":[10,20,30,40]}
   page = """
   <|{data}|chart|type=bar|x=x|y=y|>
   """
   Gui(page=page).run()
   ```
3. Observe the error:
   ```
   zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Asia/Beijing'
   ```

## Backporting
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.  
    If not, explain why: The change is a startup fallback with no external interface.
- [ ] 🔄 **End-to-End tests** have been added or updated.  
    If not, explain why: Manual testing in affected environments.
- [x] 📚 The **documentation** has been updated, or a dedicated issue has been created.  
    If not, explain why: Inline code comments provided.
- [ ] 📌 The **release notes** have been updated.  
    If not, explain why: Will be added after review.