### PR TITLE
fix(gui): delay first auto-repeat action until repeat period elapses

### DIFF
--- a/frontend/taipy-gui/src/components/Taipy/Button.spec.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Button.spec.tsx
@@ -106,7 +106,7 @@ describe("Button Component", () => {
             type: "SEND_ACTION_ACTION",
         });
     });
-    it("trigger once in auto-repeat mode after holding for less that half a second", async () => {
+    it("does not trigger before initial repeat delay in auto-repeat mode", async () => {
         const dispatch = jest.fn();
         const state: TaipyState = INITIAL_STATE;
         const { getByText } = render(
@@ -116,12 +116,25 @@ describe("Button Component", () => {
         );
         const elt = getByText("Button");
         await userEvent.pointer([{ target: elt, keys: "[MouseLeft>]" }]);
-        await new Promise((r) => setTimeout(r, 50));
+        await new Promise((r) => setTimeout(r, 300));
         await userEvent.pointer([{ target: elt, keys: "[/MouseLeft]" }]);
-        const nCalls = dispatch.mock.calls.length;
-        expect(nCalls).toBe(1);
+        expect(dispatch).not.toHaveBeenCalled();
     });
-    it("trigger multiple times in auto-repeat mode after holding for 1 second", async () => {
+    it("triggers exactly once after initial repeat delay in auto-repeat mode", async () => {
+        const dispatch = jest.fn();
+        const state: TaipyState = INITIAL_STATE;
+        const { getByText } = render(
+            <TaipyContext.Provider value={{ state, dispatch }}>
+                <Button label="Button" onAction="on_action" autoRepeat={300} />
+            </TaipyContext.Provider>
+        );
+        const elt = getByText("Button");
+        await userEvent.pointer([{ target: elt, keys: "[MouseLeft>]" }]);
+        await new Promise((r) => setTimeout(r, 600));
+        await userEvent.pointer([{ target: elt, keys: "[/MouseLeft]" }]);
+        expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+    it("triggers multiple times after holding past initial delay in auto-repeat mode", async () => {
         const dispatch = jest.fn();
         const state: TaipyState = INITIAL_STATE;
         const { getByText } = render(
@@ -131,9 +144,23 @@ describe("Button Component", () => {
         );
         const elt = getByText("Button");
         await userEvent.pointer([{ target: elt, keys: "[MouseLeft>]" }]);
-        await new Promise((r) => setTimeout(r, 1000));
+        await new Promise((r) => setTimeout(r, 1200));
         await userEvent.pointer([{ target: elt, keys: "[/MouseLeft]" }]);
-        const nCalls = dispatch.mock.calls.length;
-        expect(nCalls).toBeGreaterThan(1);
+        expect(dispatch.mock.calls.length).toBeGreaterThan(1);
+    });
+    it("does not trigger after release if held less than initial delay", async () => {
+        const dispatch = jest.fn();
+        const state: TaipyState = INITIAL_STATE;
+        const { getByText } = render(
+            <TaipyContext.Provider value={{ state, dispatch }}>
+                <Button label="Button" onAction="on_action" autoRepeat={200} />
+            </TaipyContext.Provider>
+        );
+        const elt = getByText("Button");
+        await userEvent.pointer([{ target: elt, keys: "[MouseLeft>]" }]);
+        await new Promise((r) => setTimeout(r, 100));
+        await userEvent.pointer([{ target: elt, keys: "[/MouseLeft]" }]);
+        await new Promise((r) => setTimeout(r, 200));
+        expect(dispatch).not.toHaveBeenCalled();
     });
 });

--- a/frontend/taipy-gui/src/components/Taipy/Button.tsx
+++ b/frontend/taipy-gui/src/components/Taipy/Button.tsx
@@ -65,8 +65,8 @@ const Button = (props: ButtonProps) => {
             // Prevent simultaneous repeats
             return;
         }
-        handleClick(); // Trigger immediately
         autoRepeatInitialRef.current = setTimeout(() => {
+            handleClick();
             autoRepeatIntervalRef.current = setInterval(handleClick, autoRepeatDelay);
             autoRepeatInitialRef.current = null;
         }, initialRepeatDelay);
@@ -106,7 +106,7 @@ const Button = (props: ButtonProps) => {
                 variant={variant}
                 size={size}
                 className={`${className} ${getComponentClassName(props.children)}`}
-                onClick={handleClick}
+                onClick={autoRepeatDelay ? undefined : handleClick}
                 disabled={!active}
                 sx={buttonSx}
                 onMouseDown={autoRepeatDelay ? startRepeating : undefined}


### PR DESCRIPTION
Closes #2860

## Summary

Fixes the `auto_repeat` button behavior so the first action fires only after the repeat period has elapsed, not immediately on press.

## Changes

- **`Button.tsx`**: Removed the immediate `handleClick()` call from `startRepeating`. The first action now fires after `initialRepeatDelay` (500ms), matching the expected behavior. Also disabled the `onClick` handler when `autoRepeat` is active to prevent double-firing from both `mousedown` and `click` events.

- **`Button.spec.tsx`**: Updated and expanded tests to verify the corrected behavior:
  - No trigger before initial repeat delay
  - Exactly one trigger after initial delay
  - Multiple triggers when held longer
  - No trigger after early release