### PR TITLE
Backport: upgrade pandas to 2.2 for python >= 3.10

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ markdown = "==3.7"
 marshmallow = "==3.20.1"
 networkx = "==2.6"
 openpyxl = "==3.1.2"
-pandas = "==1.3.5"
+pandas = "==2.2"
 pyarrow = "==16.0.0"
 pymongo = {extras = ["srv"], version = "==4.6.3"}
 python-dotenv = "==1.0.0"

--- a/tools/packages/taipy-core/setup.requirements.txt
+++ b/tools/packages/taipy-core/setup.requirements.txt
@@ -1,7 +1,8 @@
 boto3>=1.29.4,<=1.34.113
 networkx>=2.6,<=3.3
 openpyxl>=3.1.2,<=3.1.2
-pandas>=1.3.5,<=2.2.2
+pandas>=2.2,<3; python_version >= '3.10'
+pandas>=1.3.5,<=2.2.3; python_version < '3.10'
 pyarrow>=16.0.0,<19.0
 pymongo[srv]>=4.2.0,<=4.7.2
 sqlalchemy>=2.0.16,<=2.0.30

--- a/tools/packages/taipy-gui/setup.requirements.txt
+++ b/tools/packages/taipy-gui/setup.requirements.txt
@@ -7,7 +7,8 @@ gevent-websocket>=0.10.1,<=0.10.1
 gitignore-parser>=0.1,<=0.1.11
 kthread>=0.2.3,<=0.2.3
 markdown>=3.4.4,<=3.6
-pandas>=1.3.5,<=2.2.2
+pandas>=2.2,<3; python_version >= '3.10'
+pandas>=1.3.5,<=2.2.3; python_version < '3.10'
 python-dotenv>=1.0.0,<=1.0.1
 pytz>=2021.3,<=2024.1
 simple-websocket>=0.10.1,<=1.0.0


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [x] 🛠 Backport
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
Backport: upgrade pandas to 2.2 for python >= 3.10

