### PR TITLE
auth and not auth related or otherwise

### DIFF
--- a/frontend/taipy/src/CoreSelector.tsx
+++ b/frontend/taipy/src/CoreSelector.tsx
@@ -423,7 +423,7 @@ const CoreSelector = (props: CoreSelectorProps) => {
                         dispatch(
                             createSendUpdateAction(
                                 updateVarName,
-                                multiple ? [] : "",
+                                multiple ? [] : null,
                                 module,
                                 onChange,
                                 propagate,

--- a/frontend/taipy/src/JobSelector.tsx
+++ b/frontend/taipy/src/JobSelector.tsx
@@ -763,7 +763,25 @@ const JobSelector = (props: JobSelectorProps) => {
         setJobRows(filteredJobRows);
         const jobIds = filteredJobRows.map((j) => j[JobProps.id]);
         setChecked((ids) => ids.filter((id) => jobIds.includes(id)));
-    }, [filters, props.jobs]);
+        setSelected((ids) => {
+            const newSelected = ids.filter((id) => jobIds.includes(id));
+            if (ids.length !== newSelected.length) {
+                const jobsVar = getUpdateVar(props.updateVars, "jobs");
+                dispatch(
+                    createSendUpdateAction(
+                        props.updateVarName,
+                        newSelected,
+                        module,
+                        props.onChange,
+                        propagate,
+                        jobsVar,
+                    ),
+                );
+                return newSelected;
+            }
+            return ids;
+        });
+    }, [filters, props.jobs, dispatch, module, props.onChange, props.updateVarName, props.updateVars, propagate]);
 
     useEffect(() => {
         if (props.value) {

--- a/frontend/taipy/src/PropertiesEditor.tsx
+++ b/frontend/taipy/src/PropertiesEditor.tsx
@@ -110,7 +110,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                 setFocusName("");
             }
         },
-        [isDefined, props.onEdit, entityId, properties, newProp, id, dispatch, module, setFocusName, updateVars]
+        [isDefined, props.onEdit, entityId, properties, newProp, id, dispatch, module, setFocusName, updateVars],
     );
     const cancelProperty = useCallback(
         (e?: MouseEvent<HTMLElement>, dataset?: DOMStringMap) => {
@@ -120,12 +120,12 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                 const property = entProperties.find(([key]) => key === propId);
                 property &&
                     setProperties((ps) =>
-                        ps.map((p) => (p.id === property[0] ? { ...p, key: property[0], value: property[1] } : p))
+                        ps.map((p) => (p.id === property[0] ? { ...p, key: property[0], value: property[1] } : p)),
                     );
                 setFocusName("");
             }
         },
-        [isDefined, entProperties, setFocusName]
+        [isDefined, entProperties, setFocusName],
     );
 
     const onKeyDown = useCallback(
@@ -142,7 +142,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                 }
             }
         },
-        [editProperty, cancelProperty]
+        [editProperty, cancelProperty],
     );
 
     const deleteProperty = useCallback(
@@ -156,11 +156,11 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                     createSendActionNameAction(id, module, props.onEdit, {
                         id: entityId,
                         deleted_properties: [property],
-                    })
+                    }),
                 );
             setFocusName("");
         },
-        [props.onEdit, entityId, id, dispatch, module, properties, setFocusName]
+        [props.onEdit, entityId, id, dispatch, module, properties, setFocusName],
     );
 
     useEffect(() => {
@@ -170,7 +170,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                     id: k,
                     key: k,
                     value: v,
-                }))
+                })),
             );
     }, [show, entProperties]);
 
@@ -232,8 +232,9 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                                                       data-id={property.id}
                                                       onClick={editProperty}
                                                       size="small"
+                                                      disabled={!property.key || !isDefined}
                                                   >
-                                                      <CheckCircle color="primary" />
+                                                      <CheckCircle color={disableColor("primary", !property.key || !isDefined)} />
                                                   </IconButton>
                                               </Tooltip>
                                               <Tooltip title="Cancel">
@@ -295,7 +296,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                     onClick={onFocus}
                     sx={hoverSx}
                 >
