### PR TITLE
doc: Improve documentation for decimation on datetime axis

### DIFF
--- a/doc/gui/examples/charts/datetime_decimation.py
+++ b/doc/gui/examples/charts/datetime_decimation.py
@@ -1,0 +1,65 @@
+# Copyright 2021-2025 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+# -----------------------------------------------------------------------------------------
+# To execute this script, make sure that the taipy-gui package is installed in your
+# Python environment and run:
+#     python <script>
+# -----------------------------------------------------------------------------------------
+"""
+Example demonstrating proper use of decimators with datetime data.
+
+This example shows how to handle datetime data with MinMaxDecimator by using
+numeric x-axis values while keeping datetime information separate.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+
+import taipy.gui.builder as tgb
+from taipy.gui import Gui
+from taipy.gui.data.decimator import MinMaxDecimator
+
+# Create sample datetime data
+x_values = np.linspace(1, 100, 50000)
+y_values = np.log(x_values) * np.sin(x_values / 5)
+noise_mask = np.random.rand(*y_values.shape) < 0.01
+noise_values = np.random.uniform(-0.5, 0.5, size=np.sum(noise_mask))
+y_values_noise = np.copy(y_values)
+y_values_noise[noise_mask] += noise_values
+
+# How to decimate datetime data? - Structure data for decimation algorithm:
+# Column 0: Numeric values for decimation algorithm (data[:, 0])
+# Column 1: Y values (data[:, 1])
+# Column 2: DateTime values for x-axis display (data[:, 2])
+start_time = datetime.now()
+timestamps = [start_time + pd.Timedelta(seconds=x) for x in x_values]
+
+data = pd.DataFrame({"X_numeric": x_values, "Y": y_values_noise, "X_datetime": timestamps})
+
+decimator = MinMaxDecimator(200)
+
+if __name__ == "__main__":
+    with tgb.Page() as page:
+        tgb.chart(
+            "{data}",
+            type="markers",
+            x="X_datetime",  # Show datetime on x-axis
+            y="Y",
+            decimator=decimator,
+        )
+
+        tgb.text("Data Preview")
+        tgb.table("{data.head(10)}")
+
+    gui = Gui(page=page)
+    gui.run(port=5010, title="Chart - DateTime Decimation")


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [x] 📝 Documentation Update

## Description
<!-- Provide a clear and concise description of the changes introduced in this PR. -->

Adds an example of decimating data where we want to display a datetime axis. The idea is that the `MinMaxDecimator` [takes the first and second column of the dataframe](https://github.com/Avaiga/taipy/blob/develop/taipy/gui/data/decimator/minmax.py) as `x` and `y` axes:

```
x = data[:, 0]
y = data[:, 1]
```

But it's possible to just set a different column as X axis marks. (Please correct me if my understanding isn't correct :)

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them below.
Following [GitHub's guidance on linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) helps with automation.

Example:
- Closes #1234
- Related to #5678
-->

- Closes #2285.

## How to reproduce the issue

<!-- Provide step-by-step instructions to reproduce the issue or test the feature. -->

N/A - it's just a docs update, but feel free to run the included example file as well.

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why: _docs only_
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why: _docs only_
- [x] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why: _handled by maintainers?_
