### PR TITLE
fix: preserve unicode characters in uploaded filenames

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -32,7 +32,6 @@ from urllib.parse import unquote, urlencode, urlparse
 
 import markdown as md_lib
 import tzlocal
-from werkzeug.utils import secure_filename
 
 import __main__  # noqa: F401
 from taipy.common import _module_exists
@@ -89,6 +88,7 @@ from .utils import (
     _LocalsContext,
     _MapDict,
     _patch_value,
+    _secure_filename_unicode,
     _setscopeattr,
     _setscopeattr_drill,
     _TaipyBase,
@@ -1122,7 +1122,7 @@ class Gui:
             upload_path = Path(upload_path).resolve()
             os.makedirs(upload_path, exist_ok=True)
             # Save file into upload_path directory
-            file_path = _get_non_existent_file_path(upload_path, secure_filename(file.filename))
+            file_path = _get_non_existent_file_path(upload_path, _secure_filename_unicode(file.filename))
             self._server.save_uploaded_file(file, os.path.join(upload_path, (file_path.name + suffix)))
         else:
             _warn(f"upload files: Path {path} points outside of upload root.")

--- a/taipy/gui/utils/__init__.py
+++ b/taipy/gui/utils/__init__.py
@@ -29,7 +29,7 @@ from .clientvarname import _get_broadcast_var_name, _get_client_var_name, _to_ca
 from .datatype import _get_data_type
 from .date import _date_to_string, _string_to_date
 from .expr_var_name import _get_expr_var_name
-from .filename import _get_non_existent_file_path
+from .filename import _get_non_existent_file_path, _secure_filename_unicode
 from .filter_locals import _filter_locals
 from .get_imported_var import _get_imported_var
 from .get_module_name import _get_module_name_from_frame, _get_module_name_from_imported_var

--- a/taipy/gui/utils/filename.py
+++ b/taipy/gui/utils/filename.py
@@ -9,7 +9,35 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import os
+import re
+import unicodedata
 from pathlib import Path
+
+_WINDOWS_DEVICE_FILES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+}
 
 
 def _get_non_existent_file_path(dir_path: Path, file_name: str) -> Path:
@@ -23,3 +51,21 @@ def _get_non_existent_file_path(dir_path: Path, file_name: str) -> Path:
         file_path = dir_path / f"{file_stem}.{index}{file_suffix}"
         index += 1
     return file_path
+
+
+def _secure_filename_unicode(filename: str) -> str:
+    """Modified version that preserves Unicode characters"""
+    filename = unicodedata.normalize("NFKD", filename)
+
+    for sep in os.sep, os.path.altsep:
+        if sep:
+            filename = filename.replace(sep, " ")
+
+    filename = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "", filename)
+    filename = "_".join(filename.split()).strip("._")
+
+    # Windows device file check
+    if os.name == "nt" and filename and filename.split(".")[0].upper() in _WINDOWS_DEVICE_FILES:
+        filename = f"_{filename}"
+
+    return filename

--- a/taipy/gui/utils/filename.py
+++ b/taipy/gui/utils/filename.py
@@ -55,14 +55,22 @@ def _get_non_existent_file_path(dir_path: Path, file_name: str) -> Path:
 
 def _secure_filename_unicode(filename: str) -> str:
     """Modified version that preserves Unicode characters"""
-    filename = unicodedata.normalize("NFKD", filename)
+    filename = unicodedata.normalize("NFC", filename)
 
     for sep in os.sep, os.path.altsep:
         if sep:
             filename = filename.replace(sep, " ")
 
-    filename = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "", filename)
-    filename = "_".join(filename.split()).strip("._")
+    filename = re.sub(r'[<>:"/\\|?*\x00-\x1f\x7f]', "", filename)
+
+    # Replace all whitespace (including newlines, tabs) with spaces
+    filename = re.sub(r"\s+", " ", filename)
+
+    # Convert spaces to underscores and clean up multiple underscores
+    filename = re.sub(r"_+", "_", filename.replace(" ", "_"))
+
+    # Remove leading/trailing dots and underscores
+    filename = filename.strip("._")
 
     # Windows device file check
     if os.name == "nt" and filename and filename.split(".")[0].upper() in _WINDOWS_DEVICE_FILES:

