### PR TITLE
fix(gui): resolve date and date_range day loss in negative UTC offsets (#2879)

### DIFF
--- a/frontend/taipy-gui/package-lock.json
+++ b/frontend/taipy-gui/package-lock.json
@@ -147,7 +147,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -768,7 +767,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -792,7 +790,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -899,7 +896,6 @@
             "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
             "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -943,7 +939,6 @@
             "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
             "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
                 "@emotion/babel-plugin": "^11.13.5",
@@ -2084,7 +2079,6 @@
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
             "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
                 "@mui/core-downloads-tracker": "^9.0.1",
@@ -2195,7 +2189,6 @@
             "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
             "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
                 "@mui/private-theming": "^9.0.1",
@@ -2924,7 +2917,8 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -3237,7 +3231,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -3248,7 +3241,6 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -3382,7 +3374,6 @@
             "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.59.2",
                 "@typescript-eslint/types": "8.59.2",
@@ -4091,7 +4082,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4658,7 +4648,6 @@
             "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.26.0"
             }
@@ -4838,7 +4827,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -5773,8 +5761,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/d": {
             "version": "1.0.2",
@@ -6001,7 +5988,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
             "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -6218,7 +6204,8 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -6871,7 +6858,6 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -8789,7 +8775,6 @@
             "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/html-minifier-terser": "^6.0.0",
                 "html-minifier-terser": "^6.0.2",
@@ -9748,7 +9733,6 @@
             "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.3.0",
                 "@jest/types": "30.3.0",
@@ -10864,7 +10848,6 @@
             "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.2.1",
                 "data-urls": "^5.0.0",
@@ -11290,6 +11273,7 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -13008,7 +12992,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -13100,7 +13083,6 @@
             "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-3.5.1.tgz",
             "integrity": "sha512-rUzQ7Q46whi1aWT2JlvKE2dnryNORPrxyy66OGSMXgejK3XgD4ysD9SapMOI1RzzUJyX0KbfVDFcB9/DqOyH9Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@plotly/d3": "3.8.2",
                 "@plotly/d3-sankey": "0.7.2",
@@ -13192,7 +13174,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -13354,6 +13335,7 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -13369,6 +13351,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -13517,7 +13500,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
             "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13542,7 +13524,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
             "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -14268,7 +14249,6 @@
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -15830,7 +15810,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16232,7 +16211,6 @@
             "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -16856,7 +16834,6 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/frontend/taipy-gui/src/components/Taipy/DateSelector.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/DateSelector.spec.tsx
@@ -250,6 +250,7 @@ describe("DateSelector with time Component", () => {
             <LocalizationProvider dateAdapter={AdapterDateFns}>
                 <DateSelector
                     defaultDate="2011-01-01T00:10:01.001Z"
+                    withTime={true}
                     date={undefined as unknown as string}
                     format="yy-MM-dd mm"
                 />

--- a/frontend/taipy-gui/src/utils/index.spec.ts
+++ b/frontend/taipy-gui/src/utils/index.spec.ts
@@ -14,7 +14,7 @@
 import "@testing-library/jest-dom";
 import { FormatConfig } from "../context/taipyReducers";
 
-import { getNumberString, getDateTimeString } from "./index";
+import { getNumberString, getDateTimeString, getDateTime, getTimeZonedDate } from "./index";
 
 let myWarn: jest.Mock;
 
@@ -108,3 +108,33 @@ describe("getDateTimeString", () => {
         expect(myWarn).toHaveBeenCalledWith("Invalid date format:", "Invalid time value")
     });
 });
+
+describe("getDateTime and getTimeZonedDate date-only parsing and formatting", () => {
+    it("getDateTime parses date-only string as local midnight without timezone offset when withTime is false", () => {
+        const dateVal = getDateTime("2025-06-06", "UTC", false);
+        expect(dateVal).not.toBeNull();
+        expect(dateVal!.getFullYear()).toBe(2025);
+        expect(dateVal!.getMonth()).toBe(5); // 0-based June is 5
+        expect(dateVal!.getDate()).toBe(6);
+    });
+
+    it("getTimeZonedDate keeps local date components exactly as selected and sets time to 00:00 when withTime is false", () => {
+        const localDate = new Date(2025, 5, 6, 12, 30, 15);
+        const result = getTimeZonedDate(localDate, "America/Los_Angeles", false);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(5);
+        expect(result.getDate()).toBe(6);
+        expect(result.getHours()).toBe(0);
+        expect(result.getMinutes()).toBe(0);
+        expect(result.getSeconds()).toBe(0);
+    });
+
+    it("getTimeZonedDate clones the date object to prevent in-place mutation of the original date object", () => {
+        const localDate = new Date(2025, 5, 6);
+        const originalTime = localDate.getTime();
+        const result = getTimeZonedDate(localDate, "America/Los_Angeles", false);
+        expect(result).not.toBe(localDate);
+        expect(localDate.getTime()).toBe(originalTime);
+    });
+});
+

