### PR TITLE
fix: pass updateVarName instead of id in Chat action dispatch

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Chat.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.spec.tsx
@@ -140,7 +140,7 @@ describe("Chat Component", () => {
         await userEvent.keyboard("new message{Enter}");
         expect(dispatch).toHaveBeenCalledWith({
             type: "SEND_ACTION_ACTION",
-            name: "",
+            name: "varName",
             context: undefined,
             payload: {
                 action: undefined,
@@ -162,7 +162,7 @@ describe("Chat Component", () => {
         await userEvent.click(getByRole("button", { name: /send message/i }));
         expect(dispatch).toHaveBeenCalledWith({
             type: "SEND_ACTION_ACTION",
-            name: "",
+            name: "varName",
             context: undefined,
             payload: {
                 action: undefined,

--- a/frontend/taipy-gui/src/components/Taipy/Chat.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Chat.tsx
@@ -284,7 +284,7 @@ const Chat = (props: ChatProps) => {
                     .then((dataUrl) => {
                         dispatch(
                             createSendActionNameAction(
-                                id,
+                                updateVarName,
                                 module,
                                 onAction,
                                 reason,
@@ -305,7 +305,7 @@ const Chat = (props: ChatProps) => {
                     .catch(console.debug);
             }
         },
-        [imagePreview, updateVarName, onAction, senderId, id, dispatch, module]
+        [imagePreview, updateVarName, onAction, senderId, dispatch, module]
     );
 
     const handleAction = useCallback(


### PR DESCRIPTION
The Chat component passed its HTML element id (undefined when not explicitly set by the user) as the first argument to createSendActionNameAction. This caused the WebSocket message name to be empty, making _get_real_var_name("") return "" on the backend, resulting in an empty var_name in the on_action callback.

Changed to pass updateVarName (the hashed messages variable name), matching how PaginatedTable and AutoLoadingTable dispatch actions. Updated test assertions accordingly.

Fixes #2584

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
<!-- Provide a clear and concise description of the changes introduced in this PR. -->

## Related Tickets & Documents

<!--
For pull requests that relate to or close an issue, please include them below.
Following [GitHub's guidance on linking issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) helps with automation.

Example:
- Closes #1234
- Related to #5678
-->

- Related Issue #
- Closes #2584

## How to reproduce the issue

<!-- Provide step-by-step instructions to reproduce the issue or test the feature. -->

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [ ] 📝 The related issue checklist is completed.
- [ ] 🧪 This PR includes **unit tests** for the developed code.
    If not, explain why:
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
