### PR TITLE
fix: clean up deleted jobs from orchestrator during scenario deletion

### DIFF
--- a/taipy/core/_orchestrator/_orchestrator.py
+++ b/taipy/core/_orchestrator/_orchestrator.py
@@ -289,6 +289,19 @@ class _Orchestrator(_AbstractOrchestrator):
                 cls._unlock_edit_on_jobs_outputs(to_cancel_or_abandon_jobs)
 
     @classmethod
+    def _remove_jobs(cls, jobs: Iterable[Union[Job, JobId]]) -> None:
+        with cls.lock:
+            job_ids = {job.id if isinstance(job, Job) else job for job in jobs}
+            cls.blocked_jobs = [job for job in cls.blocked_jobs if job.id not in job_ids]
+
+            new_jobs_to_run: Queue = Queue()
+            while not cls.jobs_to_run.empty():
+                current_job = cls.jobs_to_run.get()
+                if current_job.id not in job_ids:
+                    new_jobs_to_run.put(current_job)
+            cls.jobs_to_run = new_jobs_to_run
+
+    @classmethod
     def __find_subsequent_jobs(cls, submit_id, output_dn_config_ids: Set) -> Set[Job]:
         next_output_dn_config_ids = set()
         subsequent_jobs = set()

--- a/taipy/core/job/_job_manager.py
+++ b/taipy/core/job/_job_manager.py
@@ -60,14 +60,25 @@ class _JobManager(_Manager[Job], _VersionMixin):
 
     @classmethod
     def _delete(cls, job: Union[Job, JobId], force=False) -> None:
+        job_id = job.id if isinstance(job, Job) else JobId(job)
         if isinstance(job, str):
             job = cls._get(job)
         if cls._is_deletable(job) or force:
-            super()._delete(job.id)
+            super()._delete(job_id)
+            from .._orchestrator._orchestrator_factory import _OrchestratorFactory
+
+            _OrchestratorFactory._build_orchestrator()._remove_jobs([job_id])
         else:
-            err = JobNotDeletedException(job.id)
+            err = JobNotDeletedException(job_id)
             cls._logger.error(err)
             raise err
+
+    @classmethod
+    def _delete_many(cls, ids: Iterable[JobId]) -> None:
+        super()._delete_many(ids)
+        from .._orchestrator._orchestrator_factory import _OrchestratorFactory
+
+        _OrchestratorFactory._build_orchestrator()._remove_jobs(ids)
 
     @classmethod
     def _cancel(cls, job: Union[str, Job]) -> None:

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -257,7 +257,9 @@ def test_get_all_on_multiple_versions_environment():
     for version in range(1, 3):
         for i in range(5):
             _ScenarioManager._repository._save(
-                Scenario(f"config_id_{i+version}", [], {}, [], ScenarioId(f"id{i}_v{version}"), version=f"{version}.0")
+                Scenario(
+                    f"config_id_{i + version}", [], {}, [], ScenarioId(f"id{i}_v{version}"), version=f"{version}.0"
+                )
             )
 
     _VersionManager._set_experiment_version("1.0")
@@ -1042,6 +1044,36 @@ def test_hard_delete_shared_entities():
     assert len(_TaskManager._get_all()) == 4
     assert len(_DataManager._get_all()) == 4
     assert len(_JobManager._get_all()) == 6
+
+
+def test_hard_delete_scenario_while_jobs_are_blocked():
+    input_dn_config = Config.configure_data_node("input_dn", "in_memory", scope=Scope.SCENARIO)
+    output_dn_config = Config.configure_data_node("output_dn", "in_memory", scope=Scope.SCENARIO)
+    task_config = Config.configure_task("task_cfg", print, input_dn_config, output_dn_config)
+    scenario_config = Config.configure_scenario("scenario_cfg", [task_config])
+
+    scenario_1 = _ScenarioManager._create(scenario_config)
+    scenario_2 = _ScenarioManager._create(scenario_config)
+
+    # Submit both scenarios. Their jobs will be blocked because the input data nodes are not ready.
+    _ScenarioManager._submit(scenario_1.id)
+    _ScenarioManager._submit(scenario_2.id)
+
+    # Both jobs should be in the blocked list.
+    assert len(_Orchestrator.blocked_jobs) == 2
+
+    # Hard delete Scenario 1. This should trigger cleanup of jobs.
+    _ScenarioManager._hard_delete(scenario_1.id)
+
+    # Let's check that we don't crash when unblocking jobs are processed
+    # In the bug, this raises AttributeError.
+    # Note: under the hood, this will iterate through blocked_jobs.
+    # After the fix, blocked_jobs should only contain the job of scenario_2.
+    _Orchestrator._Orchestrator__unblock_jobs()
+
+    # The blocked job list should only contain the job of scenario_2.
+    assert len(_Orchestrator.blocked_jobs) == 1
+    assert _Orchestrator.blocked_jobs[0].submit_entity_id == scenario_2.id
 
 
 def test_is_submittable():


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

* [x] 🐛 Bug Fix

## Description

Deleting a scenario while jobs are still running or blocked could leave stale job references in the orchestrator. When a remaining job later completed, the orchestrator attempted to unblock dependent jobs that had already been deleted along with the scenario.

Because the deleted jobs' input data nodes no longer existed, dependency resolution could retrieve `None` from the data manager and subsequently raise:

```python
AttributeError: 'NoneType' object has no attribute 'is_ready_for_reading'
```

This PR ensures that deleted jobs are removed from the orchestrator's internal scheduling queues, preventing stale job references from being processed after scenario deletion.

## Related Tickets & Documents

* Closes #2877 

## How to reproduce the issue

1. Create two scenarios sharing the same workflow.
2. Submit both scenarios.
3. Delete one scenario while jobs are still running or blocked.
4. Allow the remaining jobs to complete.
5. Observe the orchestrator attempting to unblock deleted jobs and crashing with:

```python
AttributeError: 'NoneType' object has no attribute 'is_ready_for_reading'
```

The added regression test reproduces this workflow and verifies the fix.

## Changes

### _orchestrator.py

* Added `_remove_jobs()` to safely remove deleted job IDs from orchestrator scheduling queues.
* Cleans up `blocked_jobs` and `jobs_to_run` entries associated with deleted jobs.

### _job_manager.py

* Updated `_delete()` to notify the orchestrator when jobs are deleted.
* Added `_delete_many()` support to perform the same cleanup for bulk deletions.

### test_scenario_manager.py

* Added `test_hard_delete_scenario_while_jobs_are_blocked`.
* Verifies that scenario deletion during execution does not leave stale orchestrator references.
* Confirms no crash occurs when remaining jobs complete.

## Backporting

*This change should be backported to:*

* [ ] 3.0
* [ ] 3.1
* [ ] 4.0
* [x] develop

## Checklist

* [x] ✅ This solution meets the acceptance criteria of the related issue.
* [x] 📝 The related issue checklist is completed.
* [x] 🧪 This PR includes unit tests for the developed code.
* [ ] 🔄 End-to-End tests have been added or updated.

Reason: The issue is fully covered by a regression/unit test exercising the orchestrator and scenario deletion workflow.

* [ ] 📚 The documentation has been updated, or a dedicated issue has been created.

Reason: Internal bug fix with no user-facing API or behavior changes requiring documentation updates.

* [ ] 📌 The release notes have been updated.

Reason: Small internal bug fix; release note inclusion can be decided by maintainers.
