### PR TITLE
Bug/#2756 number min max enforce

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -55,6 +55,7 @@ const verticalDivStyle: CSSProperties = {
 const noPaddingYSx = { py: 0 };
 
 const Input = (props: TaipyInputProps) => {
+  
     const {
         type,
         id,
@@ -70,6 +71,7 @@ const Input = (props: TaipyInputProps) => {
     } = props;
 
     const [value, setValue] = useState(defaultValue);
+    
     const dispatch = useDispatch();
     const delayCall = useRef(-1);
     const [actionKeys] = useState(() => getActionKeys(props.actionKeys));
@@ -354,6 +356,7 @@ const Input = (props: TaipyInputProps) => {
     );
 
     useEffect(() => {
+     
         if (props.value !== undefined) {
             setValue(props.value);
         }
@@ -366,7 +369,15 @@ const Input = (props: TaipyInputProps) => {
                     sx={textSx}
                     margin="dense"
                     hiddenLabel
-                    value={value ?? ""}
+                    value={
+                        type === "number"
+                            ? (min !== undefined && Number(value) < min
+                                  ? min
+                                  : max !== undefined && Number(value) > max
+                                  ? max
+                                  : value)
+                            : value ?? ""
+                    }
                     className={`${className} ${getComponentClassName(props.children)}`}
                     type={showPassword && type == "password" ? "text" : type}
                     id={id}

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -168,7 +168,7 @@ const Input = (props: TaipyInputProps) => {
                     : multiline
                     ? evt.currentTarget.value
                     : evt.currentTarget.value;
-            // Always dispatch on blur within delay
+            // Always dispatch on blur within the delay
             if (delayCall.current > 0 || changeDelay === -1 || delayCall.current === -1) {
                 if (changeDelay > 0) {
                     clearTimeout(delayCall.current);

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -19,7 +19,6 @@ import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-
 import { createSendActionNameAction, createSendUpdateAction } from "../../context/taipyReducers";
 import { getCssSize, TaipyInputProps } from "./utils";
 import { useClassNames, useDispatch, useDynamicProperty, useModule } from "../../utils/hooks";
@@ -65,12 +64,11 @@ const Input = (props: TaipyInputProps) => {
         onAction,
         onChange,
         multiline = false,
-        actionOnBlur = false,
+        actionOnBlur = true,
         linesShown = 5,
         size = "medium",
     } = props;
-
-    const [value, setValue] = useState(defaultValue);
+    
     
     const dispatch = useDispatch();
     const delayCall = useRef(-1);
@@ -85,6 +83,21 @@ const Input = (props: TaipyInputProps) => {
     const stepMultiplier = useDynamicProperty(props.stepMultiplier, props.defaultStepMultiplier, 10);
     const min = useDynamicProperty(props.min, props.defaultMin, undefined);
     const max = useDynamicProperty(props.max, props.defaultMax, undefined);
+    const initializedDefaultValue = () => {
+        const initVal = 
+                type === "number"
+                    ? (min !== undefined && Number(defaultValue) < min
+                    ? min
+                    : max !== undefined && Number(defaultValue) > max
+                    ? max
+                    : defaultValue)
+                    : multiline
+                    ? defaultValue
+                    : defaultValue;
+        return initVal;
+    }
+    const initDefaultValue = initializedDefaultValue();
+    const [value, setValue] = useState(initDefaultValue);
 
     const textSx = useMemo(
         () =>
@@ -155,7 +168,8 @@ const Input = (props: TaipyInputProps) => {
                     : multiline
                     ? evt.currentTarget.value
                     : evt.currentTarget.value;
-            if (delayCall.current > 0 || changeDelay === -1) {
+            // Always dispatch on blur within delay
+            if (delayCall.current > 0 || changeDelay === -1 || delayCall.current === -1) {
                 if (changeDelay > 0) {
                     clearTimeout(delayCall.current);
                     delayCall.current = -1;
@@ -195,7 +209,7 @@ const Input = (props: TaipyInputProps) => {
                     updateValueWithDelay(val);
                     evt.preventDefault();
                 }
-            } else if (!evt.shiftKey && !evt.ctrlKey && !evt.altKey && actionKeys.includes(evt.key)) {
+            } else if (!evt.shiftKey && !evt.ctrlKey && !evt.altKey && actionKeys.includes(evt.key) ) {
                 const val = multiline
                     ? evt.currentTarget.querySelector("textarea")?.value
                     : evt.currentTarget.querySelector("input")?.value;
@@ -249,7 +263,7 @@ const Input = (props: TaipyInputProps) => {
         (event: React.MouseEvent<HTMLButtonElement>, increment: boolean) => {
             setValue((prevValue) => {
                 const newValue = calculateNewValue(
-                    prevValue,
+                    prevValue.toString(),
                     step || 1,
                     stepMultiplier || 10,
                     event.shiftKey,
@@ -373,16 +387,7 @@ const Input = (props: TaipyInputProps) => {
                     sx={textSx}
                     margin="dense"
                     hiddenLabel
-                    value={
-                        type === "number"
-                            ? (min !== undefined && Number(value) < min
-                                  ? min
-                                  : max !== undefined && Number(value) > max
-                                  ? max
-                                  : value)
-                            : value ?? ""
-                    }
-           
+                    value={value}
                     className={`${className} ${getComponentClassName(props.children)}`}
                     type={showPassword && type == "password" ? "text" : type}
                     id={id}

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -145,9 +145,13 @@ const Input = (props: TaipyInputProps) => {
 
     const handleBlur = useCallback(
         (evt: React.FocusEvent<HTMLInputElement>) => {
-            const val =
+            const val = 
                 type === "number"
-                    ? Number(evt.currentTarget.value)
+                    ? (min !== undefined && Number(value) < min
+                    ? min
+                    : max !== undefined && Number(value) > max
+                    ? max
+                    : evt.currentTarget.value)
                     : multiline
                     ? evt.currentTarget.value
                     : evt.currentTarget.value;
@@ -164,7 +168,7 @@ const Input = (props: TaipyInputProps) => {
                 });
             evt.preventDefault();
         },
-        [dispatch, type, updateVarName, module, onChange, propagate, changeDelay, id, multiline, onAction]
+        [dispatch, type, updateVarName, module, onChange, propagate, changeDelay, id, multiline, onAction, max, min, value]
     );
 
     const handleAction = useCallback(
@@ -378,6 +382,7 @@ const Input = (props: TaipyInputProps) => {
                                   : value)
                             : value ?? ""
                     }
+           
                     className={`${className} ${getComponentClassName(props.children)}`}
                     type={showPassword && type == "password" ? "text" : type}
                     id={id}

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -414,7 +414,7 @@ const Input = (props: TaipyInputProps) => {
                     sx={textSx}
                     margin="dense"
                     hiddenLabel
-                    value={value}
+                    value={value ?? ""}
                     className={`${className} ${getComponentClassName(props.children)}`}
                     type={showPassword && type == "password" ? "text" : type}
                     id={id}

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -168,7 +168,7 @@ const Input = (props: TaipyInputProps) => {
                     : multiline
                     ? evt.currentTarget.value
                     : evt.currentTarget.value;
-            // Always dispatch on blur within the delay
+            // Always dispatch on blur within the time delay
             if (delayCall.current > 0 || changeDelay === -1 || delayCall.current === -1) {
                 if (changeDelay > 0) {
                     clearTimeout(delayCall.current);


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

* [ ] 🛠 Refactor
* [ ] ✨ Feature
* [x] 🐛 Bug Fix
* [ ] ⚡ Optimization
* [ ] 📝 Documentation Update

## Description

This PR ensures that the `tgb.number` control in Taipy GUI respects the `min` and `max` bounds **for both manual input and arrow step changes**. Previously, manually typing a value could bypass the `min`/`max` constraints. The fix clamps the value inside the allowed range and updates the state accordingly.

## Related Tickets & Documents

* Related Issue #2756
* Closes #2756

## How to reproduce the issue

1. Run the following code:

```python
import taipy.gui.builder as tgb
from taipy.gui import Gui, State

number = -2

def on_change(state: State, var_name: str, var_value):
    print(var_name, type(var_value), var_value)

with tgb.Page() as page:
    tgb.number("{number}", min=1, max=3.0)

Gui(page=page).run()
```

2. Manually type a value below 1 or above 3.
3. Observe that before this fix, the number could go below `min` or above `max`. Now it correctly clamps the value.

## Backporting

*This change should be backported to:*

* [ ] 3.0
* [ ] 3.1
* [ ] 4.0
* [x] develop

## Checklist

* [x] ✅ This solution meets the acceptance criteria of the related issue.
* [x] 📝 The related issue checklist is completed.
* [ ] 🧪 This PR does not include **unit tests** for the developed code since functionality requires react state updates. 
* [ ] 🔄 **End-to-End tests** have been added or updated.

  > Not required; behavior verified with existing manual GUI tests.
* [ ] 📚 The **documentation** has not been updated, however a dedicated issue has been created.

  > Updated code comments and type hints.
* [ ] 📌 The **release notes** have noy been updated.