--- a/frontend/taipy-gui/src/utils/index.ts
+++ b/frontend/taipy-gui/src/utils/index.ts
@@ -72,20 +72,20 @@ interface StyleKit {
 
 // return date with right time and tz
 export const getTimeZonedDate = (d: Date, tz: string, withTime: boolean): Date => {
-    const newDate = d;
-    // dispatch new date which offset by the timeZone differences between client and server
-    const hours = getClientServerTimeZoneOffset(tz) / 60;
-    const minutes = getClientServerTimeZoneOffset(tz) % 60;
+    const newDate = new Date(d);
     newDate.setSeconds(0);
     newDate.setMilliseconds(0);
     if (withTime) {
+        // dispatch new date which offset by the timeZone differences between client and server
+        const hours = getClientServerTimeZoneOffset(tz) / 60;
+        const minutes = getClientServerTimeZoneOffset(tz) % 60;
         // Parse data with selected time if it is a datetime selector
         newDate.setHours(newDate.getHours() + hours);
         newDate.setMinutes(newDate.getMinutes() + minutes);
     } else {
-        // Parse data with 00:00 UTC time if it is a date selector
-        newDate.setHours(hours);
-        newDate.setMinutes(minutes);
+        // Keep the local date components exactly as selected for date-only components
+        newDate.setHours(0);
+        newDate.setMinutes(0);
     }
     return newDate;
 };
@@ -103,6 +103,12 @@ export const getDateTime = (value: string | null | undefined, tz?: string, withT
         return null;
     }
     try {
+        if (!withTime) {
+            const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+            if (match) {
+                return new Date(parseInt(match[1], 10), parseInt(match[2], 10) - 1, parseInt(match[3], 10));
+            }
+        }
         return tz && tz !== "Etc/Unknown" && withTime ? toZonedTime(value, tz) : new Date(value);
     } catch {
         return null;


### PR DESCRIPTION
- Avoid direct in-place mutation of Date objects by cloning them inside getTimeZonedDate
- Avoid applying timezone offset adjustments to date-only pickers (withTime=false)
- Parse date-only ISO strings (YYYY-MM-DD) as local midnight instead of UTC midnight in getDateTime
- Add unit tests verifying robust local date-only parsing and formatting
- Fix missing withTime prop in DateSelector.spec.tsx test

## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
This PR fixes a critical bug where `tgb.date` and `tgb.date_range` with `with_time=False` lose exactly one day every time a new date is selected if the browser is in a timezone with a negative UTC offset (e.g., `America/Los_Angeles` which is UTC-0700).

### 🔍 Root Cause
1. **ECMAScript ISO Date Parsing**: In `getDateTime()`, date-only ISO strings (like `"2025-06-06"`) were parsed using `new Date(value)`. The JS standard specifies that date-only ISO strings should be parsed as **UTC midnight**. In a negative timezone, UTC midnight translates to the previous day in local time (e.g. June 5th 17:00:00), leading to a day-loss on initial rendering.
2. **In-place State Mutation & Timezone Offsetting**: In `getTimeZonedDate()`, timezone adjustments directly mutated the Date object in-place (`const newDate = d`), polluting the React component state. Additionally, date-only values were being shifted by timezone offset hours, leading to cumulative day-loss on updates.

### 🛠️ Proposed Changes
- **Clone Date Instances**: Updated `getTimeZonedDate()` to clone the incoming date (`const newDate = new Date(d)`) to protect React state against side-effects.
- **Skip Timezone Adjustments for Date-Only Pickers**: Bypassed timezone addition/subtraction when `withTime` is `false` inside `getTimeZonedDate()`. Local hours and minutes are now cleanly set to local midnight (`00:00`), ensuring the local date components match exactly what the user selected.
- **Local Midnight Parsing**: Configured `getDateTime()` to detect date-only strings (matching `^(\d{4})-(\d{2})-(\d{2})`) and construct the `Date` object using local date components (`new Date(year, monthIndex, day)`) instead of UTC midnight.
- **Spec Improvements**:
  - Added a missing `withTime={true}` prop to a test inside `DateSelector.spec.tsx` that asserts time formatting.
  - Added 3 new unit tests to `index.spec.ts` validating robust date-only parsing, formatting, and clone/non-mutation behaviors.

---

## Related Tickets & Documents
- Closes #2879

---

## How to reproduce the issue
1. Set your machine's system time or browser timezone to a negative offset (e.g. `America/New_York` or `America/Los_Angeles`).
2. Run a Taipy application with a date selector: `<tgb:date d="{date_var}" with_time="False"/>`
3. Select any date (e.g., `06/06/2025`). The display will immediately slip back and show `06/05/2025`.

---

## Backporting
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

---

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [x] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why: No E2E UI-level automation tests were added because the bug and its fix reside in core client-side parsing utility code, which is 100% covered and verified by the new unit tests in `index.spec.ts` and component tests in `DateSelector.spec.tsx`.
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why: The public API, properties, and configuration syntax remain unchanged; this is an internal logic fix.
- [ ] 📌 The **release notes** have been updated.
    If not, explain why: Standard internal bugfix; will be logged automatically by maintainers on merge.
