### PR TITLE
fix: use gui._get_content to serve local favicon files correctly (#1767)

### DIFF
--- a/taipy/gui/servers/flask/server.py
+++ b/taipy/gui/servers/flask/server.py
@@ -313,12 +313,16 @@ class _FlaskServer(_Server):
         extension_bp.add_url_rule(f"/{Gui._EXTENSION_ROOT}/<path:path>", view_func=gui._serve_extension)  # pyright: ignore[reportAttributeAccessIssue]
         flask_blueprint.append(extension_bp)
 
+        favicon = gui._get_config("favicon", Gui._DEFAULT_FAVICON_URL)
+        if favicon:
+            favicon = gui._get_content("__taipy_favicon", favicon, True)  # pyright: ignore[reportAttributeAccessIssue]
+
         flask_blueprint.append(
             self._get_default_handler(
                 static_folder=gui._get_webapp_path(),  # pyright: ignore[reportAttributeAccessIssue]
                 template_folder=gui._get_webapp_path(),  # pyright: ignore[reportAttributeAccessIssue]
                 title=gui._get_config("title", "Taipy App"),  # pyright: ignore[reportAttributeAccessIssue]
-                favicon=gui._get_config("favicon", Gui._DEFAULT_FAVICON_URL),  # pyright: ignore[reportAttributeAccessIssue]
+                favicon=favicon,
                 root_margin=gui._get_config("margin", None),  # pyright: ignore[reportAttributeAccessIssue]
                 scripts=scripts,
                 styles=styles,

--- a/tests/gui/gui_specific/test_favicon.py
+++ b/tests/gui/gui_specific/test_favicon.py
@@ -56,3 +56,17 @@ def test_favicon_fastapi(gui: Gui, helpers):
             assert msgs[0].get("args", {}).get("payload", {}).get("value", None) == "https://newfavicon.com/favicon.png"
         finally:
             ws_client.disconnect()
+
+@pytest.mark.skip_if_not_server("flask")
+def test_favicon_index_html(gui: Gui, helpers, tmp_path):
+    favicon_path = tmp_path / "custom_favicon.png"
+    favicon_path.write_text("fake_png_data")
+    
+    with warnings.catch_warnings(record=True):
+        gui._set_frame(inspect.currentframe())
+        gui.add_page("test", Markdown("#This is a page"))
+        gui.run(run_server=False, favicon=str(favicon_path))
+        client = gui._server.test_client()
+        response = client.get("/")
+        assert response.status_code == 200
+        assert f"/{Gui._CONTENT_ROOT}/" in response.data.decode("utf-8")


### PR DESCRIPTION
Resolves #1767. This PR ensures that when a user passes a local file path to \un(favicon=...)\, the favicon is correctly exposed through the \_get_content\ mechanism rather than injecting a raw local file path that the frontend fails to resolve.