### PR TITLE
fix(slider): handle negative and decimal values in labels

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Slider.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Slider.spec.tsx
@@ -309,6 +309,53 @@ describe("Slider Component", () => {
         render(<Slider defaultValue='["Item 1", "Item 2"]' />);
         expect(errorSpy).toHaveBeenCalledWith("Slider values should all be numbers");
     });
+    it("shows marks with decimal values", async () => {
+        const labels = {
+            "0": "0",
+            "0.2": "0.2",
+            "0.4": "0.4",
+            "0.6": "0.6",
+            "0.8": "0.8",
+            "1": "1",
+        };
+        const { container } = render(<Slider value={0.5} min={0} max={1} step={0.1} labels={JSON.stringify(labels)} />);
+        expect(container).toHaveTextContent("0");
+        expect(container).toHaveTextContent("0.2");
+        expect(container).toHaveTextContent("0.4");
+        expect(container).toHaveTextContent("0.6");
+        expect(container).toHaveTextContent("0.8");
+        expect(container).toHaveTextContent("1");
+    });
+    it("shows marks with negative values including -1", async () => {
+        const labels = {
+            "-2": "-2",
+            "-1": "-1",
+            "0": "0",
+            "1": "1",
+            "2": "2",
+        };
+        const { container } = render(<Slider value={0} min={-2} max={2} step={1} labels={JSON.stringify(labels)} />);
+        expect(container).toHaveTextContent("-2");
+        expect(container).toHaveTextContent("-1");
+        expect(container).toHaveTextContent("0");
+        expect(container).toHaveTextContent("1");
+        expect(container).toHaveTextContent("2");
+    });
+    it("shows marks with negative decimal values", async () => {
+        const labels = {
+            "-1.0": "-1.0",
+            "-0.5": "-0.5",
+            "0": "0",
+            "0.5": "0.5",
+            "1.0": "1.0",
+        };
+        const { container } = render(<Slider value={0} min={-1} max={1} step={0.5} labels={JSON.stringify(labels)} />);
+        expect(container).toHaveTextContent("-1.0");
+        expect(container).toHaveTextContent("-0.5");
+        expect(container).toHaveTextContent("0");
+        expect(container).toHaveTextContent("0.5");
+        expect(container).toHaveTextContent("1.0");
+    });
     it("should return number when default value is a number", async () => {
         const { container } = render(<Slider defaultValue={1} />);
         const slider = container.querySelector("div");

--- a/frontend/taipy-gui/src/components/Taipy/Slider.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Slider.tsx
@@ -204,15 +204,17 @@ const Slider = (props: SliderProps) => {
                     const marks: Array<{ value: number; label: string }> = [];
                     Object.keys(labels).forEach((key) => {
                         if (labels[key]) {
-                            let idx = lovList.findIndex((it) => it.id === key);
-                            if (idx == -1) {
-                                try {
-                                    idx = parseInt(key, 10);
-                                } catch {
-                                    // too bad
+                            const lovIdx = lovList.findIndex((it) => it.id === key);
+                            let idx: number | undefined;
+                            if (lovIdx !== -1) {
+                                idx = lovIdx;
+                            } else {
+                                const num = parseFloat(key);
+                                if (!isNaN(num)) {
+                                    idx = num;
                                 }
                             }
-                            if (idx != -1) {
+                            if (idx !== undefined) {
                                 marks.push({ value: idx, label: labels[key] });
                             }
                         }


### PR DESCRIPTION
Fixes #2586

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description

Fixed the slider labels functionality to properly handle negative and decimal values. The issue was caused by two problems in the label parsing logic:

1. `parseInt(key, 10)` was used instead of `parseFloat(key)`, causing decimal values like `0.2`, `0.4` to be truncated to `0`
2. `-1` was used as a sentinel value for "not found", which prevented labels at position `-1` from being displayed

The fix uses `parseFloat` for parsing and `undefined` as the sentinel value instead of `-1`.

## Related Tickets & Documents

- Related Issue #2586
- Closes #2586

## How to reproduce the issue

1. Create a slider with decimal step and labels:
```python
tgb.slider(
    value="{None}",
    min=0,
    max=1,
    step=0.1,
    labels={
        0.0: "0",
        0.2: "0.2",
        0.4: "0.4",
        0.6: "0.6",
        0.8: "0.8",
        1.0: "1",
    },
)
```
2. Observe that all labels except 0 and 1 are grouped at position 0

Or with negative values:
```python
tgb.slider(
    value="{None}",
    min=-2,
    max=2,
    step=1,
    labels={
        -2: "-2",
        -1: "-1",  # This label disappears
        0: "0",
        1: "1",
        2: "2",
    },
)
```
3. Observe that the label at position -1 is missing

## Backporting

_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
- [ ] 🔄 **End-to-End tests** have been added or updated.
    - Not needed: Unit tests cover the fix adequately
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    - Not needed: This is a bug fix, no API changes
- [ ] 📌 The **release notes** have been updated.
    - Not needed: Minor bug fix

## Changes

```
 frontend/taipy-gui/src/components/Taipy/Slider.spec.tsx | 47 ++++++++++++++++++++++
 frontend/taipy-gui/src/components/Taipy/Slider.tsx      | 16 ++++----
 2 files changed, 56 insertions(+), 7 deletions(-)
```