### PR TITLE
feat: Allow resetting sort for taipy tables

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/AutoLoadingTable.tsx
@@ -258,9 +258,20 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
         (e: MouseEvent<HTMLElement>) => {
             const col = e.currentTarget.getAttribute("data-dfid");
             if (col) {
-                const isAsc = orderBy === col && order === "asc";
-                setOrder(isAsc ? "desc" : "asc");
-                setOrderBy(col);
+                if (orderBy === col) {
+                    if (order === "asc") {
+                        // asc -> desc
+                        setOrder("desc");
+                    } else {
+                        // desc -> unsorted
+                        setOrderBy("");
+                        setOrder("asc");
+                    }
+                } else {
+                    // unsorted -> asc
+                    setOrder("asc");
+                    setOrderBy(col);
+                }
                 setRows([]);
                 Promise.resolve().then(() => infiniteLoaderRef.current?.resetloadMoreItemsCache(true)); // So that the state can be changed
             }

--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.spec.tsx
@@ -846,4 +846,22 @@ describe("PaginatedTable Component", () => {
         // Clean up the spy
         logSpy.mockRestore();
     });
+    it("should cycle through three-state sorting: unsorted -> asc -> desc -> unsorted", async () => {
+        await waitFor(() => {
+            render(<PaginatedTable data={tableValue} defaultColumns={tableColumns} />);
+        });
+        const elt = document.querySelector('svg[data-testid="ArrowDownwardIcon"]');
+        act(() => {
+            fireEvent.click(elt as Element);
+        });
+        expect(document.querySelector('th[aria-sort="ascending"]')).toBeInTheDocument();
+        act(() => {
+            fireEvent.click(elt as Element);
+        });
+        expect(document.querySelector('th[aria-sort="descending"]')).toBeInTheDocument();
+        act(() => {
+            fireEvent.click(elt as Element);
+        });
+        expect(document.querySelector('th[aria-sort]')).not.toBeInTheDocument();
+    });
 });

--- a/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/PaginatedTable.tsx
@@ -393,9 +393,20 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
         (e: MouseEvent<HTMLElement>) => {
             const col = e.currentTarget.getAttribute("data-dfid");
             if (col) {
-                const isAsc = orderBy === col && order === "asc";
-                setOrder(isAsc ? "desc" : "asc");
-                setOrderBy(col);
+                if (orderBy === col) {
+                    if (order === "asc") {
+                        // asc -> desc
+                        setOrder("desc");
+                    } else {
+                        // desc -> unsorted
+                        setOrderBy("");
+                        setOrder("asc");
+                    }
+                } else {
+                    // unsorted -> asc
+                    setOrder("asc");
+                    setOrderBy(col);
+                }
             }
         },
         [orderBy, order]


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
<!-- Provide a clear and concise description of the changes introduced in this PR. -->

Lets users cycle through sorting states in tables: `unsorted → ascending → descending → unsorted`. Previously, choosing to sort a table "locked you in" to either ascending or descending sorting until the page was refreshed.

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them below.
Following [GitHub's guidance on linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) helps with automation.

Example:
- Closes #1234
- Related to #5678
-->

- Closes #2607

## How to reproduce the issue

By using the example code from the original issue :)

```
import taipy.gui.builder as tgb
from taipy import Gui

data = {"Sentence": "Eddie ate dynamite, good bye Eddie".split(" ")}

with tgb.Page() as page:
    tgb.table("{data}")

if __name__ == "__main__":
    Gui(page=page).run()
```

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why: _simple feature_
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why: _simple feature_
- [ ] 📌 The **release notes** have been updated.
    If not, explain why: _done by maintainers?_
