### PR TITLE
feat: Add multiline support to Chat component

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chat.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.spec.tsx
@@ -54,7 +54,7 @@ describe("Chat Component", () => {
         const elt = getByText(searchMsg);
         expect(elt.tagName).toBe("DIV");
         const input = getByLabelText("message (taipy)");
-        expect(input.tagName).toBe("INPUT");
+        expect(input.tagName).toBe("TEXTAREA");
     });
     it("uses the class", async () => {
         const { getByText } = render(
@@ -240,5 +240,86 @@ describe("Chat Component", () => {
             expect(() => getByAltText("Image preview")).toThrow();
         });
         jest.restoreAllMocks();
+    });
+    it("inserts newline on Ctrl+Enter", async () => {
+        const { getByLabelText } = render(<Chat messages={messages} defaultKey={valueKey} mode="raw" />);
+        const elt = getByLabelText("message (taipy)") as HTMLTextAreaElement;
+        await userEvent.click(elt);
+        await userEvent.keyboard("Hello");
+        await userEvent.keyboard("{Control>}{Enter}{/Control}");
+        expect(elt.value).toBe("Hello\n");
+        expect(elt.selectionStart).toBe(6);
+        expect(elt.selectionEnd).toBe(6);
+    });
+    it("inserts newline on Cmd+Enter (Mac)", async () => {
+        const { getByLabelText } = render(<Chat messages={messages} defaultKey={valueKey} mode="raw" />);
+        const elt = getByLabelText("message (taipy)") as HTMLTextAreaElement;
+        await userEvent.click(elt);
+        await userEvent.keyboard("Hello");
+        await userEvent.keyboard("{Meta>}{Enter}{/Meta}");
+        expect(elt.value).toBe("Hello\n");
+        expect(elt.selectionStart).toBe(6);
+        expect(elt.selectionEnd).toBe(6);
+    });
+    it("allows multiple newlines with Ctrl+Enter", async () => {
+        const { getByLabelText } = render(<Chat messages={messages} defaultKey={valueKey} mode="raw" />);
+        const elt = getByLabelText("message (taipy)") as HTMLTextAreaElement;
+        await userEvent.click(elt);
+        await userEvent.keyboard("Line 1");
+        await userEvent.keyboard("{Control>}{Enter}{/Control}");
+        await userEvent.keyboard("Line 2");
+        await userEvent.keyboard("{Control>}{Enter}{/Control}");
+        await userEvent.keyboard("Line 3");
+        expect(elt.value).toBe("Line 1\nLine 2\nLine 3");
+    });
+    it("still sends message on Enter (backwards compatibility)", async () => {
+        const dispatch = jest.fn();
+        const state: TaipyState = INITIAL_STATE;
+        const { getByLabelText } = render(
+            <TaipyContext.Provider value={{ state, dispatch }}>
+                <Chat messages={messages} updateVarName="varName" defaultKey={valueKey} mode="raw" />
+            </TaipyContext.Provider>
+        );
+        const elt = getByLabelText("message (taipy)") as HTMLTextAreaElement;
+        await userEvent.click(elt);
+        await userEvent.keyboard("test message{Enter}");
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "SEND_ACTION_ACTION",
+            name: "",
+            context: undefined,
+            payload: {
+                action: undefined,
+                args: ["Enter", "varName", "test message", "taipy", null],
+            },
+        });
+    });
+    it("preserves newlines in message display", async () => {
+        const messagesWithNewlines: TableValueType = {
+            [valueKey]: {
+                data: [
+                    ["1", "Line 1\nLine 2\nLine 3", "Fred"],
+                ],
+                rowcount: 1,
+                start: 0,
+            },
+        };
+        const { getByText } = render(<Chat messages={messagesWithNewlines} defaultKey={valueKey} mode="raw" />);
+        const messageElement = getByText((content, element) => {
+            return element?.textContent === "Line 1\nLine 2\nLine 3";
+        });
+        expect(messageElement).toBeInTheDocument();
+    });
+    it("handles newlines in markdown mode", async () => {
+        const messagesWithNewlines: TableValueType = {
+            [valueKey]: {
+                data: [
+                    ["1", "Line 1\nLine 2\nLine 3", "Fred"],
+                ],
+                rowcount: 1,
+                start: 0,
+            },
+        };
+        const { container } = render(<Chat messages={messagesWithNewlines} defaultKey={valueKey} mode="markdown" />);
+        expect(container).toBeInTheDocument();
     });
 });

--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -194,7 +194,7 @@ const ChatRow = (props: ChatRowProps) => {
                                 ) : mode == "raw" ? (
                                     message
                                 ) : (
-                                    <Markdown>{message}</Markdown>
+                                    <Markdown>{message.replace(/\n/g, '  \n')}</Markdown>
                                 )}
                             </Paper>
                         </Stack>
