### PR TITLE
do not check the plotly generated json

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -85,6 +85,7 @@ from .utils import (
     _hasscopeattr,
     _is_function,
     _is_in_notebook,
+    _is_plotly_figure,
     _is_unnamed_function,
     _LocalsContext,
     _MapDict,
@@ -97,6 +98,7 @@ from .utils import (
     _TaipyData,
     _TaipyLov,
     _TaipyLovValue,
+    _TaipyToJson,
     _to_camel_case,
     _variable_decode,
     is_debugging,
@@ -883,6 +885,7 @@ class Gui:
             if derived_modified is not None:
                 self.__send_var_list_update(list(derived_modified), var_name)
 
+
     def _get_real_var_name(self, var_name: str) -> t.Tuple[str, str]:
         if not var_name:
             return (var_name, var_name)
@@ -1187,6 +1190,7 @@ class Gui:
             ):  # type: ignore
                 newvalue = {"__taipy_refresh": True}
             else:
+                is_json = False
                 if isinstance(newvalue, (_TaipyContent, _TaipyContentImage)):
                     ret_value = self.__get_content_accessor().get_info(
                         t.cast(str, front_var), newvalue.get(), isinstance(newvalue, _TaipyContentImage)
@@ -1204,14 +1208,17 @@ class Gui:
                         newvalue.get_name(), newvalue.get(), id_only=isinstance(newvalue, _TaipyLovValue)
                     )
                 elif isinstance(newvalue, _TaipyBase):
+                    is_json = isinstance(newvalue, _TaipyToJson)
                     newvalue = newvalue.get()
                 # Skip in taipy-gui, available in custom frontend
                 if isinstance(newvalue, (dict, _MapDict)) and not _Hooks()._is_in_custom_page_context():
                     continue
+                if _is_plotly_figure(newvalue):
+                        continue
                 if isinstance(newvalue, float) and math.isnan(newvalue):
                     # do not let NaN go through json, it is not handle well (dies silently through websocket)
                     newvalue = None
-                if newvalue is not None and not isinstance(newvalue, str):
+                if newvalue is not None and not isinstance(newvalue, str) and not is_json:
                     debug_warnings: t.List[warnings.WarningMessage] = []
                     with warnings.catch_warnings(record=True) as warns:
                         warnings.resetwarnings()
@@ -2612,7 +2619,7 @@ class Gui:
         ):
             return _Hooks()._handle_custom_page_render(self, page_name, pr)
         # Handle page rendering
-        context = page.render(self)  # type: ignore[arg-type]
+        context = page.render(self)
         if (
             nav_page == Gui.__root_page_name
             and page._rendered_jsx is not None

--- a/taipy/gui/utils/__init__.py
+++ b/taipy/gui/utils/__init__.py
@@ -17,6 +17,7 @@ from ._attributes import (
     _setscopeattr,
     _setscopeattr_drill,
 )
+from ._check_plotly import _is_plotly_figure
 from ._lambda import _get_lambda_id
 from ._locals_context import _LocalsContext
 from ._map_dict import _MapDict

--- a/taipy/gui/utils/_check_plotly.py
+++ b/taipy/gui/utils/_check_plotly.py
@@ -1,0 +1,18 @@
+# Copyright 2021-2025 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+from taipy.common import _module_exists
+
+
+def _is_plotly_figure(obj) -> bool:
+    if _module_exists("plotly.graph_objs"):
+        from plotly.graph_objs import Figure as PlotlyFigure  # type: ignore[reportMissingImports]
+        return isinstance(obj, PlotlyFigure)
+    return False

--- a/taipy/gui/utils/types.py
+++ b/taipy/gui/utils/types.py
@@ -15,10 +15,8 @@ import typing as t
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-from taipy.common import _module_exists
-
 from .._warnings import _warn
-from . import _date_to_string, _MapDict, _string_to_date, _variable_decode
+from . import _date_to_string, _is_plotly_figure, _MapDict, _string_to_date, _variable_decode
 
 
 class _DoNotUpdate:
@@ -223,15 +221,12 @@ class _TaipyToJson(_TaipyBase):
         val = super().get()
         if not val:
             return None
-        if _module_exists("plotly.graph_objs"):
-            from plotly.graph_objs import Figure as PlotlyFigure  # type: ignore[reportMissingImports]
-
-            if isinstance(val, PlotlyFigure):
-                try:
-                    return [json.loads(val.to_json())]
-                except Exception as e:
-                    _warn("Issue while serializing Plotly Figure", e)
-                    return None
+        if _is_plotly_figure(val):
+            try:
+                return [json.loads(t.cast(str, val.to_json()))]
+            except Exception as e:
+                _warn("Issue while serializing Plotly Figure", e)
+                return None
         _warn("'figure' property value must be a plotly.graph_objects.Figure.")
         return None
 


### PR DESCRIPTION

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
do not check the plotly generated json
And do not send Plotly figures to the front-end

## Related Tickets & Documents
- Closes #2716


## How to reproduce the issue

```py
import pandas as pd
import plotly.express as px
import plotly.graph_objs as go
import requests
import taipy.gui.builder as tgb
from taipy.gui import Gui, State

counties = requests.get("https://raw.githubusercontent.com/plotly/datasets/master/geojson-counties-fips.json").json()

df = pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/fips-unemp-16.csv", dtype={"fips": str})


fig = px.choropleth(
    df,
    geojson=counties,
    locations="fips",
    color="unemp",
    color_continuous_scale="Viridis",
    range_color=(0, 12),
    scope="usa",
    labels={"unemp": "unemployment rate"},
)
fig.update_layout(margin={"r": 0, "t": 0, "l": 0, "b": 0})


def on_change(state: State, var_name: str, var_value):
    print(var_name, type(var_value))


def reset_fig(state):
    state.fig = go.Figure()
    state.fig = fig


with tgb.Page() as root_page:
    tgb.chart(figure="{fig}")
    tgb.button("Reset fig", on_action=reset_fig)

pages = {"/": root_page}

if __name__ == "__main__":
    gui = Gui(pages=pages)
    gui.run()

```

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [x] 4.1
- [ ] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
