### PR TITLE
changed the row hover visibility

### DIFF
--- a/frontend/taipy-gui/public/stylekit/controls/table.css
+++ b/frontend/taipy-gui/public/stylekit/controls/table.css
@@ -48,6 +48,40 @@
   font-weight: bold;
 }
 
+
+.MuiTableRow-root.Mui-selected td {
+    background: color-mix(in srgb, var(--color-primary) 5%, transparent);
+    box-shadow: inset 0 2px 4px color-mix(in srgb, var(--color-primary) 10%, transparent),
+                inset 0 -2px 4px color-mix(in srgb, var(--color-primary) 10%, transparent);
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.MuiTableRow-root.Mui-selected:hover td {
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+    box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-primary) 20%, transparent),
+                inset 0 -2px 6px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.MuiTableRow-root.Mui-selected td:first-child {
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+    box-shadow: inset 3px 0 0 0 var(--color-primary),
+                inset 0 2px 4px color-mix(in srgb, var(--color-primary) 10%, transparent),
+                inset 0 -2px 4px color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+.MuiTableRow-root.Mui-selected:hover td:first-child {
+    box-shadow: inset 3px 0 0 0 var(--color-primary),
+                inset 0 2px 6px color-mix(in srgb, var(--color-primary) 20%, transparent),
+                inset 0 -2px 6px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.MuiTableRow-root.Mui-selected td:last-child {
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+}
+
+
 /* No borders on rows as Stylekit default */
 /* "rows-bordered" class to return to MUI default rows with borders */
 .taipy-table:where(:not(.rows-bordered)) thead th,

--- a/frontend/taipy-gui/src/themes/stylekit.ts
+++ b/frontend/taipy-gui/src/themes/stylekit.ts
@@ -164,6 +164,23 @@ export const stylekitTheme = () => ({
                 },
             },
         },
+
+        MuiTableRow: {
+            styleOverrides: {
+                root: {
+                    "&:hover": {
+                        backgroundColor: "rgba(0, 0, 0, 0.08)",
+                    },
+                    "&.Mui-selected": {
+                        backgroundColor: "rgba(245, 197, 197, 0.86)", // Selected color
+                    },
+                    "&.Mui-selected:hover": {
+                        backgroundColor: "rgba(234, 140, 140, 0.8)", // Selected + hover color
+                    },
+                },
+            },
+        },
+
     },
 });
 


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
Enhanced the visual feedback for table row interactions by increasing the color intensity of hover and selected states.

### File Modified
`stylekitTheme.js` 

### Code Added
Added `MuiTableRow` component styling to the theme configuration:
```javascript
MuiTableRow: {
    styleOverrides: {
        root: {
            "&:hover": {
                backgroundColor: "rgba(0, 0, 0, 0.08)",
            },
            "&.Mui-selected": {
                backgroundColor: "rgba(245, 197, 197, 0.86)",
            },
            "&.Mui-selected:hover": {
                backgroundColor: "rgba(234, 140, 140, 0.8)",
            },
        },
    },
},
```

#### BEFORE
<img width="378" height="402" alt="before" src="https://github.com/user-attachments/assets/a2141c7f-52d0-47e6-8bd0-041113a3272e" />


#### AFTER
<img width="422" height="313" alt="after" src="https://github.com/user-attachments/assets/86ccb8aa-9a00-4333-b523-2f889d1d0f93" />


## Related Tickets & Documents

- Related to #2609 

## How to reproduce the issue
create a file `table.py` in the root directory and run this.
```python
# table_test.py in root directory
import taipy.gui.builder as tgb
from taipy import Gui

data = {"a": [1, 2, 3, 4, 5], "b": [5, 4, 3, 2, 1]}

selected = [0]

def num_on_action(state, var_name, payload):
    index = payload.get("index")
    if index in state.selected:
        state.selected = list(set(state.selected) - {index})
    else:
        state.selected = state.selected + [index]

with tgb.Page() as page:
    tgb.toggle(theme=True)
    
    tgb.text("## Table Without Custom Classes")
    tgb.table("{data}", selected="{selected}", on_action=num_on_action)
    
    tgb.text("## Table With rows-similar rows-bordered")
    tgb.table("{data}", selected="{selected}", on_action=num_on_action, 
              class_name="rows-similar rows-bordered")

if __name__ == "__main__":
    gui = Gui(page=page)
    gui.run(port=5000, debug=True, use_reloader=True)
```
you can now select the row and hover over the unselected row, the difference is a lot more visible now.

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [ ] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:

