### PR TITLE
'number' control can force integer values

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Input.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.spec.tsx
@@ -28,30 +28,26 @@ describe("Input Component", () => {
     });
     it("displays the right info for string", async () => {
         const { getByDisplayValue } = render(
-            <Input value="toto" type="text" defaultValue="titi" className="taipy-input" />,
+            <Input value="toto" type="text" defaultValue="titi" className="taipy-input" />
         );
         const elt = getByDisplayValue("toto");
         expect(elt.parentElement?.parentElement).toHaveClass("taipy-input");
     });
     it("displays the default value", async () => {
         const { getByDisplayValue } = render(
-            <Input defaultValue="titi" value={undefined as unknown as string} type="text" />,
+            <Input defaultValue="titi" value={undefined as unknown as string} type="text" />
         );
         getByDisplayValue("titi");
     });
     it("displays with width=70%", async () => {
-        const { getByDisplayValue } = render(
-            <Input value="toto" type="text" defaultValue="titi" width="70%"/>
-        );
+        const { getByDisplayValue } = render(<Input value="toto" type="text" defaultValue="titi" width="70%" />);
         const element = getByDisplayValue("toto");
-        expect(element.parentElement?.parentElement).toHaveStyle('max-width: 70%');
+        expect(element.parentElement?.parentElement).toHaveStyle("max-width: 70%");
     });
     it("displays with width=500", async () => {
-        const { getByDisplayValue } = render(
-            <Input value="toto" type="text" defaultValue="titi" width={500}/>
-        );
+        const { getByDisplayValue } = render(<Input value="toto" type="text" defaultValue="titi" width={500} />);
         const element = getByDisplayValue("toto");
-        expect(element.parentElement?.parentElement).toHaveStyle('max-width: 500px');
+        expect(element.parentElement?.parentElement).toHaveStyle("max-width: 500px");
     });
     it("is disabled", async () => {
         const { getByDisplayValue } = render(<Input value="val" type="text" active={false} />);
@@ -68,7 +64,7 @@ describe("Input Component", () => {
         const elt = getByDisplayValue("val");
         expect(elt).not.toBeDisabled();
     });
-    it("applies correct size", async ()=> {
+    it("applies correct size", async () => {
         const { getByRole } = render(<Input value="val" type="text" size="small" />);
         const elt = getByRole("textbox");
         expect(elt).toBeInTheDocument();
@@ -80,7 +76,7 @@ describe("Input Component", () => {
         const { getByDisplayValue } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <Input value="Val" type="text" updateVarName="varname" />
-            </TaipyContext.Provider>,
+            </TaipyContext.Provider>
         );
         const elt = getByDisplayValue("Val");
         await userEvent.clear(elt);
@@ -98,7 +94,7 @@ describe("Input Component", () => {
         const { getByDisplayValue } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <Input value="Val" type="text" updateVarName="varname" onAction="on_action" />
-            </TaipyContext.Provider>,
+            </TaipyContext.Provider>
         );
         const elt = getByDisplayValue("Val");
         await userEvent.click(elt);
@@ -116,7 +112,7 @@ describe("Input Component", () => {
         const { getByDisplayValue } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <Input value="Val" type="text" updateVarName="varname" changeDelay={-1} />
-            </TaipyContext.Provider>,
+            </TaipyContext.Provider>
         );
         const elt = getByDisplayValue("Val");
         await userEvent.click(elt);
@@ -135,7 +131,7 @@ describe("Input Component", () => {
         const { getByDisplayValue } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <Input value="Val" type="text" updateVarName="varname" changeDelay={0} />
-            </TaipyContext.Provider>,
+            </TaipyContext.Provider>
         );
         const elt = getByDisplayValue("Val");
         await userEvent.click(elt);
@@ -154,7 +150,7 @@ describe("Input Component", () => {
         const { getByDisplayValue } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <Input value="Val" type="text" updateVarName="varname" onAction="on_action" />
-            </TaipyContext.Provider>,
+            </TaipyContext.Provider>
         );
         const elt = getByDisplayValue("Val");
         await userEvent.click(elt);
@@ -169,19 +165,19 @@ describe("Input Component", () => {
     });
     it("should display visibility off icon when password is visible", async () => {
         const { getByLabelText } = render(<Input value={"Test Input"} type="password" />);
-        const visibilityButton = getByLabelText("toggle password visibility");
+        const visibilityButton = getByLabelText("Toggle password visibility");
         fireEvent.click(visibilityButton);
         const visibilityIcon = document.querySelector('svg[data-testid="VisibilityOffIcon"]');
         expect(visibilityIcon).toBeInTheDocument();
     });
     it("should display visibility icon when password is hidden", async () => {
         const { getByLabelText } = render(<Input value={"Test Input"} type="password" />);
-        const visibilityButton = getByLabelText("toggle password visibility");
+        const visibilityButton = getByLabelText("Toggle password visibility");
         expect(visibilityButton).toBeInTheDocument();
     });
     it("should prevent default action when mouse down event occurs on password visibility button", async () => {
         const { getByLabelText } = render(<Input value={"Test Input"} type="password" />);
-        const visibilityButton = getByLabelText("toggle password visibility");
+        const visibilityButton = getByLabelText("Toggle password visibility");
         const keyDown = createEvent.mouseDown(visibilityButton);
         fireEvent(visibilityButton, keyDown);
         expect(keyDown.defaultPrevented).toBe(true);
@@ -202,14 +198,14 @@ describe("Number Component", () => {
     });
     it("displays the right info for string", async () => {
         const { getByDisplayValue } = render(
-            <Input value="12" type="number" defaultValue="1" className="taipy-number" />,
+            <Input value="12" type="number" defaultValue="1" className="taipy-number" />
         );
         const elt = getByDisplayValue(12);
         expect(elt.parentElement?.parentElement).toHaveClass("taipy-number");
     });
     it("displays the default value", async () => {
         const { getByDisplayValue } = render(
-            <Input defaultValue="1" value={undefined as unknown as string} type="number" />,
+            <Input defaultValue="1" value={undefined as unknown as string} type="number" />
         );
         getByDisplayValue("1");
     });
@@ -236,7 +232,7 @@ describe("Number Component", () => {
         const { getByDisplayValue } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <Input value={"33"} type="number" updateVarName="varname" />
-            </TaipyContext.Provider>,
+            </TaipyContext.Provider>
         );
         const elt = getByDisplayValue("33");
         await userEvent.clear(elt);
@@ -261,7 +257,7 @@ describe("Number Component", () => {
     });
     it("Validates increment by step value on up click", async () => {
         const { getByDisplayValue, getByLabelText } = render(
-            <Input id={"Test Input"} value={"0"} type="number" step={2} />,
+            <Input id={"Test Input"} value={"0"} type="number" step={2} />
         );
         const upSpinner = getByLabelText("Increment value");
         const elt = getByDisplayValue("0") as HTMLInputElement;
@@ -270,7 +266,7 @@ describe("Number Component", () => {
     });
     it("Validates decrement by step value on down click", async () => {
         const { getByDisplayValue, getByLabelText } = render(
-            <Input id={"Test Input"} value={"0"} type="number" step={2} />,
+            <Input id={"Test Input"} value={"0"} type="number" step={2} />
         );
         const downSpinner = getByLabelText("Decrement value");
         const elt = getByDisplayValue("0") as HTMLInputElement;
@@ -280,7 +276,7 @@ describe("Number Component", () => {
     it("Validates increment when holding shift key and clicking up", async () => {
         const user = userEvent.setup();
         const { getByDisplayValue, getByLabelText } = render(
-            <Input id={"Test Input"} value={"0"} type="number" step={2} />,
+            <Input id={"Test Input"} value={"0"} type="number" step={2} />
         );
         const upSpinner = getByLabelText("Increment value");
         const elt = getByDisplayValue("0") as HTMLInputElement;
@@ -291,7 +287,7 @@ describe("Number Component", () => {
     it("Validates decrement when holding shift key and clicking down", async () => {
         const user = userEvent.setup();
         const { getByDisplayValue, getByLabelText } = render(
-            <Input id={"Test Input"} value={"0"} type="number" step={2} />,
+            <Input id={"Test Input"} value={"0"} type="number" step={2} />
         );
         const downSpinner = getByLabelText("Decrement value");
         const elt = getByDisplayValue("0") as HTMLInputElement;
@@ -339,7 +335,7 @@ describe("Number Component", () => {
     });
     it("should not exceed max value when incrementing", async () => {
         const { getByLabelText } = render(
-            <Input id={"Test Input"} type="number" value="0" max={20} step={2} stepMultiplier={15} />,
+            <Input id={"Test Input"} type="number" value="0" max={20} step={2} stepMultiplier={15} />
         );
         const upSpinner = getByLabelText("Increment value");
         fireEvent.mouseDown(upSpinner, { shiftKey: true });

--- a/frontend/taipy-gui/src/components/Taipy/Input.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.spec.tsx
@@ -240,7 +240,7 @@ describe("Number Component", () => {
         await waitFor(() => expect(dispatch).toHaveBeenCalled());
         expect(dispatch).toHaveBeenLastCalledWith({
             name: "varname",
-            payload: { value: "666" },
+            payload: { value: 666 },
             propagate: true,
             type: "SEND_UPDATE_ACTION",
         });

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -95,10 +95,19 @@ const Input = (props: TaipyInputProps) => {
         [props.width]
     );
 
+    // 0 if value is not a number, 1 means general number, 2 means integer
+    const IS_INTEGER = 2;
+    const numberType = useMemo<number>(() => {
+        return type === "number" ? (props.integer === true ? 2 : 1) : 0;
+    }, [type, props.integer]);
+
     const updateValueWithDelay = useCallback(
         (value: number | string) => {
             if (changeDelay === -1) {
                 return;
+            }
+            if (numberType) {
+                value = numberType === IS_INTEGER ? Math.round(Number(value)) : Number(value);
             }
             if (changeDelay === 0) {
                 // Workaround using microtask to ensure the value is updated before the next action to avoid the bad setState behavior
@@ -115,19 +124,30 @@ const Input = (props: TaipyInputProps) => {
                 dispatch(createSendUpdateAction(updateVarName, value, module, onChange, propagate));
             }, changeDelay);
         },
-        [changeDelay, dispatch, updateVarName, module, onChange, propagate]
+        [changeDelay, numberType, dispatch, updateVarName, module, onChange, propagate]
     );
 
     const handleInput = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
             const val = e.target.value;
+            if (numberType === IS_INTEGER && !/^-?\d*$/.test(val)) {
+                return;
+            }
             setValue(val);
             if (changeDelay === -1) {
                 return;
             }
             if (changeDelay === 0) {
                 Promise.resolve().then(() => {
-                    dispatch(createSendUpdateAction(updateVarName, val, module, onChange, propagate));
+                    dispatch(
+                        createSendUpdateAction(
+                            updateVarName,
+                            numberType ? (numberType === IS_INTEGER ? Math.round(Number(val)) : Number(val)) : val,
+                            module,
+                            onChange,
+                            propagate
+                        )
+                    );
                 });
             }
             if (delayCall.current > 0) {
@@ -135,20 +155,35 @@ const Input = (props: TaipyInputProps) => {
             }
             delayCall.current = window.setTimeout(() => {
                 delayCall.current = -1;
-                dispatch(createSendUpdateAction(updateVarName, val, module, onChange, propagate));
+                dispatch(
+                    createSendUpdateAction(
+                        updateVarName,
+                        numberType ? (numberType === IS_INTEGER ? Math.round(Number(val)) : Number(val)) : val,
+                        module,
+                        onChange,
+                        propagate
+                    )
+                );
             }, changeDelay);
         },
-        [changeDelay, dispatch, updateVarName, module, onChange, propagate]
+        [changeDelay, numberType, dispatch, updateVarName, module, onChange, propagate]
     );
 
     const handleBlur = useCallback(
         (evt: React.FocusEvent<HTMLInputElement>) => {
-            const val =
-                type === "number"
-                    ? Number(evt.currentTarget.value)
-                    : multiline
-                    ? evt.currentTarget.value
-                    : evt.currentTarget.value;
+            let val = numberType
+                ? numberType === IS_INTEGER
+                    ? Math.round(Number(evt.currentTarget.value))
+                    : Number(evt.currentTarget.value)
+                : evt.currentTarget.value;
+            if (numberType) {
+                if (min !== undefined && (val as number) < min) {
+                    val = min;
+                }
+                if (max !== undefined && (val as number) > max) {
+                    val = max;
+                }
+            }
             if (delayCall.current > 0 || changeDelay === -1) {
                 if (changeDelay > 0) {
                     clearTimeout(delayCall.current);
@@ -162,12 +197,12 @@ const Input = (props: TaipyInputProps) => {
                 });
             evt.preventDefault();
         },
-        [dispatch, type, updateVarName, module, onChange, propagate, changeDelay, id, multiline, onAction]
+        [dispatch, numberType, updateVarName, module, onChange, propagate, changeDelay, id, onAction]
     );
 
     const handleAction = useCallback(
         (evt: KeyboardEvent<HTMLDivElement>) => {
-            if (evt.shiftKey && type === "number") {
+            if (evt.shiftKey && numberType) {
                 if (evt.key === "ArrowUp") {
                     let val =
                         Number(evt.currentTarget.querySelector("input")?.value || 0) +
@@ -192,7 +227,12 @@ const Input = (props: TaipyInputProps) => {
             } else if (!evt.shiftKey && !evt.ctrlKey && !evt.altKey && actionKeys.includes(evt.key)) {
                 const val = multiline
                     ? evt.currentTarget.querySelector("textarea")?.value
+                    : numberType
+                    ? numberType === IS_INTEGER
+                        ? Math.round(Number(evt.currentTarget.querySelector("input")?.value))
+                        : Number(evt.currentTarget.querySelector("input")?.value)
                     : evt.currentTarget.querySelector("input")?.value;
+
                 if (changeDelay > 0 && delayCall.current > 0) {
                     clearTimeout(delayCall.current);
                     delayCall.current = -1;
@@ -205,11 +245,12 @@ const Input = (props: TaipyInputProps) => {
             }
         },
         [
-            type,
+            numberType,
             multiline,
             actionKeys,
             step,
             stepMultiplier,
+            min,
             max,
             updateValueWithDelay,
             onAction,
@@ -217,7 +258,6 @@ const Input = (props: TaipyInputProps) => {
             id,
             module,
             updateVarName,
-            min,
             changeDelay,
             onChange,
             propagate,
@@ -328,7 +368,7 @@ const Input = (props: TaipyInputProps) => {
                       input: {
                           endAdornment: (
                               <IconButton
-                                  aria-label="toggle password visibility"
+                                  aria-label="Toggle password visibility"
                                   onClick={handleClickShowPassword}
                                   onMouseDown={handleMouseDownPassword}
                                   edge="end"

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -56,9 +56,8 @@ const noPaddingYSx = { py: 0 };
 const IsInteger = 2;
 
 // numberType: 0 -> not a number, 1 -> number, 2 -> integer
-const valToNumber = (val: string, numberType: number) => {
+const valToNumber = (val: string, numberType: number) =>
     numberType ? (numberType === IsInteger ? Math.round(Number(val)) : Number(val)) : val;
-};
 
 const Input = (props: TaipyInputProps) => {
     const {

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -197,7 +197,7 @@ const Input = (props: TaipyInputProps) => {
                 });
             evt.preventDefault();
         },
-        [dispatch, numberType, updateVarName, module, onChange, propagate, changeDelay, id, onAction]
+        [dispatch, numberType, min, max, updateVarName, module, onChange, propagate, changeDelay, id, onAction]
     );
 
     const handleAction = useCallback(

--- a/frontend/taipy-gui/src/components/Taipy/Input.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Input.tsx
@@ -53,6 +53,12 @@ const verticalDivStyle: CSSProperties = {
     gap: 0,
 };
 const noPaddingYSx = { py: 0 };
+const IsInteger = 2;
+
+// numberType: 0 -> not a number, 1 -> number, 2 -> integer
+const valToNumber = (val: string, numberType: number) => {
+    numberType ? (numberType === IsInteger ? Math.round(Number(val)) : Number(val)) : val;
+};
 
 const Input = (props: TaipyInputProps) => {
     const {
@@ -96,9 +102,8 @@ const Input = (props: TaipyInputProps) => {
     );
 
     // 0 if value is not a number, 1 means general number, 2 means integer
-    const IS_INTEGER = 2;
     const numberType = useMemo<number>(() => {
-        return type === "number" ? (props.integer === true ? 2 : 1) : 0;
+        return type === "number" ? (props.integer === true ? IsInteger : 1) : 0;
     }, [type, props.integer]);
 
     const updateValueWithDelay = useCallback(
@@ -107,7 +112,7 @@ const Input = (props: TaipyInputProps) => {
                 return;
             }
             if (numberType) {
-                value = numberType === IS_INTEGER ? Math.round(Number(value)) : Number(value);
+                value = numberType === IsInteger ? Math.round(Number(value)) : Number(value);
             }
             if (changeDelay === 0) {
                 // Workaround using microtask to ensure the value is updated before the next action to avoid the bad setState behavior
@@ -130,7 +135,7 @@ const Input = (props: TaipyInputProps) => {
     const handleInput = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
             const val = e.target.value;
-            if (numberType === IS_INTEGER && !/^-?\d*$/.test(val)) {
+            if (numberType === IsInteger && !/^-?\d*$/.test(val)) {
                 return;
             }
             setValue(val);
@@ -140,13 +145,7 @@ const Input = (props: TaipyInputProps) => {
             if (changeDelay === 0) {
                 Promise.resolve().then(() => {
                     dispatch(
-                        createSendUpdateAction(
-                            updateVarName,
-                            numberType ? (numberType === IS_INTEGER ? Math.round(Number(val)) : Number(val)) : val,
-                            module,
-                            onChange,
-                            propagate
-                        )
+                        createSendUpdateAction(updateVarName, valToNumber(val, numberType), module, onChange, propagate)
                     );
                 });
             }
@@ -156,13 +155,7 @@ const Input = (props: TaipyInputProps) => {
             delayCall.current = window.setTimeout(() => {
                 delayCall.current = -1;
                 dispatch(
-                    createSendUpdateAction(
-                        updateVarName,
-                        numberType ? (numberType === IS_INTEGER ? Math.round(Number(val)) : Number(val)) : val,
-                        module,
-                        onChange,
-                        propagate
-                    )
+                    createSendUpdateAction(updateVarName, valToNumber(val, numberType), module, onChange, propagate)
                 );
             }, changeDelay);
         },
@@ -172,7 +165,7 @@ const Input = (props: TaipyInputProps) => {
     const handleBlur = useCallback(
         (evt: React.FocusEvent<HTMLInputElement>) => {
             let val = numberType
-                ? numberType === IS_INTEGER
+                ? numberType === IsInteger
                     ? Math.round(Number(evt.currentTarget.value))
                     : Number(evt.currentTarget.value)
                 : evt.currentTarget.value;
@@ -228,7 +221,7 @@ const Input = (props: TaipyInputProps) => {
                 const val = multiline
                     ? evt.currentTarget.querySelector("textarea")?.value
                     : numberType
-                    ? numberType === IS_INTEGER
+                    ? numberType === IsInteger
                         ? Math.round(Number(evt.currentTarget.querySelector("input")?.value))
                         : Number(evt.currentTarget.querySelector("input")?.value)
                     : evt.currentTarget.querySelector("input")?.value;

--- a/frontend/taipy-gui/src/components/Taipy/Login.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Login.tsx
@@ -81,7 +81,9 @@ const Login = (props: LoginProps) => {
             const { close, idx } = evt?.currentTarget.dataset || {};
             const args = close
                 ? [null, null, document.location.pathname.substring(1)]
-                : idx ? [user, password, document.location.pathname.substring(1), parseInt(idx, 10)]: [user, password, document.location.pathname.substring(1)];
+                : idx
+                ? [user, password, document.location.pathname.substring(1), parseInt(idx, 10)]
+                : [user, password, document.location.pathname.substring(1)];
             setShowProgress(!idx);
             dispatch(createSendActionNameAction(id, module, onAction, ...args));
         },
@@ -115,7 +117,7 @@ const Login = (props: LoginProps) => {
                 endAdornment: (
                     <InputAdornment position="end">
                         <IconButton
-                            aria-label="toggle password visibility"
+                            aria-label="Toggle password visibility"
                             onClick={handleClickShowPassword}
                             onMouseDown={handleMouseDownPassword}
                             edge="end"

--- a/frontend/taipy-gui/src/components/Taipy/utils.ts
+++ b/frontend/taipy-gui/src/components/Taipy/utils.ts
@@ -63,6 +63,7 @@ export interface TaipyInputProps extends TaipyActiveProps, TaipyChangeProps, Tai
     defaultMin?: number;
     max?: number;
     defaultMax?: number;
+    integer?: boolean;
     changeDelay?: number;
     onAction?: string;
     actionKeys?: string;

--- a/taipy/common/version.json
+++ b/taipy/common/version.json
@@ -1,1 +1,1 @@
-{"major": 4, "minor": 1, "patch": 0}
+{"major": 4, "minor": 2, "patch": 0}

--- a/taipy/core/version.json
+++ b/taipy/core/version.json
@@ -1,1 +1,1 @@
-{"major": 4, "minor": 1, "patch": 0}
+{"major": 4, "minor": 2, "patch": 0}

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -444,6 +444,7 @@ class _Factory:
                 ("step_multiplier", PropertyType.dynamic_number, 10),
                 ("min", PropertyType.dynamic_number),
                 ("max", PropertyType.dynamic_number),
+                ("integer", PropertyType.boolean, False),
                 ("hover_text", PropertyType.dynamic_string),
                 ("on_change", PropertyType.function),
                 ("on_action", PropertyType.function),

--- a/taipy/gui/extension/library.py
+++ b/taipy/gui/extension/library.py
@@ -304,6 +304,10 @@ class ElementLibrary(ABC):
         """
         return _to_camel_case(self.get_name(), True)
 
+    def get_tgb_header(self) -> t.Optional[str]:
+        # Inserted at the top of the __init__.pyi file
+        return None
+
     def __get_class_folder(self):
         if not hasattr(self, "_class_folder"):
             module_obj = sys.modules.get(self.__class__.__module__)

--- a/taipy/gui/state.py
+++ b/taipy/gui/state.py
@@ -17,7 +17,7 @@ from operator import attrgetter
 from pathlib import Path
 from types import FrameType, SimpleNamespace
 
-from .utils import _get_module_name_from_frame, _is_in_notebook
+from .utils import _get_module_name_from_frame, _is_in_notebook  # pyright: ignore[reportPrivateUsage]
 from .utils._attributes import _attrsetter
 
 if t.TYPE_CHECKING:
@@ -154,7 +154,12 @@ class State(SimpleNamespace, metaclass=ABCMeta):
     def _invoke_on_gui(self, method: t.Callable, *args: t.Any) -> t.Any: ...
 
     @abstractmethod
-    def patch(self, name: str, change: t.Optional[dict] = None, remove: t.Optional[dict] = None):
+    def patch(
+        self,
+        name: str,
+        change: t.Optional[t.Dict[t.Union[str, int], t.Any]] = None,
+        remove: t.Optional[t.Dict[t.Union[str, int], t.Any]] = None,
+    ):
         """Patch a variable on a client.
 
         The connected client will receive an update of the variable called *name* with the
@@ -233,7 +238,9 @@ class _GuiState(State):
             encoded_name = self._gui._bind_var(name)  # type: ignore[attr-defined]
             self._gui._broadcast_all_clients(encoded_name, value)  # type: ignore[attr-defined]
 
-    def patch(self, name: str, change: t.Optional[dict] = None, remove: t.Optional[dict] = None):
+    def patch(
+        self, name: str, change: t.Optional[dict[t.Any, t.Any]] = None, remove: t.Optional[dict[t.Any, t.Any]] = None
+    ):
         with self._set_context(self._gui):
             self._gui._patch_variable(name, change, remove, getattr(self, name, None))  # type: ignore[attr-defined]
 

--- a/taipy/gui/types.py
+++ b/taipy/gui/types.py
@@ -75,35 +75,56 @@ class PropertyType(Enum):
     """
     The property holds a Boolean value.
     """
-    toHtmlContent = _TaipyContentHtml
-    content = _TaipyContent
-    data = _TaipyData
-    date = _TaipyDate
-    date_range = _TaipyDateRange
-    dict = "dict"
-    time = _TaipyTime
+    dynamic_boolean = _TaipyBool
     """
-    The property holds a dictionary.
+    The property is dynamic and holds a Boolean value.
     """
-    dynamic_date = "dynamicdate"
+    number = "number"
     """
-    The property is dynamic and holds a date.
-    """
-    dynamic_dict = _TaipyDict
-    """
-    The property is dynamic and holds a dictionary.
+    The property holds a number.
     """
     dynamic_number = _TaipyNumber
     """
     The property is dynamic and holds a number.
     """
+    string = "string"
+    """
+    The property holds a string.
+    """
+    dynamic_string = "dynamicstring"
+    """
+    The property is dynamic and holds a string.
+    """
+    string_or_number = "string|number"
+    """
+    The property holds a string or a number.
+
+    This is typically used to handle CSS dimension values, where a unit can be used.
+    """
+    date = _TaipyDate
+    """
+    The property holds a date.
+    """
+    time = _TaipyTime
+    dynamic_date = "dynamicdate"
+    """
+    The property is dynamic and holds a date.
+    """
+    date_range = _TaipyDateRange
+    dict = "dict"
+    """
+    The property holds a dictionary.
+    """
+    dynamic_dict = _TaipyDict
+    """
+    The property is dynamic and holds a dictionary.
+    """
+    toHtmlContent = _TaipyContentHtml
+    content = _TaipyContent
+    data = _TaipyData
     dynamic_lo_numbers = _TaipyLoNumbers
     """
     The property is dynamic and holds a list of numbers.
-    """
-    dynamic_boolean = _TaipyBool
-    """
-    The property is dynamic and holds a Boolean value.
     """
     dynamic_list = "dynamiclist"
     """
@@ -112,10 +133,6 @@ class PropertyType(Enum):
     The React component must have two parameters: "<propertyName>" that must be a list of object, and
     "default<PropertyName>" that must be a string, set to the JSON representation of the initial value
     of the property.
-    """
-    dynamic_string = "dynamicstring"
-    """
-    The property is dynamic and holds a string.
     """
     function = "function"
     """
@@ -140,22 +157,8 @@ class PropertyType(Enum):
     """
     The property holds a value in a LoV (list of values).
     """
-    number = "number"
-    """
-    The property holds a number.
-    """
     react = "react"
     broadcast = "broadcast"
-    string = "string"
-    """
-    The property holds a string.
-    """
-    string_or_number = "string|number"
-    """
-    The property holds a string or a number.
-
-    This is typically used to handle CSS dimension values, where a unit can be used.
-    """
     boolean_or_list = "boolean|list"
     slider_value = "number|number[]|lovValue"
     toggle_value = "boolean|lovValue"

--- a/taipy/gui/version.json
+++ b/taipy/gui/version.json
@@ -1,1 +1,1 @@
-{"major": 4, "minor": 1, "patch": 0}
+{"major": 4, "minor": 2, "patch": 0}

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -183,6 +183,12 @@
                         "doc": "The maximum acceptable value.<br/>Values above this threshold are invalid."
                     },
                     {
+                        "name": "integer",
+                        "type": "bool",
+                        "default_value": "False",
+                        "doc": "If True, the value is restricted to integers only."
+                    },
+                    {
                         "name": "action_on_blur",
                         "type": "bool",
                         "default_value": "False",

--- a/taipy/rest/version.json
+++ b/taipy/rest/version.json
@@ -1,1 +1,1 @@
-{"major": 4, "minor": 1, "patch": 0}
+{"major": 4, "minor": 2, "patch": 0}

--- a/taipy/templates/version.json
+++ b/taipy/templates/version.json
@@ -1,1 +1,1 @@
-{"major": 4, "minor": 1, "patch": 0}
+{"major": 4, "minor": 2, "patch": 0}

--- a/taipy/version.json
+++ b/taipy/version.json
@@ -1,1 +1,1 @@
-{"major": 4, "minor": 1, "patch": 0}
+{"major": 4, "minor": 2, "patch": 0}


### PR DESCRIPTION
- Send numbers instead of string in number control
- Added 'integer' property to number control (exchanges are integers)
- Clamp value on blur
- Update version numbers to 4.2.0

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [x] 📝 Documentation Update

## Description

New property 'integer' to the 'number' control.
If True, only integer values are exchanged.

## Related Tickets & Documents

Addresses #2698, #2755 and #2756

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [x] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
