### PR TITLE
fix(docs): correct internal link for Contributing section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ No more compromises on performance, customization, and scalability.
 - [Taipy and its ecosystem](#-taipy-and-taipy-ecosystem)
 - [Quickstart](#-quickstart)
 - [Documentation and resources](#-documentation-and-resources)
-- [Contributing](#-contributing)
+- [Contributing](#contributing)
 - [Code of Conduct](#-code-of-conduct)
 - [License](#-license)
 
@@ -129,7 +129,7 @@ It includes
 [API references](https://docs.taipy.io/en/latest/refmans/), and
 [Galleries](https://docs.taipy.io/en/latest/gallery/).
 
-## ⚒️ Contributing
+## ⚒️ Contributing <a id="contributing"></a>
 
 Want to help build Taipy? Check out our [**Contributing Guide**](https://github.com/Avaiga/taipy/blob/develop/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ No more compromises on performance, customization, and scalability.
 - [Taipy and its ecosystem](#-taipy-and-taipy-ecosystem)
 - [Quickstart](#-quickstart)
 - [Documentation and resources](#-documentation-and-resources)
-- [Contributing](#contributing)
+- [Contributing](#-contributing)
 - [Code of Conduct](#-code-of-conduct)
 - [License](#-license)
 
@@ -129,7 +129,7 @@ It includes
 [API references](https://docs.taipy.io/en/latest/refmans/), and
 [Galleries](https://docs.taipy.io/en/latest/gallery/).
 
-## ⚒️ Contributing <a id="contributing"></a>
+## ⚒️ Contributing <a id="-contributing"></a>
 
 Want to help build Taipy? Check out our [**Contributing Guide**](https://github.com/Avaiga/taipy/blob/develop/CONTRIBUTING.md).
 


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [x] 📝 Documentation Update

## Description
Summary
This PR fixes the broken "Contributing" link in the README’s Table of Contents.
The issue occurred because the emoji (⚒️) in the section heading introduced a hidden Unicode variation selector, causing GitHub to generate an encoded anchor (#%EF%B8%8F-contributing) that didn’t match the Markdown link.

Changes Made
- Updated the ## ⚒️ Contributing heading to include a stable custom ID (<a id="contributing"></a>).
- Updated the Table of Contents link to use #contributing for consistent behavior across Markdown renderers.
- Verified that all ToC links now work correctly on GitHub.

## Related Tickets & Documents

- Closes #2739 

## How to reproduce the issue

- Open the main README.md file on GitHub.
- Click on the “Contributing” entry in the Table of Contents.
Observe that the link fails to scroll to the corresponding section.

## Backporting
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [ x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [ x] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why: documentation pr, hence unit test not required
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why: documentation pr, hence E2E test not required
- [x] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why: documentation pr, hence update to release notes not required