--- a/taipy/gui/utils/filename.py
+++ b/taipy/gui/utils/filename.py
@@ -54,7 +54,28 @@ def _get_non_existent_file_path(dir_path: Path, file_name: str) -> Path:
 
 
 def _secure_filename_unicode(filename: str) -> str:
-    """Modified version that preserves Unicode characters"""
+    """
+    Sanitizes a filename for safe filesystem use while preserving Unicode characters.
+
+    This function removes or replaces characters that are invalid or unsafe for filenames,
+    normalizes Unicode characters, replaces path separators with spaces, and ensures
+    compatibility with Windows device filenames.
+
+    Parameters:
+        filename (str): The original filename to sanitize.
+
+    Returns:
+        str: The sanitized filename, safe for use on most filesystems. Returns an empty string
+        if the input is invalid or results in an empty filename after sanitization.
+
+    Important:
+        - Preserves Unicode characters using NFC normalization.
+        - Removes invalid characters (e.g., < > : " / \ | ? * and control characters).
+        - Replaces path separators with spaces.
+        - Converts whitespace to underscores and collapses multiple underscores.
+        - Strips leading/trailing dots and underscores.
+        - On Windows, prepends an underscore if the filename matches a reserved device name.
+    """
     filename = unicodedata.normalize("NFC", filename)
 
     for sep in os.sep, os.path.altsep:

--- a/taipy/gui/utils/filename.py
+++ b/taipy/gui/utils/filename.py
@@ -54,7 +54,7 @@ def _get_non_existent_file_path(dir_path: Path, file_name: str) -> Path:
 
 
 def _secure_filename_unicode(filename: str) -> str:
-    """
+    r"""
     Sanitizes a filename for safe filesystem use while preserving Unicode characters.
 
     This function removes or replaces characters that are invalid or unsafe for filenames,

--- a/tests/gui/utils/test_filename.py
+++ b/tests/gui/utils/test_filename.py
@@ -9,11 +9,14 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import os
 import pathlib
 import tempfile
 
+import pytest
+
 from taipy.gui import Gui
-from taipy.gui.utils import _get_non_existent_file_path
+from taipy.gui.utils import _get_non_existent_file_path, _secure_filename_unicode
 
 
 def test_empty_file_name(gui: Gui, helpers):
@@ -39,3 +42,120 @@ def test_existent_file(gui: Gui, helpers):
     assert file_path.exists()
     file_path = _get_non_existent_file_path(pathlib.Path(tempfile.gettempdir()), "")
     assert file_path.name == f"{file_stem}.{index + 2}{file_suffix}"
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output",
+    [
+        ("normal_file.txt", "normal_file.txt"),
+        ("file with spaces.txt", "file_with_spaces.txt"),
+        ("file.with.dots.txt", "file.with.dots.txt"),
+    ],
+)
+def test_secure_filename_unicode_valid_cases(gui: Gui, helpers, input_filename, expected_output):
+    """Test that valid filenames pass through unchanged"""
+    assert _secure_filename_unicode(input_filename) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output",
+    [
+        ('file<>:"/\\|?*.txt', "file_.txt"),
+        ("file<s>.txt", "files.txt"),
+        ("file:name.txt", "filename.txt"),
+        ('file"name".txt', "filename.txt"),
+        ("file/test\\file.txt", "file_testfile.txt"),
+        ("file\x00\x1f\x7f.txt", "file.txt"),
+    ],
+)
+def test_secure_filename_unicode_special_chars(gui: Gui, helpers, input_filename, expected_output):
+    """Test removal of forbidden and control characters"""
+    assert _secure_filename_unicode(input_filename) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output",
+    [
+        ("café.txt", "café.txt"),
+        ("naïve.txt", "naïve.txt"),
+        ("résumé.txt", "résumé.txt"),
+        ("测试文件.txt", "测试文件.txt"),
+        ("файл.txt", "файл.txt"),
+        ("café", "café"),
+        ("poup\u00e9e", "poupée"),
+        ("cafe\u0301", "café"),
+    ],
+)
+def test_secure_filename_unicode_preservation(gui: Gui, helpers, input_filename, expected_output):
+    """Test Unicode character preservation and normalization"""
+    assert _secure_filename_unicode(input_filename) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output",
+    [
+        ("  file  .txt  ", "file_.txt"),
+        ("file   with   spaces.txt", "file_with_spaces.txt"),
+        ("file\nwith\ttabs.txt", "filewithtabs.txt"),
+        ("..file.txt", "file.txt"),
+        ("file..txt", "file..txt"),
+        ("__file__.txt", "file_.txt"),
+        (".file_.txt", "file_.txt"),
+    ],
+)
+def test_secure_filename_unicode_whitespace_cleanup(gui: Gui, helpers, input_filename, expected_output):
+    """Test whitespace handling and leading/trailing character cleanup"""
+    assert _secure_filename_unicode(input_filename) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output",
+    [
+        ("", ""),
+        ("   ", ""),
+        ("...", ""),
+        ("___", ""),
+        ('<>:"/\\|?*', ""),
+    ],
+)
+def test_secure_filename_unicode_empty_cases(gui: Gui, helpers, input_filename, expected_output):
+    """Test edge cases that result in empty filenames"""
+    assert _secure_filename_unicode(input_filename) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output",
+    [
+        ("My Document (Final Version).pdf", "My_Document_(Final_Version).pdf"),
+        ("Report 2024: Q1 Results.xlsx", "Report_2024_Q1_Results.xlsx"),
+        ('User\'s File: "Important".docx', "User's_File_Important.docx"),
+        ("café & naïve résumé.pdf", "café_&_naïve_résumé.pdf"),
+    ],
+)
+def test_secure_filename_unicode_real_world_cases(gui: Gui, helpers, input_filename, expected_output):
+    """Test realistic filename scenarios with mixed issues"""
+    assert _secure_filename_unicode(input_filename) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_filename,expected_output_windows,expected_output_non_windows",
+    [
+        ("CON.txt", "_CON.txt", "CON.txt"),
+        ("PRN.txt", "_PRN.txt", "PRN.txt"),
+        ("AUX.txt", "_AUX.txt", "AUX.txt"),
+        ("NUL.txt", "_NUL.txt", "NUL.txt"),
+        ("COM1.txt", "_COM1.txt", "COM1.txt"),
+        ("LPT1.txt", "_LPT1.txt", "LPT1.txt"),
+        ("con.txt", "_con.txt", "con.txt"),
+        ("Con.Txt", "_Con.Txt", "Con.Txt"),
+    ],
+)
+def test_secure_filename_unicode_windows_device_files(
+    gui: Gui, helpers, input_filename, expected_output_windows, expected_output_non_windows
+):
+    """Test Windows device file handling (platform-specific)"""
+
+    if os.name == "nt":
+        assert _secure_filename_unicode(input_filename) == expected_output_windows
+    else:
+        assert _secure_filename_unicode(input_filename) == expected_output_non_windows

--- a/tests/gui/utils/test_filename.py
+++ b/tests/gui/utils/test_filename.py
@@ -64,7 +64,7 @@ def test_secure_filename_unicode_valid_cases(gui: Gui, helpers, input_filename, 
         ("file<s>.txt", "files.txt"),
         ("file:name.txt", "filename.txt"),
         ('file"name".txt', "filename.txt"),
-        ("file/test\\file.txt", "file_testfile.txt"),
+        ("file|name.txt", "filename.txt"),
         ("file\x00\x1f\x7f.txt", "file.txt"),
     ],
 )


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
This PR fixes the bug reported in #2720.
The issue was caused by the use of `secure_filename` from` werkzeug.utils`, which converts all characters to ASCII
I created a new helper function called `_secure_filename_unicode`, inspired by Werkzeug’s implementation but adapted to preserve Unicode characters while maintaining the same level of security.

## Related Tickets & Documents
- Closes  #2720 

<!--
For pull requests that relate to or close an issue, please include them below.
Following [GitHub's guidance on linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) helps with automation.



## How to reproduce the issue
Already exists in # #2720 

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [X] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [X] ✅ This solution meets the acceptance criteria of the related issue.
- [X] 📝 The related issue checklist is completed.
- [X] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
