### PR TITLE
Better error message when passing global callbacks to Gui and Gui.run

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -201,6 +201,18 @@ class Gui:
 
     __content_providers: dict[type, t.Callable[..., str]] = {}
 
+    # Global callback names that can be set as attributes on the Gui instance
+    __GLOBAL_CALLBACKS = {
+        "on_action",
+        "on_change",
+        "on_init",
+        "on_page_load",
+        "on_navigate",
+        "on_exception",
+        "on_status",
+        "on_user_content",
+    }
+
     # See set_unsupported_data_converter()
     __unsupported_data_converter: t.Optional[t.Callable] = None
 
@@ -214,6 +226,7 @@ class Gui:
         libraries: t.Optional[list[ElementLibrary]] = None,
         script_paths: t.Union[str, Path, list[t.Union[str, Path]], None] = None,
         server: t.Union[str, t.Any] = "flask",
+        **kwargs,
     ):
         """Initialize a new Gui instance.
 
@@ -261,6 +274,21 @@ class Gui:
                 It can be a string representing the type of the server or a server instance.<br/>
                 The default value is `flask`.<br/>
         """
+        # Check for global callback names passed as keyword arguments
+        _callback_args = {k for k in kwargs if k in Gui.__GLOBAL_CALLBACKS}
+        if _callback_args:
+            _cb_list = ", ".join(sorted(_callback_args))
+            raise TypeError(
+                f"Gui.__init__() got unexpected keyword argument(s): {_cb_list}. "
+                f"Global callbacks cannot be passed to the Gui constructor. "
+                f"Please assign them after creating the Gui instance, for example: "
+                f"gui.{next(iter(sorted(_callback_args)))} = {next(iter(sorted(_callback_args)))}"
+            )
+        if kwargs:
+            _unknown = ", ".join(sorted(kwargs))
+            raise TypeError(
+                f"Gui.__init__() got unexpected keyword argument(s): {_unknown}"
+            )
         # store suspected local containing frame
         self.__frame = t.cast(FrameType, t.cast(FrameType, currentframe()).f_back)
         self.__default_module_name = _get_module_name_from_frame(self.__frame)
@@ -2938,6 +2966,18 @@ class Gui:
                 "run_in_thread": run_in_thread,
                 "async_mode": async_mode,
             }
+
+        # Warn if global callback names are passed as keyword arguments to run()
+        _callback_kwargs = {k for k in kwargs if k in Gui.__GLOBAL_CALLBACKS}
+        if _callback_kwargs:
+            _cb_list = ", ".join(sorted(_callback_kwargs))
+            _first_cb = next(iter(sorted(_callback_kwargs)))
+            _warn(
+                f"Gui.run() received global callback argument(s): {_cb_list}. "
+                f"These arguments are not supported by Gui.run() and will be ignored. "
+                f"Please assign them to the Gui instance directly, for example: "
+                f"gui.{_first_cb} = {_first_cb}"
+            )
 
         # Load application config from multiple sources (env files, kwargs, command line)
         self._config._build_config(run_root_dir, self.__env_filename, kwargs)

--- a/tests/gui/gui_specific/test_gui.py
+++ b/tests/gui/gui_specific/test_gui.py
@@ -112,3 +112,26 @@ def test_on_action_call(gui: Gui):
     with gui.get_app_context():
         gui._Gui__on_action(an_id, a_non_action_payload)  # type: ignore[attr-defined]
         gui._Gui__on_action(an_id, an_action_payload)  # type: ignore[attr-defined]
+
+
+def test_init_rejects_global_callback_with_helpful_message():
+    with pytest.raises(TypeError, match="Global callbacks cannot be passed to the Gui constructor"):
+        Gui(page="# test", on_change=lambda s, v, val: None)
+
+
+def test_init_rejects_multiple_global_callbacks_with_helpful_message():
+    with pytest.raises(TypeError, match="Global callbacks cannot be passed to the Gui constructor") as exc_info:
+        Gui(page="# test", on_change=lambda s, v, val: None, on_init=lambda s: None)
+    msg = str(exc_info.value)
+    assert "on_change" in msg
+    assert "on_init" in msg
+
+
+def test_init_rejects_unknown_kwargs():
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        Gui(page="# test", unknown_param=42)
+
+
+def test_run_warns_on_global_callback_kwargs(gui: Gui):
+    with pytest.warns(UserWarning, match="Gui.run\\(\\) received global callback argument"):
+        gui.run(run_server=False, on_change=lambda s, v, val: None)


### PR DESCRIPTION
## Summary

Fixes #2764

- **`Gui.__init__()`**: Now raises a clear `TypeError` with actionable guidance when users mistakenly pass global callback names (`on_change`, `on_init`, `on_navigate`, `on_action`, `on_exception`, `on_status`, `on_page_load`, `on_user_content`) as keyword arguments. The error message directs users to assign them as attributes on the Gui instance instead (e.g., `gui.on_change = handle_change`).
- **`Gui.run()`**: Now emits a warning when global callback names are passed as keyword arguments, since they were previously silently ignored due to not being recognized config keys. The warning provides the same actionable guidance.
- Unknown keyword arguments to `Gui.__init__()` also produce a clear `TypeError` instead of being silently accepted.

### Before
```python
# Raises: TypeError: Gui.__init__() got an unexpected keyword argument 'on_change'
Gui(pages=pages, on_change=handle_change).run()

# Silently does nothing - very confusing to troubleshoot
Gui(pages=pages).run(on_change=handle_change)
```

### After
```python
# Raises: TypeError: Gui.__init__() got unexpected keyword argument(s): on_change.
# Global callbacks cannot be passed to the Gui constructor.
# Please assign them after creating the Gui instance, for example: gui.on_change = on_change
Gui(pages=pages, on_change=handle_change).run()

# Warns: Gui.run() received global callback argument(s): on_change.
# These arguments are not supported by Gui.run() and will be ignored.
# Please assign them to the Gui instance directly, for example: gui.on_change = on_change
Gui(pages=pages).run(on_change=handle_change)
```

## Test plan

- [x] Added `test_init_rejects_global_callback_with_helpful_message` - verifies single callback in `__init__`
- [x] Added `test_init_rejects_multiple_global_callbacks_with_helpful_message` - verifies multiple callbacks in `__init__`
- [x] Added `test_init_rejects_unknown_kwargs` - verifies unknown kwargs still raise `TypeError`
- [x] Added `test_run_warns_on_global_callback_kwargs` - verifies warning in `run()`
- [x] Existing tests continue to pass (normal `Gui()` construction is unaffected)