### PR TITLE
dialog title dynamic

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Dialog.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Dialog.spec.tsx
@@ -44,7 +44,7 @@ describe("Dialog Component", () => {
         const { getByText } = render(
             <HelmetProvider>
                 <Dialog title="Dialog-Test-Title" page="page" open={true} />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         const elt = getByText("Dialog-Test-Title");
         expect(elt.tagName).toBe("H2");
@@ -54,7 +54,7 @@ describe("Dialog Component", () => {
         const { queryAllByText } = render(
             <HelmetProvider>
                 <Dialog title="Dialog-Test-Title" page="page" open={false} />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(queryAllByText("Dialog-Test-Title")).toHaveLength(0);
         const divs = document.getElementsByTagName("div");
@@ -65,7 +65,7 @@ describe("Dialog Component", () => {
         render(
             <HelmetProvider>
                 <Dialog title="Dialog-Test-Title" page="page" open={true} className="taipy-dialog" />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         const elt = document.querySelector(".MuiDialog-root");
         expect(elt).toHaveClass("taipy-dialog");
@@ -79,7 +79,7 @@ describe("Dialog Component", () => {
                     defaultOpen="true"
                     open={undefined as unknown as boolean}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         getByText("Dialog-Test-Title");
     });
@@ -92,7 +92,7 @@ describe("Dialog Component", () => {
                     defaultOpen="true"
                     open={undefined as unknown as boolean}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(getAllByRole("button")).toHaveLength(1);
     });
@@ -106,7 +106,7 @@ describe("Dialog Component", () => {
                     open={undefined as unknown as boolean}
                     labels={JSON.stringify(["toto"])}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(getAllByRole("button")).toHaveLength(2);
     });
@@ -120,7 +120,7 @@ describe("Dialog Component", () => {
                     open={undefined as unknown as boolean}
                     labels={JSON.stringify(["toto", "titi", "toto"])}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(getAllByRole("button")).toHaveLength(4);
     });
@@ -134,7 +134,7 @@ describe("Dialog Component", () => {
                     active={false}
                     labels={JSON.stringify(["testValidate", "testCancel"])}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(getByText("testValidate")).toBeDisabled();
         expect(getByText("testCancel")).toBeDisabled();
@@ -148,7 +148,7 @@ describe("Dialog Component", () => {
                     open={true}
                     labels={JSON.stringify(["testValidate", "testCancel"])}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(getByText("testValidate")).not.toBeDisabled();
         expect(getByText("testCancel")).not.toBeDisabled();
@@ -163,7 +163,7 @@ describe("Dialog Component", () => {
                     active={true}
                     labels={JSON.stringify(["testValidate", "testCancel"])}
                 />
-            </HelmetProvider>
+            </HelmetProvider>,
         );
         expect(getByText("testValidate")).not.toBeDisabled();
         expect(getByText("testCancel")).not.toBeDisabled();
@@ -183,7 +183,7 @@ describe("Dialog Component", () => {
                         onAction="testValidateAction"
                     />
                 </HelmetProvider>
-            </TaipyContext.Provider>
+            </TaipyContext.Provider>,
         );
         await userEvent.click(getByTitle("Close"));
         expect(dispatch).toHaveBeenLastCalledWith({
@@ -208,7 +208,7 @@ describe("Dialog Component", () => {
                         onAction="testValidateAction"
                     />
                 </HelmetProvider>
-            </TaipyContext.Provider>
+            </TaipyContext.Provider>,
         );
         await userEvent.click(getByText("testValidate"));
         expect(dispatch).toHaveBeenLastCalledWith({
@@ -233,7 +233,7 @@ describe("Dialog Component", () => {
                         onAction="testValidateAction"
                     />
                 </HelmetProvider>
-            </TaipyContext.Provider>
+            </TaipyContext.Provider>,
         );
         await userEvent.click(getByText("Another One"));
         expect(dispatch).toHaveBeenLastCalledWith({
@@ -245,8 +245,10 @@ describe("Dialog Component", () => {
     it("should log an error when labels prop is not a valid JSON string", () => {
         const consoleSpy = jest.spyOn(console, "info");
         render(<Dialog title={"Dialog-Test-Title"} labels={"not a valid JSON string"} />);
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Error parsing dialog.labels"),
-            expect.any(SyntaxError),);
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining("Error parsing dialog.labels"),
+            expect.any(SyntaxError),
+        );
     });
     it("should apply width and height styles when they are provided", async () => {
         const { findByRole } = render(<Dialog title="Dialog-Test-Title" width="500px" height="300px" open={true} />);
@@ -263,7 +265,7 @@ describe("Dialog Component", () => {
     it("calls localAction prop when handleAction is triggered", async () => {
         const localActionMock = jest.fn();
         const { getByLabelText } = render(
-            <Dialog id="test-dialog" title="Test Dialog" localAction={localActionMock} open={true} />
+            <Dialog id="test-dialog" title="Test Dialog" localAction={localActionMock} open={true} />,
         );
         const closeButton = getByLabelText("close");
         await fireEvent.click(closeButton);
@@ -277,11 +279,17 @@ describe("Dialog Component", () => {
                     Hello
                 </Dialog>
                 <div>Outside</div>
-            </>
+            </>,
         );
         getByText("Hello");
         getByText("Outside");
-        await userEvent.keyboard("{Escape}")
+        await userEvent.keyboard("{Escape}");
         expect(localActionMock).toHaveBeenCalledWith(-1);
+    });
+    it("shows dynamic title", async () => {
+        const { getByText, rerender } = render(<Dialog defaultTitle={"Dynamic Title"} page="page" open={true} />);
+        getByText("Dynamic Title");
+        rerender(<Dialog defaultTitle={"Dynamic Title"} page="page" open={true} title={"Updated Title"} />);
+        getByText("Updated Title");
     });
 });

--- a/frontend/taipy-gui/src/components/Taipy/Dialog.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Dialog.tsx
@@ -81,7 +81,6 @@ const popoverAnchor: PopoverOrigin = {
 const Dialog = (props: DialogProps) => {
     const {
         id,
-        title,
         defaultOpen,
         open,
         onAction = "",
@@ -100,6 +99,7 @@ const Dialog = (props: DialogProps) => {
     const active = useDynamicProperty(props.active, props.defaultActive, true);
     const hover = useDynamicProperty(props.hoverText, props.defaultHoverText, undefined);
     const refId = useDynamicProperty(props.refId, props.defaultRefId, undefined);
+    const title = useDynamicProperty(props.title, props.defaultTitle, "");
 
     const handleAction = useCallback(
         (evt: MouseEvent<HTMLElement>) => {

--- a/frontend/taipy-gui/src/components/Taipy/Dialog.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Dialog.tsx
@@ -30,7 +30,8 @@ import { useClassNames, useDispatch, useDynamicProperty, useModule } from "../..
 import { getComponentClassName } from "./TaipyStyle";
 
 interface DialogProps extends TaipyActiveProps {
-    title: string;
+    title?: string;
+    defaultTitle?: string;
     onAction?: string;
     closeLabel?: string;
     labels?: string;
@@ -110,7 +111,7 @@ const Dialog = (props: DialogProps) => {
                 dispatch(createSendActionNameAction(id, module, onAction, parseInt(idx, 10)));
             }
         },
-        [dispatch, id, onAction, module, localAction]
+        [dispatch, id, onAction, module, localAction],
     );
 
     const labels = useMemo(() => {

--- a/taipy/gui/_hook.py
+++ b/taipy/gui/_hook.py
@@ -43,8 +43,8 @@ class _Hooks(object, metaclass=_Singleton):
                     if not callable(func):
                         raise Exception(f"'{name}' hook is not callable")
                     res = func(*args, **kwargs)
-                except Exception as e:
-                    _TaipyLogger._get_logger().exception("Error while calling hook '%s':", name, exc_info=e)
+                except Exception:
+                    _TaipyLogger._get_logger().exception("Error while calling hook '%s':", name)
                     return
                 # check if the hook returns True -> stop the chain
                 if res is True:

--- a/taipy/gui/_hook.py
+++ b/taipy/gui/_hook.py
@@ -44,7 +44,7 @@ class _Hooks(object, metaclass=_Singleton):
                         raise Exception(f"'{name}' hook is not callable")
                     res = func(*args, **kwargs)
                 except Exception as e:
-                    _TaipyLogger._get_logger().exception("Error while calling hook '%s':", name)
+                    _TaipyLogger._get_logger().exception("Error while calling hook '%s':", name, exc_info=e)
                     return
                 # check if the hook returns True -> stop the chain
                 if res is True:

--- a/taipy/gui/_hook.py
+++ b/taipy/gui/_hook.py
@@ -28,7 +28,7 @@ class _Hooks(object, metaclass=_Singleton):
         # Prevent duplicated hooks
         for h in self.__hooks:
             if type(hook) is type(h):
-                _TaipyLogger._get_logger().info(f"Failed to register duplicated hook of type '{type(h)}'")
+                _TaipyLogger._get_logger().info("Failed to register duplicated hook of type '%s'", type(hook).__name__)
                 return
         self.__hooks.append(hook)
 
@@ -44,7 +44,7 @@ class _Hooks(object, metaclass=_Singleton):
                         raise Exception(f"'{name}' hook is not callable")
                     res = func(*args, **kwargs)
                 except Exception as e:
-                    _TaipyLogger._get_logger().error(f"Error while calling hook '{name}': {e}")
+                    _TaipyLogger._get_logger().exception("Error while calling hook '%s':", name)
                     return
                 # check if the hook returns True -> stop the chain
                 if res is True:

--- a/taipy/gui/_renderers/__init__.py
+++ b/taipy/gui/_renderers/__init__.py
@@ -88,12 +88,12 @@ class _Renderer(Page, ABC):
             encoding = "utf-8"
             if self._encoding is not None:
                 encoding = self._encoding
-                _TaipyLogger._get_logger().info(f"'{encoding}' encoding was used to decode file '{content}'.")
+                _TaipyLogger._get_logger().info("'%s' encoding was used to decode file '%s'.", encoding, content)
             elif (detected_encoding := t.cast(str, detect(file_content).get("encoding"))) is not None:
                 encoding = detected_encoding
-                _TaipyLogger._get_logger().info(f"Detected '{encoding}' encoding for file '{content}'.")
+                _TaipyLogger._get_logger().info("Detected '%s' encoding for file '%s'.", encoding, content)
             else:
-                _TaipyLogger._get_logger().info(f"Using default '{encoding}' encoding for file '{content}'.")
+                _TaipyLogger._get_logger().info("Using default '%s' encoding for file '%s'.", encoding, content)
             self._content = self.__sanitize_content(file_content.decode(encoding))
             # Save file path for error handling
             self._filepath = content

--- a/taipy/gui/_renderers/factory.py
+++ b/taipy/gui/_renderers/factory.py
@@ -217,7 +217,7 @@ class _Factory:
         .set_attributes(
             [
                 ("page",),
-                ("title",),
+                ("title", PropertyType.dynamic_string),
                 ("on_action", PropertyType.function),
                 ("close_label", PropertyType.string),
                 ("labels", PropertyType.string_list),

--- a/taipy/gui/_renderers/utils.py
+++ b/taipy/gui/_renderers/utils.py
@@ -123,4 +123,4 @@ class FileWatchdogHandler(FileSystemEventHandler):
         self._last_modified = datetime.datetime.now()
         if Path(event.src_path).resolve() == Path(self._file_path).resolve():
             self._renderer.set_content(self._file_path)
-            _TaipyLogger._get_logger().info(f"File '{self._file_path}' has been modified.")
+            _TaipyLogger._get_logger().info("File '%s' has been modified.", self._file_path)

--- a/taipy/gui/builder/_api_generator.py
+++ b/taipy/gui/builder/_api_generator.py
@@ -86,12 +86,13 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
         library_name = library.get_name()
         if self.__module is None:
             _TaipyLogger._get_logger().info(
-                f"Python API for extension library '{library_name}' is not available. To fix this, import 'taipy.gui.builder' before importing the extension library."  # noqa: E501
+                "Python API for extension library '%s' is not available. To fix this, import 'taipy.gui.builder' before importing the extension library.",  # noqa: E501
+                library_name,
             )
             return
         library_module = sys.modules[library.__module__]
         if not library_module.__package__:
-            _TaipyLogger._get_logger().info(f"Cannot locate package for extension library `{library_name}`.")
+            _TaipyLogger._get_logger().info("Cannot locate package for extension library '%s'.", library_name)
             return
         package_module = sys.modules[library_module.__package__]
         for element_name, element in library.get_elements().items():
@@ -105,7 +106,9 @@ class _ElementApiGenerator(object, metaclass=_Singleton):
             # Allow element to be accessed from this module (taipy.gui.builder)
             if hasattr(self.__module, element_name):
                 _TaipyLogger._get_logger().info(
-                    f"Can't add element `{element_name}` of library `{library_name}` to the root of Builder API as another element with the same name already exists."  # noqa: E501
+                    "Can't add element '%s' of library '%s' to the root of Builder API as another element with the same name already exists.",  # noqa: E501
+                    element_name,
+                    library_name,
                 )
             else:
                 setattr(self.__module, element_name, element_api)

--- a/taipy/gui/data/data_scope.py
+++ b/taipy/gui/data/data_scope.py
@@ -59,7 +59,8 @@ class _DataScopes:
             return self.__scopes[_DataScopes._GLOBAL_ID], self.__scopes_metadata[_DataScopes._GLOBAL_ID]
         if client_id not in self.__scopes:
             _TaipyLogger._get_logger().debug(
-                f"Session id {client_id} not found in data scope. Taipy will automatically create a scope for this session id but you may have to reload your page."  # noqa: E501
+                "Session id '%s' not found in data scope. Taipy will automatically create a scope for this session id but you may have to reload your page.",  # noqa: E501
+                client_id,
             )
             self.create_scope(client_id)
         return self.__scopes[client_id], self.__scopes_metadata[client_id]

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1195,7 +1195,7 @@ class Gui:
         in_custom_page_context = _Hooks()._is_in_custom_page_context()
         for _var in modified_vars:
             if not self.__is_front_end_variable(_var) and not in_custom_page_context:
-                _TaipyLogger._get_logger().debug(f"Skipping variable '{_var}' not in front-end.")
+                _TaipyLogger._get_logger().debug("Skipping variable '%s' not in front-end.", _var)
                 continue
             newvalue = values.get(_var)
             if isinstance(newvalue, (_TaipyData)) or (
@@ -2826,7 +2826,7 @@ class Gui:
         if hasattr(self, "_ngrok"):
             # Keep the ngrok instance if token has not changed
             if app_config.get("ngrok_token") == self._ngrok[1]:
-                _TaipyLogger._get_logger().info(f" * NGROK Public Url: {self._ngrok[0].public_url}")
+                _TaipyLogger._get_logger().info(" * NGROK Public Url: %s", self._ngrok[0].public_url)
                 return
             # Close the old tunnel so new tunnel can open for new token
             ngrok.disconnect(self._ngrok[0].public_url)  # type: ignore[reportPossiblyUnboundVariable]
@@ -2835,7 +2835,7 @@ class Gui:
                 raise RuntimeError("Cannot use ngrok as pyngrok package is not installed.")
             ngrok.set_auth_token(token)  # type: ignore[reportPossiblyUnboundVariable]
             self._ngrok = (ngrok.connect(app_config.get("port"), "http"), token)  # type: ignore[reportPossiblyUnboundVariable]
-            _TaipyLogger._get_logger().info(f" * NGROK Public Url: {self._ngrok[0].public_url}")
+            _TaipyLogger._get_logger().info(" * NGROK Public Url: %s", self._ngrok[0].public_url)
 
     def __bind_default_function(self):
         with self.get_app_context():

--- a/taipy/gui/servers/flask/server.py
+++ b/taipy/gui/servers/flask/server.py
@@ -377,10 +377,10 @@ class _FlaskServer(_Server):
             log = logging.getLogger("werkzeug")
             log.disabled = True
             operation = "reloaded" if self.is_running_from_reloader() else "starting"
-            _TaipyLogger._get_logger().info(f" * Server {operation} on {server_url}{message_details}")
+            _TaipyLogger._get_logger().info(" * Server %s on %s%s", operation, server_url, message_details)
             if client_url is not None:
                 client_url = client_url.format(port=port)
-                _TaipyLogger._get_logger().info(f" * Application is accessible at {client_url}")
+                _TaipyLogger._get_logger().info(" * Application is accessible at %s", client_url)
         if not self.is_running_from_reloader() and self._gui._get_config("run_browser", False):  # type: ignore[attr-defined]
             webbrowser.open(client_url or server_url, new=2)
         if _is_in_notebook() or run_in_thread:

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1798,6 +1798,12 @@
                         "doc": "If True, the dialog is visible. If False, it is hidden."
                     },
                     {
+                        "name": "title",
+                        "type": "dynamic(str)",
+                        "default_value": "None",
+                        "doc": "The title of the dialog, displayed at the top of the dialog."
+                    },
+                    {
                         "name": "on_action",
                         "type": "Union[str, Callable]",
                         "doc": "A function or the name of a function triggered when a button is pressed.<br/>This function is invoked with the following parameters:<ul><li><i>state</i> (<code>State^</code>): the state instance.</li><li><i>id</i> (str): the identifier of the dialog if it has one.</li><li><i>payload</i> (dict): the details on this callback's invocation.<br/>This dictionary has the following keys:\n<ul><li><i>action:</i>: the name of the action that triggered this callback.</li><li><i>args:</i>: a list where the first element contains the index of the selected label.</li></ul></li></ul>",

--- a/taipy/gui/viselements.json
+++ b/taipy/gui/viselements.json
@@ -1801,7 +1801,7 @@
                         "name": "title",
                         "type": "dynamic(str)",
                         "default_value": "None",
-                        "doc": "The title of the dialog, displayed at the top of the dialog."
+                        "doc": "The title displayed at the top of the dialog. If None, no title is shown."
                     },
                     {
                         "name": "on_action",

--- a/tests/gui/builder/control/test_dialog.py
+++ b/tests/gui/builder/control/test_dialog.py
@@ -24,7 +24,7 @@ def test_dialog_builder_1(gui: Gui, helpers):
         "<Dialog",
         'onAction="validate_action"',
         'page="page_test"',
-        'title="This is a Dialog"',
+        'defaultTitle="This is a Dialog"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',
     ]
@@ -35,9 +35,10 @@ def test_dialog_builder_2(gui: Gui, helpers):
     gui._set_frame(inspect.currentframe())
     partial = gui.add_partial(Markdown("# A partial"))  # noqa: F841
     dialog_open = False  # noqa: F841
+    title = "Another Dialog"  # noqa: F841
     with tgb.Page(frame=None) as page:
         tgb.dialog(  # type: ignore[attr-defined]
-            title="Another Dialog",
+            title="{title}",
             open="{dialog_open}",
             partial="{partial}",
             on_action="validate_action",
@@ -45,7 +46,8 @@ def test_dialog_builder_2(gui: Gui, helpers):
     expected_list = [
         "<Dialog",
         'page="TaiPy_partials',
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
+        'title="{!',
         'onAction="validate_action"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',
@@ -67,7 +69,7 @@ def test_dialog_labels_builder(gui: Gui, helpers):
     expected_list = [
         "<Dialog",
         'page="page_test"',
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
         'labels="[&quot;Cancel&quot;, &quot;Validate&quot;]"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'closeLabel="MYClose"',
@@ -80,7 +82,7 @@ def test_dialog_builder_block(gui: Gui, helpers):
         tgb.text(value="This is in a dialog")  # type: ignore[attr-defined]
     expected_list = [
         "<Dialog",
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
         "This is in a dialog",
     ]
     helpers.test_control_builder(gui, tgb.Page(content, frame=None), expected_list)

--- a/tests/gui/control/test_dialog.py
+++ b/tests/gui/control/test_dialog.py
@@ -22,7 +22,7 @@ def test_dialog_md_1(gui: Gui, helpers):
         "<Dialog",
         'onAction="validate_action"',
         'page="page_test"',
-        'title="This is a Dialog"',
+        'defaultTitle="This is a Dialog"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',
     ]
@@ -33,11 +33,13 @@ def test_dialog_md_2(gui: Gui, helpers):
     gui._set_frame(inspect.currentframe())
     partial = gui.add_partial(Markdown("# A partial"))  # noqa: F841
     dialog_open = False  # noqa: F841
-    md_string = "<|dialog|title=Another Dialog|open={dialog_open}|partial={partial}|on_action=validate_action|>"
+    title = "Another Dialog"  # noqa: F841
+    md_string = "<|dialog|title={title}|open={dialog_open}|partial={partial}|on_action=validate_action|>"
     expected_list = [
         "<Dialog",
         'page="TaiPy_partials',
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
+        'title="{!',
         'onAction="validate_action"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',
@@ -54,7 +56,7 @@ def test_dialog_labels_md(gui: Gui, helpers):
     expected_list = [
         "<Dialog",
         'page="page_test"',
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
         'labels="[&quot;Cancel&quot;, &quot;Validate&quot;]"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'closeLabel="MYClose"',
@@ -72,7 +74,7 @@ def test_dialog_html_1(gui: Gui, helpers):
     expected_list = [
         "<Dialog",
         'page="page1"',
-        'title="This is a Dialog"',
+        'defaultTitle="This is a Dialog"',
         'onAction="validate_action"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',
@@ -90,7 +92,7 @@ def test_dialog_html_2(gui: Gui, helpers):
     expected_list = [
         "<Dialog",
         'page="TaiPy_partials',
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
         'onAction="validate_action"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',
@@ -107,7 +109,7 @@ def test_dialog_labels_html(gui: Gui, helpers):
     expected_list = [
         "<Dialog",
         'page="page_test"',
-        'title="Another Dialog"',
+        'defaultTitle="Another Dialog"',
         'labels="[&quot;Cancel&quot;, &quot;Validate&quot;]"',
         'updateVarName="_TpB_tpec_TpExPr_dialog_open_TPMDL_0"',
         'open="{!_TpB_tpec_TpExPr_dialog_open_TPMDL_0',


### PR DESCRIPTION

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
Dialog dynamic title And log without f-string


## Related Tickets & Documents
- Closes #2846 

## How to reproduce the issue

```py
from taipy.gui import Gui, State, notify

open_dialog = True

dialog_title = "Are you a scientist?"

modal_dialog = """
<|{open_dialog}|dialog|title={dialog_title}|width=30%|
**Warning**
You must be a scientist to be able to view this page
<br/>
<|I am a scientist|button|class_name=fullwidth plain|on_action=close_modal_window_and_render_page|>
<|Change Title|button|on_action={lambda s: s.assign(dialog_title="New Title")}|>
|>

<|part|render={not open_dialog}|
All the sciency stuff now shows up here
|>
"""


def close_modal_window_and_render_page(state: State):
    state.open_dialog = False
    notify(state, "S", "Welcome, Scientist!")

if __name__ == "__main__":
    gui = Gui(page=modal_dialog)
    gui.run(title="#2846 Open Dialog Demo")
```

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [ ] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [ ] ✅ This solution meets the acceptance criteria of the related issue.
- [ ] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
