### PR TITLE
fix(core): populate stacktrace before notifying subscribers

### DIFF
--- a/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -151,13 +151,13 @@ class _JobDispatcher(threading.Thread):
     def _update_job_status(job: Job, exceptions):
         """Update the job status based on the success or the failure of its execution."""
         if exceptions:
-            job.failed()
             _TaipyLogger._get_logger().error(f" {len(exceptions)} errors occurred during execution of job {job.id}")
             for e in exceptions:
                 st = "".join(traceback.format_exception(type(e), value=e, tb=e.__traceback__))
                 job._stacktrace.append(st)
                 _TaipyLogger._get_logger().error(st)
             _JobManagerFactory._build_manager()._update(job)
+            job.failed()
         else:
             for output in job.task.output.values():
                 output.track_edit(job_id=job.id)

--- a/tests/core/_orchestrator/_dispatcher/test_dispatcher__update_job_status.py
+++ b/tests/core/_orchestrator/_dispatcher/test_dispatcher__update_job_status.py
@@ -76,3 +76,31 @@ def test_update_job_status_with_exceptions():
     assert len(job.stacktrace) == 2
     assert job.stacktrace[0] == "".join(traceback.format_exception(type(e_1), value=e_1, tb=e_1.__traceback__))
     assert job.stacktrace[1] == "".join(traceback.format_exception(type(e_2), value=e_2, tb=e_2.__traceback__))
+
+
+_observed_stacktrace = None
+
+
+def subscriber(job):
+    global _observed_stacktrace
+    _observed_stacktrace = list(job.stacktrace)
+
+
+def test_update_job_status_callback_receives_stacktrace():
+    global _observed_stacktrace
+    _observed_stacktrace = None
+
+    task = Task("config_id", {}, nothing)
+    _TaskManagerFactory._build_manager()._repository._save(task)
+
+    job = Job(JobId("id"), task, "s_id", task.id)
+    _JobManagerFactory._build_manager()._repository._save(job)
+
+    e = Exception("test")
+
+    job._subscribers.append(subscriber)
+
+    _JobDispatcher(_OrchestratorFactory._orchestrator)._update_job_status(job, [e])
+
+    assert len(_observed_stacktrace) == 1
+    assert "Exception: test" in _observed_stacktrace[0]


### PR DESCRIPTION
## What type of PR is this? (Check all that apply)

- [ ] 🛠 Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📝 Documentation Update

## Description
This PR ensures that job subscribers receive the populated stacktrace when a job fails.

Previously, job.failed() was called before the stacktrace was appended to job._stacktrace, causing status change callbacks to observe an empty stacktrace. This change updates the execution order so that exceptions are recorded and persisted before subscribers are notified.

A regression test has also been added to verify that callbacks receive the expected stacktrace content.

## Related Tickets & Documents

Example:
- Related to #2887 

## How to reproduce the issue
1. Create a job with a status-change subscriber.
2. Trigger a job failure with an exception.
3. Observe job.stacktrace inside the subscriber callback.

Before this change, the callback received an empty stacktrace.

Example:

observed_stacktrace = None

def subscriber(job):
&emsp;global observed_stacktrace
&emsp;observed_stacktrace = list(job.stacktrace)

job._subscribers.append(subscriber)

_JobDispatcher(...)._update_job_status(job, [Exception("test")])

assert len(observed_stacktrace) == 1

## Backporting
<!-- Specify any branches or releases this change needs to be backported to. -->
_This change should be backported to:_
- [ ] 3.0
- [ ] 3.1
- [ ] 4.0
- [x] develop

## Checklist
_We encourage keeping the code coverage percentage at **80% or above**._

- [x] ✅ This solution meets the acceptance criteria of the related issue.
- [ ] 📝 The related issue checklist is completed.
- [x] 🧪 This PR includes **unit tests** for the developed code.
- [ ] 🔄 **End-to-End tests** have been added or updated.
    If not, explain why:
This change affects internal job status handling and is fully covered by a unit regression test. No end-to-end behavior is modified.
- [ ] 📚 The **documentation** has been updated, or a dedicated issue has been created.
    If not, explain why:
This is an internal bug fix and does not change the public API or user-facing behavior.
- [ ] 📌 The **release notes** have been updated.
    If not, explain why:
The change is a small internal bug fix and does not require a release note entry.