-                    {active && focusName == "new-property" ? (
+                    {active && !notEditableReason && focusName == "new-property" ? (
                         <>
                             <Grid size={4}>
                                 <TextField
@@ -318,14 +319,21 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                                     variant="outlined"
                                     sx={FieldNoMaxWidth}
                                     disabled={!isDefined}
-                                    slotProps={{ htmlInput: { onKeyDown, "data-enter": true }}}
+                                    slotProps={{ htmlInput: { onKeyDown, "data-enter": true } }}
                                 />
                             </Grid>
                             <Grid size={2} container alignContent="center" alignItems="center" justifyContent="center">
                                 <Tooltip title="Apply">
-                                    <IconButton sx={IconPaddingSx} onClick={editProperty} size="small">
-                                        <CheckCircle color="primary" />
-                                    </IconButton>
+                                    <span>
+                                        <IconButton
+                                            sx={IconPaddingSx}
+                                            onClick={editProperty}
+                                            size="small"
+                                            disabled={!newProp.key || !isDefined}
+                                        >
+                                            <CheckCircle color={disableColor("primary", !newProp.key || !isDefined)} />
+                                        </IconButton>
+                                    </span>
                                 </Tooltip>
                                 <Tooltip title="Cancel">
                                     <IconButton sx={IconPaddingSx} onClick={cancelProperty} size="small">

--- a/frontend/taipy/src/PropertiesEditor.tsx
+++ b/frontend/taipy/src/PropertiesEditor.tsx
@@ -95,16 +95,21 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                 const { id: propId = "" } = dataset || e?.currentTarget.dataset || {};
                 const property = propId ? properties.find((p) => p.id === propId) : newProp;
                 if (property) {
+                    if (!property.key) {
+                        return;
+                    }
                     const oldId = property.id;
                     const payload: PropertiesEditPayload = {
                         id: entityId,
-                        properties: [property],
+                        properties: property.key ? [property] : [],
                         error_id: getUpdateVar(updateVars, "error_id"),
                     };
                     if (oldId && oldId != property.key) {
                         payload.deleted_properties = [{ key: oldId }];
                     }
-                    dispatch(createSendActionNameAction(id, module, props.onEdit, payload));
+                    if (payload.properties?.length || payload.deleted_properties?.length) {
+                        dispatch(createSendActionNameAction(id, module, props.onEdit, payload));
+                    }
                 }
                 setNewProp((np) => ({ ...np, key: "", value: "" }));
                 setFocusName("");

--- a/frontend/taipy/src/PropertiesEditor.tsx
+++ b/frontend/taipy/src/PropertiesEditor.tsx
@@ -101,7 +101,7 @@ const PropertiesEditor = (props: PropertiesEditorProps) => {
                     const oldId = property.id;
                     const payload: PropertiesEditPayload = {
                         id: entityId,
-                        properties: property.key ? [property] : [],
+                        properties: [property],
                         error_id: getUpdateVar(updateVars, "error_id"),
                     };
                     if (oldId && oldId != property.key) {

--- a/frontend/taipy/src/ScenarioSelector.tsx
+++ b/frontend/taipy/src/ScenarioSelector.tsx
@@ -195,7 +195,7 @@ const ScenarioEditDialog = ({ scenario, submit, open, actionEdit, configs, close
 
     useEffect(() => {
         form.setValues(
-            scenario
+            actionEdit && scenario
                 ? {
                       id: scenario[ScFProps.id],
                       config: scenario[ScFProps.config_id],
@@ -206,10 +206,10 @@ const ScenarioEditDialog = ({ scenario, submit, open, actionEdit, configs, close
                 : { ...emptyScenario, config: configs?.length === 1 ? configs[0][0] : "" },
         );
         setProperties(
-            scenario ? scenario[ScFProps.properties].map(([k, v], i) => ({ id: i + "", key: k, value: v })) : [],
+            actionEdit && scenario ? scenario[ScFProps.properties].map(([k, v], i) => ({ id: i + "", key: k, value: v })) : [],
         );
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scenario, configs]);
+    }, [actionEdit, scenario, configs]);
 
     const onDeleteScenario = useCallback(() => {
         submit(actionEdit, true, { id: scenario && scenario[ScFProps.id] });

--- a/taipy/gui/_renderers/builder.py
+++ b/taipy/gui/_renderers/builder.py
@@ -338,8 +338,9 @@ class _Builder:
         if isinstance(value, list):
             self.__set_json_attribute(_to_camel_case(f"default_{name}"), value)
         if hash := self.__hashes.get(name):
-            self.__update_vars.append(f"{name}={hash}")
-            self.__set_react_attribute(name, hash)
+            var_name = _to_camel_case(name)
+            self.__update_vars.append(f"{var_name}={hash}")
+            self.__set_react_attribute(var_name, hash)
         return self
 
     def __set_list_attribute(

--- a/taipy/gui/data/data_accessor.py
+++ b/taipy/gui/data/data_accessor.py
@@ -149,6 +149,12 @@ class _DataAccessors(object):
                     access = self.__access_4_type.get(type(converted_value))
                     if access is not None:
                         return access
+                for cl in self.__access_4_type.keys():
+                    if isinstance(value, cl):
+                        access = self.__access_4_type[cl]
+                        self.__access_4_type[type(value)] = access
+                        return access
+
                 _warn(f"Can't find Data Accessor for type {str(type(value))}.")
             return self.__invalid_data_accessor
         return access

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1182,7 +1182,7 @@ class Gui:
         for k, v in values.items():
             if isinstance(v, (_TaipyData, _TaipyContentHtml)) and v.get_name() in modified_vars:
                 modified_vars.remove(v.get_name())
-            elif isinstance(v, _DoNotUpdate):
+            elif isinstance(v, _DoNotUpdate) and k in modified_vars:
                 modified_vars.remove(k)
         custom_page_filtered_types = _Hooks()._get_resource_handler_data_layer_supported_types()
         in_custom_page_context = _Hooks()._is_in_custom_page_context()

--- a/taipy/gui_core/_adapters.py
+++ b/taipy/gui_core/_adapters.py
@@ -112,7 +112,9 @@ class _GuiCoreScenarioAdapter(_TaipyBase):
                     ]
             except Exception as e:
                 if not _is_invalidCredentials_exception(e):
-                    _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
+                    _warn(
+                        f"Access to scenario '{data.id}'" if hasattr(data, "id") else "Access to anonymous scenario", e
+                    )
 
         return None
 
@@ -172,7 +174,9 @@ class _GuiCoreScenarioDagAdapter(_TaipyBase):
                     ]
             except Exception as e:
                 if not _is_invalidCredentials_exception(e):
-                    _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
+                    _warn(
+                        f"Access to scenario '{data.id}'" if hasattr(data, "id") else "Access to anonymous scenario", e
+                    )
 
         return None
 
@@ -215,13 +219,7 @@ class _GuiCoreDatanodeAdapter(_TaipyBase):
                         json.dumps(value)
                     except Exception as e:
                         error = f"Unsupported data: {e}."
-                return (
-                    value,
-                    val_type,
-                    None,
-                    error,
-                    isinstance(dn, JSONDataNode)
-                )
+                return (value, val_type, None, error, isinstance(dn, JSONDataNode))
             except Exception as e:
                 return (None, None, None, f"read data_node: {e}")
         return (None, None, None, f"Data unavailable for {dn.get_simple_label()}")
@@ -263,13 +261,17 @@ class _GuiCoreDatanodeAdapter(_TaipyBase):
                     ]
             except Exception as e:
                 if not _is_invalidCredentials_exception(e):
-                    _warn(f"Access to data node ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
+                    _warn(
+                        f"Access to data node '{data.id}'" if hasattr(data, "id") else "Access to anonymous data node",
+                        e,
+                    )
 
         return None
 
     @staticmethod
     def get_hash():
         return _TaipyBase._HOLDER_PREFIX + "Dn"
+
 
 def _is_invalidCredentials_exception(e: Exception):
     return type(e).__name__ == "InvalidCredentials"
@@ -574,9 +576,7 @@ class _GuiCoreDatanodeProperties(_GuiCoreProperties):
         _GuiCorePropDesc(DataNodeFilter("Last edit date", datetime, "last_edit_date"), for_sort=True),
         _GuiCorePropDesc(DataNodeFilter("Expiration date", datetime, "expiration_date"), extended=True, for_sort=True),
         _GuiCorePropDesc(DataNodeFilter("Expired", bool, "is_expired"), extended=True),
-        _GuiCorePropDesc(
-            DataNodeFilter("Rank", int, "_get_rank()", [ParamType.ScenarioConfigId]), for_sort=True
-        ),
+        _GuiCorePropDesc(DataNodeFilter("Rank", int, "_get_rank()", [ParamType.ScenarioConfigId]), for_sort=True),
     ]
     __DN_VALIDITY = None
 

--- a/taipy/gui_core/_adapters.py
+++ b/taipy/gui_core/_adapters.py
@@ -111,7 +111,8 @@ class _GuiCoreScenarioAdapter(_TaipyBase):
                         _get_reason(is_editable(scenario), "Scenario not editable"),
                     ]
             except Exception as e:
-                _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
+                if not _is_invalidCredentials_exception(e):
+                    _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
 
         return None
 
@@ -170,7 +171,8 @@ class _GuiCoreScenarioDagAdapter(_TaipyBase):
                         ],
                     ]
             except Exception as e:
-                _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
+                if not _is_invalidCredentials_exception(e):
+                    _warn(f"Access to scenario ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
 
         return None
 
@@ -260,13 +262,17 @@ class _GuiCoreDatanodeAdapter(_TaipyBase):
                         else "",
                     ]
             except Exception as e:
-                _warn(f"Access to data node ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
+                if not _is_invalidCredentials_exception(e):
+                    _warn(f"Access to data node ({data.id if hasattr(data, 'id') else 'No_id'}) failed", e)
 
         return None
 
     @staticmethod
     def get_hash():
         return _TaipyBase._HOLDER_PREFIX + "Dn"
+
+def _is_invalidCredentials_exception(e: Exception):
+    return type(e).__name__ == "InvalidCredentials"
 
 
 _operators: t.Dict[str, t.Callable] = {

--- a/tests/gui/data/test_accessors.py
+++ b/tests/gui/data/test_accessors.py
@@ -1,6 +1,8 @@
 import typing as t
 from unittest.mock import Mock
 
+import pytest
+
 from taipy.gui import Gui
 from taipy.gui.data.data_accessor import (
     _DataAccessor,
@@ -49,6 +51,169 @@ class MyDataAccessor(_DataAccessor):
         pass
 
 
+class MyStringAccessor(_DataAccessor):
+    @staticmethod
+    def get_supported_classes() -> t.List[t.Type]:
+        return [str]
+
+    def get_data(
+        self,
+        var_name: str,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        data_format: _DataFormat,
+    ) -> t.Dict[str, t.Any]:
+        return {"value": value}
+
+    def get_cols_description(self, var_name: str, value: t.Any) -> t.Dict[str, t.Dict[str, str]]:
+        return {}
+
+    def to_pandas(self, value: t.Any) -> t.Union[t.List[t.Any], t.Any]:
+        return value
+
+    def on_edit(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return payload
+
+    def on_delete(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return payload
+
+    def on_add(
+        self,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        new_row: t.Optional[t.List[t.Any]] = None,
+    ) -> t.Optional[t.Any]:
+        return new_row
+
+    def to_csv(self, var_name: str, value: t.Any) -> t.Optional[str]:
+        return str(value)
+
+
+class NoSupportedClassAccessor(_DataAccessor):
+    @staticmethod
+    def get_supported_classes() -> t.List[t.Type]:
+        return []
+
+    def get_data(
+        self,
+        var_name: str,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        data_format: _DataFormat,
+    ) -> t.Dict[str, t.Any]:
+        return {}
+
+    def get_cols_description(self, var_name: str, value: t.Any) -> t.Dict[str, t.Dict[str, str]]:
+        return {}
+
+    def to_pandas(self, value: t.Any) -> t.Union[t.List[t.Any], t.Any]:
+        return value
+
+    def on_edit(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return value
+
+    def on_delete(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return value
+
+    def on_add(
+        self,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        new_row: t.Optional[t.List[t.Any]] = None,
+    ) -> t.Optional[t.Any]:
+        return value
+
+    def to_csv(self, var_name: str, value: t.Any) -> t.Optional[str]:
+        return None
+
+
+class NotInstantiableAccessor(_DataAccessor):
+    def __init__(self, gui: Gui):
+        raise RuntimeError("boom")
+
+    @staticmethod
+    def get_supported_classes() -> t.List[t.Type]:
+        return [float]
+
+    def get_data(
+        self,
+        var_name: str,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        data_format: _DataFormat,
+    ) -> t.Dict[str, t.Any]:
+        return {}
+
+    def get_cols_description(self, var_name: str, value: t.Any) -> t.Dict[str, t.Dict[str, str]]:
+        return {}
+
+    def to_pandas(self, value: t.Any) -> t.Union[t.List[t.Any], t.Any]:
+        return value
+
+    def on_edit(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return value
+
+    def on_delete(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return value
+
+    def on_add(
+        self,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        new_row: t.Optional[t.List[t.Any]] = None,
+    ) -> t.Optional[t.Any]:
+        return value
+
+    def to_csv(self, var_name: str, value: t.Any) -> t.Optional[str]:
+        return None
+
+
+class Parent:
+    pass
+
+
+class Child(Parent):
+    pass
+
+
+class ParentAccessor(_DataAccessor):
+    @staticmethod
+    def get_supported_classes() -> t.List[t.Type]:
+        return [Parent]
+
+    def get_data(
+        self,
+        var_name: str,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        data_format: _DataFormat,
+    ) -> t.Dict[str, t.Any]:
+        return {"value": "parent"}
+
+    def get_cols_description(self, var_name: str, value: t.Any) -> t.Dict[str, t.Dict[str, str]]:
+        return {}
+
+    def to_pandas(self, value: t.Any) -> t.Union[t.List[t.Any], t.Any]:
+        return ["parent", value]
+
+    def on_edit(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return {"edited": value, "payload": payload}
+
+    def on_delete(self, value: t.Any, payload: t.Dict[str, t.Any]) -> t.Optional[t.Any]:
+        return {"deleted": value, "payload": payload}
+
+    def on_add(
+        self,
+        value: t.Any,
+        payload: t.Dict[str, t.Any],
+        new_row: t.Optional[t.List[t.Any]] = None,
+    ) -> t.Optional[t.Any]:
+        return {"added": value, "payload": payload, "new_row": new_row}
+
+    def to_csv(self, var_name: str, value: t.Any) -> t.Optional[str]:
+        return f"{var_name}:{value.__class__.__name__}"
+
+
 def mock_taipy_data(value):
     """Helper to mock _TaipyData objects."""
     mock_data = Mock(spec=_TaipyData)
@@ -77,3 +242,89 @@ def test_custom_accessor(gui: Gui):
     assert result["value"] == 246
 
     data_accessors._unregister(MyDataAccessor)
+
+
+def test_register_validates_arguments(gui: Gui):
+    data_accessors = _DataAccessors(gui)
+
+    with pytest.raises(AttributeError, match="should be a class"):
+        data_accessors._register(123)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="is not a subclass of DataAccessor"):
+        data_accessors._register(str)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="returned an invalid value"):
+        data_accessors._register(NoSupportedClassAccessor)
+
+
+def test_register_non_instantiable_accessor_raises(gui: Gui):
+    data_accessors = _DataAccessors(gui)
+
+    with pytest.raises(TypeError, match="cannot be instantiated"):
+        data_accessors._register(NotInstantiableAccessor)
+
+
+def test_get_instance_uses_converted_unsupported_data(gui: Gui, monkeypatch):
+    data_accessors = _DataAccessors(gui)
+    data_accessors._register(MyStringAccessor)
+
+    def _converter(value: t.Any):
+        return "converted" if value == 10 else None
+
+    monkeypatch.setattr(Gui, "_convert_unsupported_data", staticmethod(_converter))
+    accessor = data_accessors._get_instance(mock_taipy_data(10))
+    assert isinstance(accessor, MyStringAccessor)
+    assert data_accessors.get_data("var_name", mock_taipy_data(10), {}) == {"value": 10}
+
+
+def test_get_instance_falls_back_to_isinstance_and_caches(gui: Gui, monkeypatch):
+    data_accessors = _DataAccessors(gui)
+    data_accessors._register(ParentAccessor)
+
+    monkeypatch.setattr(Gui, "_convert_unsupported_data", staticmethod(lambda _value: None))
+    value = Child()
+    first = data_accessors._get_instance(mock_taipy_data(value))
+    second = data_accessors._get_instance(mock_taipy_data(value))
+    assert isinstance(first, ParentAccessor)
+    assert first is second
+
+
+def test_get_instance_warns_and_returns_invalid_for_unsupported_type(gui: Gui, monkeypatch):
+    data_accessors = _DataAccessors(gui)
+    warnings: t.List[str] = []
+
+    monkeypatch.setattr(Gui, "_convert_unsupported_data", staticmethod(lambda _value: None))
+    monkeypatch.setattr("taipy.gui.data.data_accessor._warn", lambda message: warnings.append(message))
+    accessor = data_accessors._get_instance(mock_taipy_data(object()))
+    assert isinstance(accessor, _InvalidDataAccessor)
+    assert len(warnings) == 1
+    assert "Can't find Data Accessor for type" in warnings[0]
+
+
+def test_data_accessors_delegate_methods(gui: Gui):
+    data_accessors = _DataAccessors(gui)
+    data_accessors._register(MyDataAccessor)
+    data_accessors.set_data_format(_DataFormat.APACHE_ARROW)
+
+    data_wrapper = mock_taipy_data(5)
+    assert data_accessors.get_data("x", data_wrapper, {}) == {"value": 10}
+
+    data_accessors._register(ParentAccessor)
+    value = Child()
+    edited = data_accessors.on_edit(value, {"k": 1})
+    deleted = data_accessors.on_delete(value, {"k": 2})
+    added = data_accessors.on_add(value, {"k": 3}, [1, 2])
+    assert edited == {"edited": value, "payload": {"k": 1}}
+    assert deleted == {"deleted": value, "payload": {"k": 2}}
+    assert added == {"added": value, "payload": {"k": 3}, "new_row": [1, 2]}
+
+    string_data = mock_taipy_data("abc")
+    data_accessors._register(MyStringAccessor)
+    assert data_accessors.to_csv("name", string_data) == "abc"
+    assert data_accessors.to_pandas(string_data) == "abc"
+
+
+def test_get_instance_returns_invalid_for_none(gui: Gui):
+    data_accessors = _DataAccessors(gui)
+    accessor = data_accessors._get_instance(mock_taipy_data(None))
+    assert isinstance(accessor, _InvalidDataAccessor)


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
- in selectors, no selection should return None
- Scenario dialog should forget previous data
- Properties Editor should not allow empty keys and be auth aware
- job selectors selection on data change
- data accessor support sub classes
- json property type support dict
- small fixes and tests

## Related Tickets & Documents
- Related Issue #Enterprise 724

## How to reproduce the issue
```py
import taipy as tp
import taipy.gui.builder as tgb
from taipy import Config
from taipy.auth import Authorize
from taipy.enterprise.auth import SystemCredential
from taipy.enterprise.gui import login, logout
from taipy.gui import Gui, State


# Core config
def square(x):
    return x * x


x_cfg = Config.configure_data_node("x", default_data=3)
y_cfg = Config.configure_data_node("y")
square_task_cfg = Config.configure_task("square", function=square, input=[x_cfg], output=[y_cfg])
scenario_cfg = Config.configure_scenario("scenario", task_configs=[square_task_cfg])

# Auth config
roles = {
    "admin": ["TAIPY_ADMIN"],
    "reader": ["TAIPY_READER"],
    "executor": ["TAIPY_EXECUTOR"],
    "editor": ["TAIPY_EDITOR"],
}
Config.configure_authentication(
    protocol="taipy",
    roles=roles,
)

# GUI
selected_scenario = None
selected_job = None
selected_data_node = None

def on_change(state: State, var_name: str, var_value):
    print(var_name, type(var_value), var_value)

logged_in = False

with tgb.Page() as main_page:
    with tgb.layout(columns="1 2 2"):
        with tgb.part():
            tgb.button("Login as admin", on_action=lambda state: state.assign("logged_in", login(state, "admin", "admin") is not None), active="{not logged_in}")
            tgb.button("Login as reader", on_action=lambda state: state.assign("logged_in", login(state, "reader", "reader") is not None), active="{not logged_in}")
            tgb.button("Login as executor", on_action=lambda state: state.assign("logged_in", login(state, "executor", "executor") is not None), active="{not logged_in}")
            tgb.button("Login as editor", on_action=lambda state: state.assign("logged_in", login(state, "editor", "editor") is not None), active="{not logged_in}")
            tgb.button("Logout", on_action=lambda state: state.assign("logged_in", logout(state) is not None), active="{logged_in}")
        with tgb.part():
            tgb.scenario_selector("{selected_scenario}")
            tgb.scenario("{selected_scenario}")
        with tgb.part():
            tgb.data_node_selector("{selected_data_node}")
            tgb.data_node("{selected_data_node}")
            tgb.job_selector("{selected_job}")

if __name__ == "__main__":
    Config.configure_job_executions(mode="standalone")
    tp.Orchestrator().run()

    with Authorize(SystemCredential()):
        tp.submit(tp.create_scenario(scenario_cfg, name="First scenario"))

    Gui(main_page).run(title="724 - Core GUI Auth Demo")

```
## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [ ] ✅ This solution meets the acceptance criteria of the related issue.
- [ ] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
