### PR TITLE
use lower level class to test instances in json type

### DIFF
--- a/taipy/gui/utils/_map_dict.py
+++ b/taipy/gui/utils/_map_dict.py
@@ -12,9 +12,10 @@
 from __future__ import annotations
 
 import typing as t
+from collections.abc import Mapping
 
 
-class _MapDict(object):
+class _MapDict(Mapping):
     """
     Provide class binding, can utilize getattr, setattr functionality
     Also perform update operation
@@ -88,7 +89,7 @@ class _MapDict(object):
     def items(self):
         return self._dict.items()
 
-    def get(self, key: t.Any, default_value: t.Optional[str] = None) -> t.Optional[t.Any]:
+    def get(self, key: t.Any, default_value: t.Optional[t.Any] = None) -> t.Optional[t.Any]:
         return self._dict.get(key, default_value)
 
     def clear(self) -> None:

--- a/taipy/gui/utils/types.py
+++ b/taipy/gui/utils/types.py
@@ -13,6 +13,7 @@
 import json
 import typing as t
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping
 from datetime import datetime
 from inspect import ismethod
 
@@ -221,14 +222,12 @@ class _TaipyTime(_TaipyBase):
 class _TaipyToJson(_TaipyBase):
     def get(self):
         val = super().get()
-        if not val:
-            return val
         if isinstance(val, JsonProperty):
             try:
                 return val.to_json()
             except Exception as e:
                 _warn("Issue while serializing 'JsonProperty'.", e)
-        elif isinstance(val, (dict, _MapDict)):
+        elif isinstance(val, (Mapping, Iterable)):
             return val._dict if isinstance(val, _MapDict) else val
         elif method := getattr(val, "to_json", None):
             if ismethod(method):
@@ -239,7 +238,7 @@ class _TaipyToJson(_TaipyBase):
                     _warn("Issue while serializing object.", e)
             else:
                 _warn(f"'{self._get_readable_name()}.to_json' is not a valid method.")
-        else:
+        elif val is not None:
             _warn(f"'{self._get_readable_name()}.to_json()' must be defined.")
         return None
 

--- a/taipy/gui/utils/types.py
+++ b/taipy/gui/utils/types.py
@@ -228,16 +228,16 @@ class _TaipyToJson(_TaipyBase):
             except Exception as e:
                 _warn("Issue while serializing 'JsonProperty'.", e)
         elif isinstance(val, (Mapping, Iterable)):
-            return val._dict if isinstance(val, _MapDict) else val
-        elif method := getattr(val, "to_json", None):
+            return val._dict if isinstance(val, _MapDict) else list(val) if isinstance(val, set) else val
+        elif method := getattr(val, "to_json", None) or (method := getattr(val, "to_dict", None)):
             if ismethod(method):
                 try:
                     json_val = method()
                     return json.loads(json_val) if isinstance(json_val, str) else json_val
                 except Exception as e:
-                    _warn("Issue while serializing object.", e)
+                    _warn(f"Issue while serializing object with '{self._get_readable_name()}.{method.__name__}'.", e)
             else:
-                _warn(f"'{self._get_readable_name()}.to_json' is not a valid method.")
+                _warn(f"'{self._get_readable_name()}.{method.__name__}' is not a valid method.")
         elif val is not None:
             _warn(f"'{self._get_readable_name()}.to_json()' must be defined.")
         return None

--- a/tests/gui/utils/test_patch.py
+++ b/tests/gui/utils/test_patch.py
@@ -90,3 +90,12 @@ def test_update_empty_list():
     assert obj2.get("a").get("b", [])[0] == 1 # pyright: ignore[reportOptionalMemberAccess]
     assert len(obj2.get("a").get("b", [])) == 2 # pyright: ignore[reportOptionalMemberAccess]
 
+def test_update_empty_root_dict():
+    obj = {}
+    _patch_value(obj, { "a": { "b": { "c": 1 } } })
+    assert obj.get("a").get("b").get("c") == 1 # pyright: ignore[reportOptionalMemberAccess]
+
+def test_update_empty_root_list():
+    obj = []
+    _patch_value(obj, { 0: { "a": 1 } } )
+    assert obj[0].get("a") == 1 # pyright: ignore[reportOptionalMemberAccess]

--- a/tests/gui/utils/test_types.py
+++ b/tests/gui/utils/test_types.py
@@ -10,7 +10,6 @@
 # specific language governing permissions and limitations under the License.
 
 
-import json
 import typing as t
 import warnings
 

--- a/tests/gui/utils/test_types.py
+++ b/tests/gui/utils/test_types.py
@@ -14,6 +14,7 @@ import warnings
 
 import pytest
 
+from taipy.gui.utils._map_dict import _MapDict
 from taipy.gui.utils.date import _string_to_date
 from taipy.gui.utils.types import (
     JsonProperty,
@@ -103,3 +104,17 @@ def test_taipy_to_json():
     assert tb.get() == {"data": [], "layout": {}}
 
     assert _TaipyToJson(None, "hash").get() is None
+
+def test_taipy_to_json_with_dict():
+    tb = _TaipyToJson({}, "hash")
+    assert tb.get() == {}
+
+    tb = _TaipyToJson({"key": "value"}, "hash")
+    assert tb.get() == {"key": "value"}
+
+def test_taipy_to_json_with_MapDict():
+    tb = _TaipyToJson(_MapDict({}), "hash")
+    assert tb.get() == {}
+
+    tb = _TaipyToJson(_MapDict({"key": "value"}), "hash")
+    assert tb.get() == {"key": "value"}

--- a/tests/gui/utils/test_types.py
+++ b/tests/gui/utils/test_types.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 
+import typing as t
 import warnings
 
 import pytest
@@ -118,3 +119,11 @@ def test_taipy_to_json_with_MapDict():
 
     tb = _TaipyToJson(_MapDict({"key": "value"}), "hash")
     assert tb.get() == {"key": "value"}
+
+def test_taipy_to_json_with_typed_dict():
+    class Movie(t.TypedDict):
+        name: str
+        year: int
+
+    tb = _TaipyToJson(Movie(name="name", year=1928), "hash")
+    assert tb.get() == {"name": "name", "year": 1928}

--- a/tests/gui/utils/test_types.py
+++ b/tests/gui/utils/test_types.py
@@ -190,7 +190,7 @@ def test_taipy_to_json_with_non_serializable_to_json():
         assert tb.get() is None
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning)
-        assert "Issue while serializing object." in str(w[-1].message)
+        assert "Issue while serializing object with 'hash.to_json'." in str(w[-1].message)
 
 
 def test_taipy_to_json_with_set():

--- a/tests/gui/utils/test_types.py
+++ b/tests/gui/utils/test_types.py
@@ -127,3 +127,47 @@ def test_taipy_to_json_with_typed_dict():
 
     tb = _TaipyToJson(Movie(name="name", year=1928), "hash")
     assert tb.get() == {"name": "name", "year": 1928}
+
+def test_taipy_to_json_with_list():
+    tb = _TaipyToJson([], "hash")
+    assert tb.get() == []
+
+    tb = _TaipyToJson(["key", "value"], "hash")
+    assert tb.get() == ["key", "value"]
+
+def test_taipy_to_json_with_tuple():
+    tb = _TaipyToJson((), "hash")
+    assert tb.get() == ()
+
+    tb = _TaipyToJson(("key", "value"), "hash")
+    assert tb.get() == ("key", "value")
+
+def test_taipy_to_json_with_string():
+    tb = _TaipyToJson("", "hash")
+    assert tb.get() == ""
+
+    tb = _TaipyToJson("a string", "hash")
+    assert tb.get() == "a string"
+
+def test_taipy_to_json_with_non_serializable():
+    class NonSerializable:
+        pass
+
+    with warnings.catch_warnings(record=True) as w:
+        tb = _TaipyToJson(NonSerializable(), "hash")
+        assert tb.get() is None
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert "'hash.to_json()' must be defined." in str(w[-1].message)
+
+def test_taipy_to_json_with_non_serializable_to_json():
+    class NonSerializable:
+        def to_json(self):
+            raise Exception("Serialization error")
+
+    with warnings.catch_warnings(record=True) as w:
+        tb = _TaipyToJson(NonSerializable(), "hash")
+        assert tb.get() is None
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert "Issue while serializing object." in str(w[-1].message)

--- a/tests/gui/utils/test_types.py
+++ b/tests/gui/utils/test_types.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 
+import json
 import typing as t
 import warnings
 
@@ -76,7 +77,7 @@ def test_taipy_date_range():
 
 def test_taipy_dict():
     assert _TaipyDict({"key": "value"}, "x").get() == '{"key": "value"}'
-    assert _TaipyDict(None, "x").get() == 'null'
+    assert _TaipyDict(None, "x").get() == "null"
 
 
 def test_taipy_time():
@@ -106,6 +107,18 @@ def test_taipy_to_json():
 
     assert _TaipyToJson(None, "hash").get() is None
 
+
+def test_taipy_to_json_with_to_dict():
+    class TestToDict:
+        def to_dict(self):
+            return {"value": "value"}
+
+    tb = _TaipyToJson(TestToDict(), "hash")
+    assert tb.get() == {"value": "value"}
+    assert tb.get_name() == "hash"
+    assert tb.get_hash() == "_TpTj"
+
+
 def test_taipy_to_json_with_dict():
     tb = _TaipyToJson({}, "hash")
     assert tb.get() == {}
@@ -113,12 +126,14 @@ def test_taipy_to_json_with_dict():
     tb = _TaipyToJson({"key": "value"}, "hash")
     assert tb.get() == {"key": "value"}
 
+
 def test_taipy_to_json_with_MapDict():
     tb = _TaipyToJson(_MapDict({}), "hash")
     assert tb.get() == {}
 
     tb = _TaipyToJson(_MapDict({"key": "value"}), "hash")
     assert tb.get() == {"key": "value"}
+
 
 def test_taipy_to_json_with_typed_dict():
     class Movie(t.TypedDict):
@@ -128,12 +143,14 @@ def test_taipy_to_json_with_typed_dict():
     tb = _TaipyToJson(Movie(name="name", year=1928), "hash")
     assert tb.get() == {"name": "name", "year": 1928}
 
+
 def test_taipy_to_json_with_list():
     tb = _TaipyToJson([], "hash")
     assert tb.get() == []
 
     tb = _TaipyToJson(["key", "value"], "hash")
     assert tb.get() == ["key", "value"]
+
 
 def test_taipy_to_json_with_tuple():
     tb = _TaipyToJson((), "hash")
@@ -142,12 +159,14 @@ def test_taipy_to_json_with_tuple():
     tb = _TaipyToJson(("key", "value"), "hash")
     assert tb.get() == ("key", "value")
 
+
 def test_taipy_to_json_with_string():
     tb = _TaipyToJson("", "hash")
     assert tb.get() == ""
 
     tb = _TaipyToJson("a string", "hash")
     assert tb.get() == "a string"
+
 
 def test_taipy_to_json_with_non_serializable():
     class NonSerializable:
@@ -160,6 +179,7 @@ def test_taipy_to_json_with_non_serializable():
         assert issubclass(w[-1].category, UserWarning)
         assert "'hash.to_json()' must be defined." in str(w[-1].message)
 
+
 def test_taipy_to_json_with_non_serializable_to_json():
     class NonSerializable:
         def to_json(self):
@@ -171,3 +191,11 @@ def test_taipy_to_json_with_non_serializable_to_json():
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning)
         assert "Issue while serializing object." in str(w[-1].message)
+
+
+def test_taipy_to_json_with_set():
+    tb = _TaipyToJson(set(), "hash")
+    assert tb.get() == []
+
+    tb = _TaipyToJson({"key", "value"}, "hash")
+    assert tb.get() == ["value", "key"] or tb.get() == ["key", "value"]


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
- use lower level class to test instances in json type
- _MapDict is now subclass of Mapping

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [ ] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [ ] ✅ This solution meets the acceptance criteria of the related issue.
- [ ] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
