### PR TITLE
Fix table edits with dataframe indexes

### DIFF
--- a/taipy/gui/data/pandas_data_accessor.py
+++ b/taipy/gui/data/pandas_data_accessor.py
@@ -550,14 +550,14 @@ class _PandasDataAccessor(_DataAccessor):
 
     def on_edit(self, value: t.Any, payload: t.Dict[str, t.Any]):
         df = self.to_pandas(value)
-        if not isinstance(df, pd.DataFrame) or not isinstance(payload.get("index"), (int, float)):
+        if not isinstance(df, pd.DataFrame) or "index" not in payload:
             raise ValueError(f"Cannot edit {type(value)} at {payload.get('index')}.")
         df.at[self._get_index_value(payload.get("index", 0)), payload["col"]] = payload["value"]
         return self._from_pandas(df, type(value))
 
     def on_delete(self, value: t.Any, payload: t.Dict[str, t.Any]):
         df = self.to_pandas(value)
-        if not isinstance(df, pd.DataFrame) or not isinstance(payload.get("index"), (int, float)):
+        if not isinstance(df, pd.DataFrame) or "index" not in payload:
             raise ValueError(f"Cannot delete a row from {type(value)} at {payload.get('index')}.")
         return self._from_pandas(df.drop(self._get_index_value(payload.get("index", 0))), type(value))
 

--- a/tests/gui/data/test_pandas_data_accessor.py
+++ b/tests/gui/data/test_pandas_data_accessor.py
@@ -383,6 +383,18 @@ def test_edit(gui, small_dataframe):
     assert ret_data["value"].iloc[0] == 10
 
 
+def test_edit_dataframe_with_string_index(gui, small_dataframe):
+    accessor = _PandasDataAccessor(gui)
+    pd = pandas.DataFrame(small_dataframe, index=["row-a", "row-b", "row-c"])
+    ln = len(pd)
+
+    ret_data = accessor.on_edit(pd, {"index": "row-b", "col": "value", "value": 10})
+
+    assert isinstance(ret_data, pandas.DataFrame)
+    assert len(ret_data) == ln
+    assert ret_data.at["row-b", "value"] == 10
+
+
 def test_delete(gui, small_dataframe):
     accessor = _PandasDataAccessor(gui)
     pd = pandas.DataFrame(small_dataframe)
@@ -390,6 +402,18 @@ def test_delete(gui, small_dataframe):
     ret_data = accessor.on_delete(pd, {"index": 0})
     assert isinstance(ret_data, pandas.DataFrame)
     assert len(ret_data) == ln - 1
+
+
+def test_delete_dataframe_with_string_index(gui, small_dataframe):
+    accessor = _PandasDataAccessor(gui)
+    pd = pandas.DataFrame(small_dataframe, index=["row-a", "row-b", "row-c"])
+    ln = len(pd)
+
+    ret_data = accessor.on_delete(pd, {"index": "row-b"})
+
+    assert isinstance(ret_data, pandas.DataFrame)
+    assert len(ret_data) == ln - 1
+    assert "row-b" not in ret_data.index
 
 
 def test_add(gui, small_dataframe):


### PR DESCRIPTION
## What changed

This fixes #2747 by allowing table edit/delete callbacks to use the dataframe index value returned by the frontend instead of requiring it to be numeric.

Dataframes with non-default indexes can now update or delete the selected row through the existing pandas index path, while the previous numeric-index behavior is preserved.

## Tests

- `python -m ruff check taipy/gui/data/pandas_data_accessor.py tests/gui/data/test_pandas_data_accessor.py`
- `git diff --check`

I also tried `python -m pytest tests/gui/data/test_pandas_data_accessor.py -q`, but this local machine only has Python 3.14 while the project declares `requires-python = ">=3.9,<3.13"`; the test run stopped during import in SQLAlchemy before reaching these tests.