@@ -211,7 +211,7 @@ const ChatRow = (props: ChatRowProps) => {
                         ) : mode == "raw" ? (
                             message
                         ) : (
-                            <Markdown>{message}</Markdown>
+                            <Markdown>{message.replace(/\n/g, '  \n')}</Markdown>
                         )}
                     </Paper>
                 )}
@@ -275,10 +275,10 @@ const Chat = (props: ChatProps) => {
         [props.height]
     );
 
-    const onChangeHandler = useCallback((evt: ChangeEvent<HTMLInputElement>) => setEnableSend(!!evt.target.value), []);
+    const onChangeHandler = useCallback((evt: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setEnableSend(!!evt.target.value), []);
 
     const sendAction = useCallback(
-        (elt: HTMLInputElement | null | undefined, reason: string) => {
+        (elt: HTMLInputElement | HTMLTextAreaElement | null | undefined, reason: string) => {
             if (elt && (elt?.value || imagePreview)) {
                 toDataUrl(imagePreview)
                     .then((dataUrl) => {
@@ -310,9 +310,22 @@ const Chat = (props: ChatProps) => {
 
     const handleAction = useCallback(
         (evt: KeyboardEvent<HTMLDivElement>) => {
-            if (!evt.shiftKey && !evt.ctrlKey && !evt.altKey && ENTER_KEY == evt.key) {
-                sendAction(evt.currentTarget.querySelector("input"), evt.key);
-                evt.preventDefault();
+            if (ENTER_KEY == evt.key) {
+                if (evt.ctrlKey || evt.metaKey) {
+                    const textarea = evt.currentTarget.querySelector("textarea") as HTMLTextAreaElement;
+                    if (textarea) {
+                        const start = textarea.selectionStart;
+                        const end = textarea.selectionEnd;
+                        const value = textarea.value;
+                        textarea.value = value.substring(0, start) + '\n' + value.substring(end);
+                        textarea.setSelectionRange(start + 1, start + 1);
+                        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+                    }
+                    evt.preventDefault();
+                } else {
+                    sendAction(evt.currentTarget.querySelector("textarea"), evt.key);
+                    evt.preventDefault();
+                }
             }
         },
         [sendAction]
@@ -320,7 +333,7 @@ const Chat = (props: ChatProps) => {
 
     const handleClick = useCallback(
         (evt: MouseEvent<HTMLButtonElement>) => {
-            sendAction(evt.currentTarget.parentElement?.parentElement?.querySelector("input"), "click");
+            sendAction(evt.currentTarget.parentElement?.parentElement?.querySelector("textarea"), "click");
             evt.preventDefault();
         },
         [sendAction]
@@ -569,6 +582,9 @@ const Chat = (props: ChatProps) => {
                         <TextField
                             margin="dense"
                             fullWidth
+                            multiline
+                            minRows={1}
+                            maxRows={4}
                             onChange={onChangeHandler}
                             className={getSuffixedClassNames(className, "-input")}
                             label={`message (${senderId})`}


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description

Fixes #2579 by adding multiline support to the Chat component.

The new behavior is that Ctrl+Enter or Cmd+Enter inserts a newline at the point of selection, while Enter still sends the message (for backwards compatibility). The newlines are also preserved in the rendered chat messages, and test cases have been added for the new feature.

<img width="1664" height="403" alt="Screenshot 2025-10-22 at 23 19 49" src="https://github.com/user-attachments/assets/2c12db60-416c-42be-8a18-82eab6a28503" />

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them below.
Following [GitHub's guidance on linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) helps with automation.

Example:
- Closes #1234
- Related to #5678
-->

- Closes #2579

## How to reproduce the issue

Here's a very simple interface which I've used for testing:

```
from taipy.gui import Gui
import taipy.gui.builder as tgb

messages = []

def evaluate(state, var_name: str, payload: dict):
    args = payload.get("args", [])
    if len(args) >= 4:
        reason, varName, text, senderId, imageData = args[0], args[1], args[2], args[3], args[4] if len(args) > 4 else None
        state.messages.append([f"{len(state.messages)}", text, senderId])
        response = f"You said: {text}"
        state.messages.append([f"{len(state.messages)}", response, "AI"])
        state.messages = state.messages


with tgb.Page() as page_home:
    tgb.chat(
        messages="{messages}",
        on_action=evaluate,
        height="80vh",
    )

gui = Gui(page=page_home)
gui.run(debug=True, use_reloader=True, port=5002)
```

Run this script! Then type some text, press Ctrl+Enter or Cmd+Enter on a Mac, and verify that a newline is being inserted at cursor position. Enter should still send the chat message, and it will be echoed with the newlines preserved. Copypasting some text with newlines present in it should work as well.

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why: _covered in unit tests_
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why: _unsure where this would be covered, but I can update the relevant docs :)_
- [ ] 📌 The **release notes** have been updated.
    If not, explain why: _l believe this is done by a maintainer later on?_
